### PR TITLE
Add EventHeader data type

### DIFF
--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -89,6 +89,7 @@ datatypes :
       - int eventNumber    //event number
       - int runNumber      //run number
       - unsigned long long timeStamp     //time stamp
+      - float weight       // event weight
 
 
   edm4hep::MCParticle:

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -81,6 +81,16 @@ components:
 
 datatypes :
 
+
+  edm4hep::EventHeader:
+    Description: "Event Header. Additional parameters are assumed to go into the metadata tree."
+    Author : "F.Gaede"
+    Members:
+      - int eventNumber    //event number
+      - int runNumber      //run number
+      - unsigned long long timeStamp     //time stamp
+
+
   edm4hep::MCParticle:
     Description: "The Monte Carlo particle - based on the lcio::MCParticle."
     Author : "F.Gaede, DESY"


### PR DESCRIPTION
This is a smaller version of the plcio equivalent, as I'm assuming here that podio will be able to put  parameters like `detectorname` in the metadata tree. Also, removing std::string members means the PODness remains intact.

BEGINRELEASENOTES
- Add EventHeader data type
ENDRELEASENOTES