### PR TITLE
Fix TravisCI Configuration for Doxygen Generation

### DIFF
--- a/.edm4hep-ci.d/compile_and_test.sh
+++ b/.edm4hep-ci.d/compile_and_test.sh
@@ -8,7 +8,7 @@ source $K4VIEW/$BINARY_TAG/setup.sh
 # edm4hep
 mkdir build install
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_STANDARD=${STANDARD:=17} -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " -G Ninja ..  \
+cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_STANDARD=${STANDARD:=17} -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " -DEDM4HEP_DOCUMENTATION=ON -G Ninja ..  \
       && ninja -k0 \
       && ninja install \
       && ctest --output-on-failure || exit 1

--- a/.edm4hep-ci.d/compile_and_test_with_podio.sh
+++ b/.edm4hep-ci.d/compile_and_test_with_podio.sh
@@ -3,7 +3,7 @@ source init.sh
 # edm4hep
 mkdir build install
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_STANDARD=17 -DEDM4HEP_documentation=ON -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " -G Ninja ..  \
+cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_STANDARD=17 -DEDM4HEP_DOCUMENTATION=ON -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " -G Ninja ..  \
       && ninja -k0 \
       && ninja doc \
       && ninja install \

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,8 @@ after_success:
   # Generate the docs only if master, the travis_build_docs is true and we can use secure variables
   - >-
     if [[ "$TRAVIS_BRANCH" = "master" && "$TRAVIS_PULL_REQUEST" = "false" ]] ; then
-      cd ${TRAVIS_BUILD_DIR} && ./.edm4hep-ci.d/generateDocumentation.sh || travis_terminate 1
+
+       cd ${PKGDIR}; docker exec -ti CI_CONTAINER  /bin/bash -c "cd /workspace; source init.sh; cd build; ninja  doc" && ./.edm4hep-ci.d/generateDocumentation.sh || travis_terminate 1
     fi
 
 # Don't send e-mail notifications


### PR DESCRIPTION
The `after_success` step, which is supposed to publish the page, failed due to a wrong directory name.