### PR TITLE
Rename cluster vectormembers in plural form

### DIFF
--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -269,8 +269,8 @@ datatypes :
       - float                phi             //intrinsic direction of cluster at position - Phi. Not to be confused with direction cluster is seen from IP. 
       - edm4hep::Vector3f    directionError  //covariance matrix of the direction (3 Parameters)
     VectorMembers:
-      - float   shape                //shape parameters - check/set collection parameter ClusterShapeParameters for size and names of parameters.
-      - float   weight               //weight of a particular cluster
+      - float   shapeParameters      //shape parameters - check/set collection parameter ClusterShapeParameters for size and names of parameters.
+      - float   weights              //weight of a particular cluster
       - float   hitContributions     //energy contribution of the hits Runs parallel to the CalorimeterHitVec from getCalorimeterHits(). 
       - float   subdetectorEnergies  //energy observed in a particular subdetector. Check/set collection parameter ClusterSubdetectorNames for decoding the indices of the array. 
     OneToManyRelations:

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -270,7 +270,6 @@ datatypes :
       - edm4hep::Vector3f    directionError  //covariance matrix of the direction (3 Parameters)
     VectorMembers:
       - float   shapeParameters      //shape parameters - check/set collection parameter ClusterShapeParameters for size and names of parameters.
-      - float   weights              //weight of a particular cluster
       - float   hitContributions     //energy contribution of the hits Runs parallel to the CalorimeterHitVec from getCalorimeterHits(). 
       - float   subdetectorEnergies  //energy observed in a particular subdetector. Check/set collection parameter ClusterSubdetectorNames for decoding the indices of the array. 
     OneToManyRelations:


### PR DESCRIPTION
Plural forms for the variable names make it easier to recognize they refer to a vector.

BEGINRELEASENOTES
- Rename cluster vectormembers with a plural form

ENDRELEASENOTES