### PR TITLE
use -Wl,--no-as-needed for linking edm4hepDict

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,25 +2,57 @@ IF(NOT BUILD_TESTING)
   RETURN()
 ENDIF()
 
+#=====================================================================
+# check if the linker supports as needed or not
+#   (needed for ROOT dict, specifically on Ubuntu)
+set(STORE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
+include(CheckCCompilerFlag)
+set(CMAKE_REQUIRED_FLAGS "-Wl,--no-as-needed")
+check_c_compiler_flag("" TEST_NO_AS_NEEDED)
+set(CMAKE_REQUIRED_FLAGS "-Wl,--as-needed")
+check_c_compiler_flag("" TEST_AS_NEEDED)
+set(CMAKE_REQUIRED_FLAGS ${STORE_REQUIRED_FLAGS})
+#=====================================================================
+
+
+
 add_executable(write_events write_events.cc)
 target_include_directories(write_events PUBLIC ${CMAKE_SOURCE_DIR}/edm4hep )
-target_link_libraries(write_events edm4hep edm4hepDict podio::podioRootIO)
+if(TEST_NO_AS_NEEDED AND TEST_AS_NEEDED)
+  target_link_libraries(write_events edm4hep
+   -Wl,--push-state,--no-as-needed edm4hepDict -Wl,--pop-state
+   podio::podioRootIO )
+else()
+  target_link_libraries(write_events edm4hep edm4hepDict podio::podioRootIO )
+endif()
 add_test(NAME write_events COMMAND write_events)
 
 add_executable(read_events read_events.cc)
 target_include_directories(read_events PUBLIC ${CMAKE_SOURCE_DIR}/edm4hep )
-target_link_libraries(read_events edm4hep edm4hepDict podio::podioRootIO)
+if(TEST_NO_AS_NEEDED AND TEST_AS_NEEDED)
+  target_link_libraries(read_events edm4hep
+   -Wl,--push-state,--no-as-needed edm4hepDict -Wl,--pop-state
+   podio::podioRootIO )
+else()
+  target_link_libraries(read_events edm4hep edm4hepDict podio::podioRootIO )
+endif()
 add_test(NAME read_events COMMAND read_events)
 set_tests_properties(read_events PROPERTIES DEPENDS write_events)
 
 IF(TARGET ROOT::ROOTDataFrame)
   add_executable(test_rdf test_rdf.cc)
   target_include_directories(test_rdf PUBLIC ${CMAKE_SOURCE_DIR}/edm4hep ${CMAKE_SOURCE_DIR}/dataframe )
-  target_link_libraries(test_rdf edm4hepRDF edm4hepDict ROOT::ROOTDataFrame )
+
+  if(TEST_NO_AS_NEEDED AND TEST_AS_NEEDED)
+    target_link_libraries(test_rdf edm4hepRDF
+      -Wl,--push-state,--no-as-needed edm4hepDict -Wl,--pop-state
+      ROOT::ROOTDataFrame )
+  else()
+    target_link_libraries(test_rdf edm4hepRDF edm4hepDict ROOT::ROOTDataFrame )
+  endif()
   add_test(NAME test_rdf COMMAND test_rdf)
   set_tests_properties(test_rdf PROPERTIES DEPENDS write_events)
 endif()
-
 
 
 find_package(tricktrack 1.0.9)


### PR DESCRIPTION
BEGINRELEASENOTES
- fix linking on Ubuntu
     - use -Wl,--no-as-needed for linking edm4hepDict (if available)
     - follows https://github.com/AIDASoft/podio/pull/91
    

ENDRELEASENOTES