### PR TITLE
[CI] Add build with dev3 nightlies

### DIFF
--- a/.edm4hep-ci.d/compile_and_test_with_podio.sh
+++ b/.edm4hep-ci.d/compile_and_test_with_podio.sh
@@ -1,9 +1,24 @@
 source init.sh
+# podio
+git clone --depth 1 https://github.com/AIDASoft/podio || true
+cd podio
+mkdir build install
+cd build
+cmake -DCMAKE_CXX_STANDARD=${STANDARD:=17} -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=../install -G Ninja .. \
+      && ninja -k0 \
+      && ninja install \
+          || exit 1
+
+cd ..
+export CMAKE_PREFIX_PATH=$PWD/install:$CMAKE_PREFIX_PATH
+export PODIO=$PWD/install:$CMAKE_PREFIX_PATH
+cd ..
+
 
 # edm4hep
 mkdir build install
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_STANDARD=17 -DEDM4HEP_DOCUMENTATION=ON -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " -G Ninja ..  \
+cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_STANDARD=${STANDARD:=17} -DEDM4HEP_DOCUMENTATION=ON -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " -G Ninja ..  \
       && ninja -k0 \
       && ninja doc \
       && ninja install \
@@ -14,5 +29,5 @@ export CMAKE_PREFIX_PATH=$PWD/install:$CMAKE_PREFIX_PATH
 cd test/downstream-project-cmake-test
 mkdir build install
 cd build
-cmake -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=../install -G Ninja .. \
+cmake -DCMAKE_CXX_STANDARD=${STANDARD} -DCMAKE_INSTALL_PREFIX=../install -G Ninja .. \
       && ninja -k0

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ language: cpp
 
 env:
   matrix:
-    - COMPILER=gcc;   LCG_RELEASE=LCG_96c_LS; STANDARD=17; COMPILER_VERSION=gcc8;
+    - COMPILER=gcc;   LCG_RELEASE=LCG_96c_LS; STANDARD=17; COMPILER_VERSION=gcc8; SCRIPT=compile_and_test.sh;
+    - COMPILER=gcc;   LCG_RELEASE=dev3/latest; STANDARD=17; COMPILER_VERSION=gcc8; SCRIPT=compile_and_test_with_podio.sh;
 
 before_install:
   - wget --no-check-certificate https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
@@ -34,9 +35,11 @@ before_install:
   - sudo mkdir -p /cvmfs/geant4.cern.ch
   - sudo mkdir -p /cvmfs/sw-nightlies.hsf.org
   - ls /cvmfs/sft.cern.ch
+  - ls /cvmfs/sft.cern.ch/lcg/views/dev3/latest/x86_64-centos7-gcc8-opt/
   - ls /cvmfs/geant4.cern.ch
   - ls /cvmfs/sw-nightlies.hsf.org
   - export CVMFS_REPOS="-v /cvmfs/sft.cern.ch:/cvmfs/sft.cern.ch"
+  - export CVMFS_REPOS="${CVMFS_REPOS} -v /cvmfs/sft-nightlies.cern.ch:/cvmfs/sft-nightlies.cern.ch"
   - export CVMFS_REPOS="${CVMFS_REPOS} -v /cvmfs/sw-nightlies.hsf.org:/cvmfs/sw-nightlies.hsf.org"
   - export CVMFS_REPOS="${CVMFS_REPOS} -v /cvmfs/geant4.cern.ch:/cvmfs/geant4.cern.ch"
 
@@ -52,7 +55,7 @@ install:
 # command to run tests
 script:
   - docker run -ti --name CI_CONTAINER -v $PKGDIR:/workspace -e COMPILER_TYPE=$COMPILER -e LCG_RELEASE=${LCG_RELEASE} -e STANDARD=${STANDARD} -e COMPILER_VERSION=${COMPILER_VERSION} ${CVMFS_REPOS} -d clicdp/cc7-lcg bash 
-  - docker exec -ti CI_CONTAINER  /bin/bash -c "cd /workspace; pwd; ls;  ./.edm4hep-ci.d/compile_and_test.sh"
+  - docker exec -ti CI_CONTAINER  /bin/bash -c "cd /workspace; pwd; ls;  ./.edm4hep-ci.d/${SCRIPT}"
 
 
 after_success:

--- a/init.sh
+++ b/init.sh
@@ -5,6 +5,8 @@
 
 # source LCG releases
 export BINARY_TAG=x86_64-${OS-centos7}-${COMPILER_VERSION-gcc8}-opt
+
+ls /cvmfs/sft.cern.ch/lcg/views/${LCG_RELEASE-LCG_96c_LS}/$BINARY_TAG
 source /cvmfs/sft.cern.ch/lcg/views/${LCG_RELEASE-LCG_96c_LS}/$BINARY_TAG/setup.sh
 
 # workaround for ROOT requiring a higher version of CMake than is provided by lcg


### PR DESCRIPTION
Fails due to a problem with the ddsim test. The key4hep nightlies were updated to  `LCG_97_FCC_2` and also have a problem with this test. 

BEGINRELEASENOTES
- add build with dev3 nightlies

ENDRELEASENOTES