### PR TITLE
Add more description concerning the internal 4-momentum state of ReconstructedParticle

### DIFF
--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -351,11 +351,11 @@ datatypes :
     Author : "F.Gaede, DESY"
     Members:
       - int                    type           //type of reconstructed particle. Check/set collection parameters ReconstructedParticleTypeNames and ReconstructedParticleTypeValues.
-      - float                  energy         // [GeV] energy of the reconstructed particle.
-      - edm4hep::Vector3f      momentum       // [GeV] particle momentum
+      - float                  energy         // [GeV] energy of the reconstructed particle. Four momentum state is not kept consistent internally.
+      - edm4hep::Vector3f      momentum       // [GeV] particle momentum. Four momentum state is not kept consistent internally.
       - edm4hep::Vector3f      referencePoint // [mm] reference, i.e. where the particle has been measured
       - float                  charge         //charge of the reconstructed particle.
-      - float                  mass           // [GeV] mass of the reconstructed particle, set independently from four vector
+      - float                  mass           // [GeV] mass of the reconstructed particle, set independently from four vector. Four momentum state is not kept consistent internally.
       - float                  goodnessOfPID  //overall goodness of the PID on a scale of [0;1]
       - std::array<float,10>   covMatrix      //cvariance matrix of the reconstructed particle 4vector (10 parameters). Stored as lower triangle matrix of the four momentum (px,py,pz,E), i.e. cov(px,px), cov(py,##
     OneToOneRelations:


### PR DESCRIPTION
BEGINRELEASENOTES
- Add additional comment to `mass`, `energy` and `momentum` members of `ReconstructedParticle` description to clearly state that the 4-momentum state is not automatically kept consistent internally. Since there are too many different use-cases, a general solution that always works was deemed hard to achieve and it is, thus, the users responsibility to keep this state consistent if it is necessary.

ENDRELEASENOTES

It is still necessary to set the mass after the momentum has been set to get everything really consistent, but without a 4-vector type, I think that is hard to achieve.