### PR TITLE
Fix the declaration of extracode in TrackState

### DIFF
--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -58,7 +58,7 @@ components:
       referencePoint : edm4hep::Vector3f # Reference point of the track parameters, e.g. the origin at the IP, or the position  of the first/last hits or the entry point into the calorimeter.
       covMatrix      : std::array<float,15> # upper triangular covariance matrix of the track parameters.  the order of parameters is:   d0, phi, omega, z0, tan(lambda). 
       ExtraCode :
-        const_declaration: "
+        declaration: "
         static const int AtOther = 0 ; // any location other than the ones defined below\n   
         static const int AtIP = 1 ;\n
         static const int AtFirstHit = 2 ;\n                   


### PR DESCRIPTION

BEGINRELEASENOTES
- Change `const_declaration` to `declaration` in `ExtraCode` to have static members of `TrackState` included in generated code (See #71 )

ENDRELEASENOTES

Fixes #71 