### PR TITLE
CI Update: Add option to build PODIO on the fly, dev3

### DIFF
--- a/.edm4hep-ci.d/compile_and_test.sh
+++ b/.edm4hep-ci.d/compile_and_test.sh
@@ -1,14 +1,8 @@
 
-export K4VIEW=/cvmfs/sw-nightlies.hsf.org/key4hep/views/latest
-export BINARY_TAG=x86_64-centos7-gcc8-opt
-source $K4VIEW/$BINARY_TAG/setup.sh
-
-
-
 # edm4hep
 mkdir build install
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_STANDARD=${STANDARD:=17} -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " -DEDM4HEP_DOCUMENTATION=ON -G Ninja ..  \
+cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_STANDARD=${STANDARD:=17} -DBUILD_DDG4EDM4HEP=${BUILD_DDG4EDM4HEP:=ON} -DBUILD_DELPHESEDM4HEP=${BUILD_DELPHESEDM4HEP:=ON} -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " -DEDM4HEP_DOCUMENTATION=ON -G Ninja ..  \
       && ninja -k0 \
       && ninja install \
       && ctest --output-on-failure || exit 1

--- a/.edm4hep-ci.d/compile_and_test_with_podio.sh
+++ b/.edm4hep-ci.d/compile_and_test_with_podio.sh
@@ -1,18 +1,16 @@
-source init.sh
 
-# edm4hep
+# podio
+git clone --depth 1 https://github.com/AIDASoft/podio || true
+cd podio
 mkdir build install
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_STANDARD=17 -DEDM4HEP_DOCUMENTATION=ON -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " -G Ninja ..  \
+cmake -DCMAKE_CXX_STANDARD=17 -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=../install -G Ninja .. \
       && ninja -k0 \
-      && ninja doc \
       && ninja install \
-      && ctest --output-on-failure || exit 1
-# test if installation can be used by external projects
+          || exit 1
+
 cd ..
 export CMAKE_PREFIX_PATH=$PWD/install:$CMAKE_PREFIX_PATH
-cd test/downstream-project-cmake-test
-mkdir build install
-cd build
-cmake -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=../install -G Ninja .. \
-      && ninja -k0
+export PODIO=$PWD/install:$CMAKE_PREFIX_PATH
+cd ..
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ install:
 
 # command to run tests
 script:
-  - docker run -ti --name CI_CONTAINER -v $PKGDIR:/workspace  -e SETUPSCRIPT=${SETUPSCRIPT}  -e BUILD_DDG4PLUGIN=${BUILD_DDG4PLUGIN} -e BUILD_DELPHESPLUGIN=${BUILD_DELPHESPLUGIN} -e STANDARD=${STANDARD}  ${CVMFS_REPOS} -d clicdp/cc7-lcg bash 
+  - docker run -ti --name CI_CONTAINER -v $PKGDIR:/workspace  -e SETUPSCRIPT=${SETUPSCRIPT}  -e BUILD_DDG4PLUGIN=${BUILD_DDG4PLUGIN} -e BUILD_DELPHESPLUGIN=${BUILD_DELPHESPLUGIN} -e STANDARD=${STANDARD} -v /cvmfs:/cvmfs:shared -d clicdp/cc7-lcg bash 
   - if [[ "$PODIO_FROM" == "STACK" ]]; 
     then docker exec -ti CI_CONTAINER  /bin/bash -c "cd /workspace; pwd; ls; source ${SETUPSCRIPT}; source ./.edm4hep-ci.d/compile_and_test.sh";
     elif [[ "$PODIO_FROM" == "BUILD_HEAD_ONTHEFLY" ]];

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,16 @@ language: cpp
 
 env:
   matrix:
-    - SETUPSCRIPT=/cvmfs/sw-nightlies.hsf.org/key4hep/views/latest/x86_64-centos7-gcc8-opt/setup.sh; STANDARD=17; BUILD_DDG4PLUGIN=ON; BUILD_DELPHESPLUGIN=ON; PODIO_FROM=STACK; STACK=KEY4HEPNIGHTLY;
-    - SETUPSCRIPT=/cvmfs/sw-nightlies.hsf.org/key4hep/views/latest/x86_64-centos7-gcc8-opt/setup.sh; STANDARD=17; BUILD_DDG4PLUGIN=ON; BUILD_DELPHESPLUGIN=ON; PODIO_FROM=BUILD_HEAD_ONTHEFLY; STACK=KEY4HEPNIGHTLY;
-    - SETUPSCRIPT=/cvmfs/sft.cern.ch/lcg/views/dev3/latest/x86_64-centos7-gcc8-opt/setup.sh; STANDARD=17; BUILD_DDG4PLUGIN=ON; BUILD_DELPHESPLUGIN=ON; PODIO_FROM=BUILD_HEAD_ONTHEFLY; STACK=KEY4HEPNIGHTLY;
-    - SETUPSCRIPT=/cvmfs/sft.cern.ch/lcg/views/dev3/latest/x86_64-centos7-clang8-opt/setup.sh; STANDARD=17; BUILD_DDG4PLUGIN=ON; BUILD_DELPHESPLUGIN=ON; PODIO_FROM=BUILD_HEAD_ONTHEFLY; STACK=KEY4HEPNIGHTLY;
+    - SETUPSCRIPT=/cvmfs/sw-nightlies.hsf.org/key4hep/views/latest/x86_64-centos7-gcc8-opt/setup.sh; STANDARD=17; BUILD_DDG4EDM4HEP=ON; BUILD_DELPHESEDM4HEP=ON; PODIO_FROM=STACK; STACK=KEY4HEPNIGHTLY;
+    - SETUPSCRIPT=/cvmfs/sw-nightlies.hsf.org/key4hep/views/latest/x86_64-centos7-gcc8-opt/setup.sh; STANDARD=17; BUILD_DDG4EDM4HEP=ON; BUILD_DELPHESEDM4HEP=ON; PODIO_FROM=BUILD_HEAD_ONTHEFLY; STACK=KEY4HEPNIGHTLY;
+    - SETUPSCRIPT=/cvmfs/sft.cern.ch/lcg/views/dev3/latest/x86_64-centos7-gcc8-opt/setup.sh; STANDARD=17; BUILD_DDG4EDM4HEP=ON; BUILD_DELPHESEDM4HEP=ON; PODIO_FROM=BUILD_HEAD_ONTHEFLY; STACK=KEY4HEPNIGHTLY;
+    - SETUPSCRIPT=/cvmfs/sft.cern.ch/lcg/views/dev3/latest/x86_64-centos7-clang8-opt/setup.sh; STANDARD=17; BUILD_DDG4EDM4HEP=ON; BUILD_DELPHESEDM4HEP=ON; PODIO_FROM=BUILD_HEAD_ONTHEFLY; STACK=KEY4HEPNIGHTLY;
 
 matrix:
   allow_failures:
-  - env: SETUPSCRIPT=/cvmfs/sw-nightlies.hsf.org/key4hep/views/latest/x86_64-centos7-gcc8-opt/setup.sh; STANDARD=17; BUILD_DDG4PLUGIN=ON; BUILD_DELPHESPLUGIN=ON; PODIO_FROM=STACK; STACK=KEY4HEPNIGHTLY;
-  - env: SETUPSCRIPT=/cvmfs/sft.cern.ch/lcg/views/dev3/latest/x86_64-centos7-clang8-opt/setup.sh; STANDARD=17; BUILD_DDG4PLUGIN=ON; BUILD_DELPHESPLUGIN=ON; PODIO_FROM=BUILD_HEAD_ONTHEFLY; STACK=KEY4HEPNIGHTLY;
-  - env: SETUPSCRIPT=/cvmfs/sft.cern.ch/lcg/views/dev3/latest/x86_64-centos7-gcc8-opt/setup.sh; STANDARD=17; BUILD_DDG4PLUGIN=ON; BUILD_DELPHESPLUGIN=ON; PODIO_FROM=BUILD_HEAD_ONTHEFLY; STACK=KEY4HEPNIGHTLY;
+  - env: SETUPSCRIPT=/cvmfs/sw-nightlies.hsf.org/key4hep/views/latest/x86_64-centos7-gcc8-opt/setup.sh; STANDARD=17; BUILD_DDG4EDM4HEP=ON; BUILD_DELPHESEDM4HEP=ON; PODIO_FROM=STACK; STACK=KEY4HEPNIGHTLY;
+  - env: SETUPSCRIPT=/cvmfs/sft.cern.ch/lcg/views/dev3/latest/x86_64-centos7-clang8-opt/setup.sh; STANDARD=17; BUILD_DDG4EDM4HEP=ON; BUILD_DELPHESEDM4HEP=ON; PODIO_FROM=BUILD_HEAD_ONTHEFLY; STACK=KEY4HEPNIGHTLY;
+  - env: SETUPSCRIPT=/cvmfs/sft.cern.ch/lcg/views/dev3/latest/x86_64-centos7-gcc8-opt/setup.sh; STANDARD=17; BUILD_DDG4EDM4HEP=ON; BUILD_DELPHESEDM4HEP=ON; PODIO_FROM=BUILD_HEAD_ONTHEFLY; STACK=KEY4HEPNIGHTLY;
 
 before_install:
   - wget --no-check-certificate https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
@@ -60,7 +60,7 @@ install:
 
 # command to run tests
 script:
-  - docker run -ti --name CI_CONTAINER -v $PKGDIR:/workspace  -e SETUPSCRIPT=${SETUPSCRIPT}  -e BUILD_DDG4PLUGIN=${BUILD_DDG4PLUGIN} -e BUILD_DELPHESPLUGIN=${BUILD_DELPHESPLUGIN} -e STANDARD=${STANDARD} -v /cvmfs:/cvmfs:shared -d clicdp/cc7-lcg bash 
+  - docker run -ti --name CI_CONTAINER -v $PKGDIR:/workspace  -e SETUPSCRIPT=${SETUPSCRIPT}  -e BUILD_DDG4EDM4HEP=${BUILD_DDG4EDM4HEP} -e BUILD_DELPHESEDM4HEP=${BUILD_DELPHESEDM4HEP} -e STANDARD=${STANDARD} -v /cvmfs:/cvmfs:shared -d clicdp/cc7-lcg bash 
   - if [[ "$PODIO_FROM" == "STACK" ]]; 
     then docker exec -ti CI_CONTAINER  /bin/bash -c "cd /workspace; pwd; ls; source ${SETUPSCRIPT}; source ./.edm4hep-ci.d/compile_and_test.sh";
     elif [[ "$PODIO_FROM" == "BUILD_HEAD_ONTHEFLY" ]];

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
   - echo "CVMFS_HTTP_PROXY=DIRECT"                                  | sudo tee -a  /etc/cvmfs/default.local > /dev/null
   - echo "CVMFS_CACHE_BASE='/var/lib/cvmfs'"                        | sudo tee -a  /etc/cvmfs/default.local > /dev/null
   - echo "CVMFS_FORCE_SIGNING='yes'"                                | sudo tee -a  /etc/cvmfs/default.local > /dev/null
-  - echo "CVMFS_REPOSITORIES='sft.cern.ch,sw-nightlies.hsf.org'"    | sudo tee -a  /etc/cvmfs/default.local > /dev/null
+  - echo "CVMFS_REPOSITORIES='sft.cern.ch,sw-nightlies.hsf.org,sft-nightlies.cern.ch,geant4.cern.ch'"    | sudo tee -a  /etc/cvmfs/default.local > /dev/null
   - echo "CVMFS_SEND_INFO_HEADER=no"                                | sudo tee -a  /etc/cvmfs/default.local > /dev/null
   - cat /etc/cvmfs/default.local
   - # change wrt dd4hep setup: don't manually mount cvmfs folders

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,14 @@ env:
   matrix:
     - SETUPSCRIPT=/cvmfs/sw-nightlies.hsf.org/key4hep/views/latest/x86_64-centos7-gcc8-opt/setup.sh; STANDARD=17; BUILD_DDG4PLUGIN=ON; BUILD_DELPHESPLUGIN=ON; PODIO_FROM=STACK; STACK=KEY4HEPNIGHTLY;
     - SETUPSCRIPT=/cvmfs/sw-nightlies.hsf.org/key4hep/views/latest/x86_64-centos7-gcc8-opt/setup.sh; STANDARD=17; BUILD_DDG4PLUGIN=ON; BUILD_DELPHESPLUGIN=ON; PODIO_FROM=BUILD_HEAD_ONTHEFLY; STACK=KEY4HEPNIGHTLY;
+    - SETUPSCRIPT=/cvmfs/sft.cern.ch/lcg/views/dev3/latest/x86_64-centos7-gcc8-opt/setup.sh; STANDARD=17; BUILD_DDG4PLUGIN=ON; BUILD_DELPHESPLUGIN=ON; PODIO_FROM=BUILD_HEAD_ONTHEFLY; STACK=KEY4HEPNIGHTLY;
+    - SETUPSCRIPT=/cvmfs/sft.cern.ch/lcg/views/dev3/latest/x86_64-centos7-clang8-opt/setup.sh; STANDARD=17; BUILD_DDG4PLUGIN=ON; BUILD_DELPHESPLUGIN=ON; PODIO_FROM=BUILD_HEAD_ONTHEFLY; STACK=KEY4HEPNIGHTLY;
 
 matrix:
   allow_failures:
   - env: SETUPSCRIPT=/cvmfs/sw-nightlies.hsf.org/key4hep/views/latest/x86_64-centos7-gcc8-opt/setup.sh; STANDARD=17; BUILD_DDG4PLUGIN=ON; BUILD_DELPHESPLUGIN=ON; PODIO_FROM=STACK; STACK=KEY4HEPNIGHTLY;
+  - env: SETUPSCRIPT=/cvmfs/sft.cern.ch/lcg/views/dev3/latest/x86_64-centos7-clang8-opt/setup.sh; STANDARD=17; BUILD_DDG4PLUGIN=ON; BUILD_DELPHESPLUGIN=ON; PODIO_FROM=BUILD_HEAD_ONTHEFLY; STACK=KEY4HEPNIGHTLY;
+  - env: SETUPSCRIPT=/cvmfs/sft.cern.ch/lcg/views/dev3/latest/x86_64-centos7-gcc8-opt/setup.sh; STANDARD=17; BUILD_DDG4PLUGIN=ON; BUILD_DELPHESPLUGIN=ON; PODIO_FROM=BUILD_HEAD_ONTHEFLY; STACK=KEY4HEPNIGHTLY;
 
 before_install:
   - wget --no-check-certificate https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,12 @@ language: cpp
 
 env:
   matrix:
-    - COMPILER=gcc;   LCG_RELEASE=LCG_96c_LS; STANDARD=17; COMPILER_VERSION=gcc8;
+    - SETUPSCRIPT=/cvmfs/sw-nightlies.hsf.org/key4hep/views/latest/x86_64-centos7-gcc8-opt/setup.sh; STANDARD=17; BUILD_DDG4PLUGIN=ON; BUILD_DELPHESPLUGIN=ON; PODIO_FROM=STACK; STACK=KEY4HEPNIGHTLY;
+    - SETUPSCRIPT=/cvmfs/sw-nightlies.hsf.org/key4hep/views/latest/x86_64-centos7-gcc8-opt/setup.sh; STANDARD=17; BUILD_DDG4PLUGIN=ON; BUILD_DELPHESPLUGIN=ON; PODIO_FROM=BUILD_HEAD_ONTHEFLY; STACK=KEY4HEPNIGHTLY;
+
+matrix:
+  allow_failures:
+  - env: SETUPSCRIPT=/cvmfs/sw-nightlies.hsf.org/key4hep/views/latest/x86_64-centos7-gcc8-opt/setup.sh; STANDARD=17; BUILD_DDG4PLUGIN=ON; BUILD_DELPHESPLUGIN=ON; PODIO_FROM=STACK; STACK=KEY4HEPNIGHTLY;
 
 before_install:
   - wget --no-check-certificate https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
@@ -51,8 +56,13 @@ install:
 
 # command to run tests
 script:
-  - docker run -ti --name CI_CONTAINER -v $PKGDIR:/workspace -e COMPILER_TYPE=$COMPILER -e LCG_RELEASE=${LCG_RELEASE} -e STANDARD=${STANDARD} -e COMPILER_VERSION=${COMPILER_VERSION} ${CVMFS_REPOS} -d clicdp/cc7-lcg bash 
-  - docker exec -ti CI_CONTAINER  /bin/bash -c "cd /workspace; pwd; ls;  ./.edm4hep-ci.d/compile_and_test.sh"
+  - docker run -ti --name CI_CONTAINER -v $PKGDIR:/workspace  -e SETUPSCRIPT=${SETUPSCRIPT}  -e BUILD_DDG4PLUGIN=${BUILD_DDG4PLUGIN} -e BUILD_DELPHESPLUGIN=${BUILD_DELPHESPLUGIN} -e STANDARD=${STANDARD}  ${CVMFS_REPOS} -d clicdp/cc7-lcg bash 
+  - if [[ "$PODIO_FROM" == "STACK" ]]; 
+    then docker exec -ti CI_CONTAINER  /bin/bash -c "cd /workspace; pwd; ls; source ${SETUPSCRIPT}; source ./.edm4hep-ci.d/compile_and_test.sh";
+    elif [[ "$PODIO_FROM" == "BUILD_HEAD_ONTHEFLY" ]];
+    then docker exec -ti CI_CONTAINER  /bin/bash -c "cd /workspace; pwd; ls; source ${SETUPSCRIPT}; source ./.edm4hep-ci.d/compile_and_test_with_podio.sh; source ./.edm4hep-ci.d/compile_and_test.sh;";
+    fi
+
 
 
 after_success:


### PR DESCRIPTION
Cleaned up some of the variables too, since we are not using exclusively the lcg setup scripts.

BEGINRELEASENOTES
- CI Update: Add option to build PODIO on the fly, dev3

ENDRELEASENOTES

 I'm also adding a  clang build with dev3 as well, for better coverage, but  only the build against the key4hep nightlies (gcc8) with the current podio master is required to pass.