### PR TITLE
[cmake] option for cpack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,10 @@ option(EDM4HEP_DOCUMENTATION "Whether or not to create doxygen doc target.")
 include(CTest)
 
 #--- enable CPack --------------------------------------------------------------
-include(cmake/EDM4HEPCPack.cmake)
+option(ENABLE_CPACK "Whether or not to use cpack config" OFF)
+if(ENABLE_CPACK)
+  include(cmake/EDM4HEPCPack.cmake)
+endif()
 
 #--- target for Doxygen documentation ------------------------------------------
 if(EDM4HEP_DOCUMENTATION)


### PR DESCRIPTION
The current CPack configuration (from the HSF template) tries to guess the platform, but fails with an error on some platforms such as arch. In order not to have to patch anything, this is turned off by default.
BEGINRELEASENOTES
- Add a cmake option for cpack

ENDRELEASENOTES