### PR TITLE
[delphes] Use the branch name instead of the delphes class for GenParticle

### DIFF
--- a/plugins/delphes/DelphesEDM4HepConverter.cc
+++ b/plugins/delphes/DelphesEDM4HepConverter.cc
@@ -55,7 +55,7 @@ DelphesEDM4HepConverter::DelphesEDM4HepConverter(ExRootConfParam /*const*/& bran
     {"Electron", &DelphesEDM4HepConverter::processMuonsElectrons}};
 
   for (const auto& branch : m_branches) {
-    if (contains(outputSettings.GenParticleCollections, branch.className.c_str())) {
+    if (contains(outputSettings.GenParticleCollections, branch.name.c_str())) {
       registerCollection<edm4hep::MCParticleCollection>(branch.name);
       m_processFunctions.emplace(branch.name, &DelphesEDM4HepConverter::processParticles);
     }

--- a/plugins/delphes/README.md
+++ b/plugins/delphes/README.md
@@ -52,7 +52,7 @@ All Delphes `GenParticle` collections that will be considered and stored as
 `edm4hep` output collection under the same name, but all generated particles
 will be considered for the associations to the `ReconstructedParticle`s in the
 global collection (See [above](#reconstructedparticlecollections)). Usually it
-is enough to use the `GenParticle` branch here since that contains all generated
+is enough to use the `Particle` branch here since that contains all generated
 particles from Delphes.
 
 #### `JetCollections`

--- a/plugins/delphes/edm4hep_output_config.tcl
+++ b/plugins/delphes/edm4hep_output_config.tcl
@@ -1,6 +1,6 @@
 module EDM4HepOutput EDM4HepOutput {
     add ReconstructedParticleCollections EFlowTrack EFlowPhoton EFlowNeutralHadron
-    add GenParticleCollections           GenParticle
+    add GenParticleCollections           Particle
     add JetCollections                   Jet
     add MuonCollections                  Muon
     add ElectronCollections              Electron


### PR DESCRIPTION
Otherwise we would select on the delphes class, which could lead to the
problem that we could accidentally select more branches than we had
anticipated. There would be not possibility to only select a subset of
all branches that correspond to the specified delphes class. Now we can
instead select the different branches by their name, which is also
consistent with how the other configuration parameters work.



BEGINRELEASENOTES
- Make delphes output configuration more consistent, by using branch names also for the generated particle collections.

ENDRELEASENOTES