### PR TITLE
Update lcg release used in init script

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -5,10 +5,8 @@
 
 # source LCG releases
 export BINARY_TAG=x86_64-${OS-centos7}-${COMPILER_VERSION-gcc8}-opt
-source /cvmfs/sft.cern.ch/lcg/views/${LCG_RELEASE-LCG_96c_LS}/$BINARY_TAG/setup.sh
+source /cvmfs/sft.cern.ch/lcg/views/${LCG_RELEASE-LCG_97a_FCC_4}/$BINARY_TAG/setup.sh
 
-# workaround for ROOT requiring a higher version of CMake than is provided by lcg
-export PATH=/cvmfs/sft.cern.ch/lcg/releases/CMake/3.14.3-34449/$BINARY_TAG/bin/:$PATH
 
 
 


### PR DESCRIPTION
The CI will override the version with environment variables, but the default version is outdated. Bumping this to the lcg version which contains podio v00-12

BEGINRELEASENOTES
- update lcg release used in init script to 97a

ENDRELEASENOTES