### PR TITLE
Clear internal maps before the referenced objects are clered by the EventStore

### DIFF
--- a/plugins/delphes/DelphesEDM4HepConverter.cc
+++ b/plugins/delphes/DelphesEDM4HepConverter.cc
@@ -103,8 +103,6 @@ void DelphesEDM4HepConverter::process(Delphes *modularDelphes) {
   for (auto& coll : m_collections) {
    coll.second->clear();
   }
-  m_genParticleIds.clear();
-  m_recoParticleGenIds.clear();
 
   for (const auto& branch : m_branches) {
     const auto* delphesCollection = modularDelphes->ImportArray(branch.input.c_str());
@@ -119,6 +117,11 @@ void DelphesEDM4HepConverter::process(Delphes *modularDelphes) {
       (this->*processFuncIt->second)(delphesCollection, branch.name);
     }
   }
+
+  // Clear the internal maps that hold references to entites that have been put
+  // into maps here for internal use only (see #89)
+  m_genParticleIds.clear();
+  m_recoParticleGenIds.clear();
 }
 
 void DelphesEDM4HepConverter::processParticles(const TObjArray* delphesCollection, std::string_view const branch)


### PR DESCRIPTION
Avoid running into a double free, because the EventStore::clearCollections that might be called outside will free the objects wo which we still hold pointers and would free again when we deconstruct the objects that we hold int he maps.

BEGINRELEASENOTES
- Fix double free in Delphes EDM4Hep converter that lead to spurious segmentation violations (#89)

ENDRELEASENOTES

Fixes #89 