### PR TITLE
Remove last remnants of delphes plugin from travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,16 @@ language: cpp
 
 env:
   matrix:
-    - SETUPSCRIPT=/cvmfs/sw.hsf.org/key4hep/setup.sh; STANDARD=17; BUILD_DDG4EDM4HEP=ON; BUILD_DELPHESEDM4HEP=ON; PODIO_FROM=STACK; STACK=KEY4HEPNIGHTLY;
-    - SETUPSCRIPT=/cvmfs/sw.hsf.org/key4hep/setup.sh; STANDARD=17; BUILD_DDG4EDM4HEP=ON; BUILD_DELPHESEDM4HEP=ON; PODIO_FROM=BUILD_HEAD_ONTHEFLY; STACK=KEY4HEPNIGHTLY;
-    - SETUPSCRIPT=/cvmfs/sft.cern.ch/lcg/views/dev3/latest/x86_64-centos7-gcc8-opt/setup.sh; STANDARD=17; BUILD_DDG4EDM4HEP=ON; BUILD_DELPHESEDM4HEP=ON; PODIO_FROM=BUILD_HEAD_ONTHEFLY; STACK=KEY4HEPNIGHTLY;
-    - SETUPSCRIPT=/cvmfs/sft.cern.ch/lcg/views/dev3/latest/x86_64-centos7-clang8-opt/setup.sh; STANDARD=17; BUILD_DDG4EDM4HEP=ON; BUILD_DELPHESEDM4HEP=ON; PODIO_FROM=BUILD_HEAD_ONTHEFLY; STACK=KEY4HEPNIGHTLY;
+    - SETUPSCRIPT=/cvmfs/sw.hsf.org/key4hep/setup.sh; STANDARD=17; BUILD_DDG4EDM4HEP=ON; PODIO_FROM=STACK; STACK=KEY4HEPNIGHTLY;
+    - SETUPSCRIPT=/cvmfs/sw.hsf.org/key4hep/setup.sh; STANDARD=17; BUILD_DDG4EDM4HEP=ON; PODIO_FROM=BUILD_HEAD_ONTHEFLY; STACK=KEY4HEPNIGHTLY;
+    - SETUPSCRIPT=/cvmfs/sft.cern.ch/lcg/views/dev3/latest/x86_64-centos7-gcc8-opt/setup.sh; STANDARD=17; BUILD_DDG4EDM4HEP=ON; PODIO_FROM=BUILD_HEAD_ONTHEFLY; STACK=KEY4HEPNIGHTLY;
+    - SETUPSCRIPT=/cvmfs/sft.cern.ch/lcg/views/dev3/latest/x86_64-centos7-clang8-opt/setup.sh; STANDARD=17; BUILD_DDG4EDM4HEP=ON; PODIO_FROM=BUILD_HEAD_ONTHEFLY; STACK=KEY4HEPNIGHTLY;
 
 matrix:
   allow_failures:
-  - env: SETUPSCRIPT=/cvmfs/sw.hsf.org/key4hep/setup.sh; STANDARD=17; BUILD_DDG4EDM4HEP=ON; BUILD_DELPHESEDM4HEP=ON; PODIO_FROM=STACK; STACK=KEY4HEPNIGHTLY;
-  - env: SETUPSCRIPT=/cvmfs/sft.cern.ch/lcg/views/dev3/latest/x86_64-centos7-clang8-opt/setup.sh; STANDARD=17; BUILD_DDG4EDM4HEP=ON; BUILD_DELPHESEDM4HEP=ON; PODIO_FROM=BUILD_HEAD_ONTHEFLY; STACK=KEY4HEPNIGHTLY;
-  - env: SETUPSCRIPT=/cvmfs/sft.cern.ch/lcg/views/dev3/latest/x86_64-centos7-gcc8-opt/setup.sh; STANDARD=17; BUILD_DDG4EDM4HEP=ON; BUILD_DELPHESEDM4HEP=ON; PODIO_FROM=BUILD_HEAD_ONTHEFLY; STACK=KEY4HEPNIGHTLY;
+  - env: SETUPSCRIPT=/cvmfs/sw.hsf.org/key4hep/setup.sh; STANDARD=17; BUILD_DDG4EDM4HEP=ON; PODIO_FROM=STACK; STACK=KEY4HEPNIGHTLY;
+  - env: SETUPSCRIPT=/cvmfs/sft.cern.ch/lcg/views/dev3/latest/x86_64-centos7-clang8-opt/setup.sh; STANDARD=17; BUILD_DDG4EDM4HEP=ON; PODIO_FROM=BUILD_HEAD_ONTHEFLY; STACK=KEY4HEPNIGHTLY;
+  - env: SETUPSCRIPT=/cvmfs/sft.cern.ch/lcg/views/dev3/latest/x86_64-centos7-gcc8-opt/setup.sh; STANDARD=17; BUILD_DDG4EDM4HEP=ON; PODIO_FROM=BUILD_HEAD_ONTHEFLY; STACK=KEY4HEPNIGHTLY;
 
 before_install:
   - wget --no-check-certificate https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
@@ -63,7 +63,7 @@ install:
 
 # command to run tests
 script:
-  - docker run -ti --name CI_CONTAINER -v $PKGDIR:/workspace  -e SETUPSCRIPT=${SETUPSCRIPT}  -e BUILD_DDG4EDM4HEP=${BUILD_DDG4EDM4HEP} -e BUILD_DELPHESEDM4HEP=${BUILD_DELPHESEDM4HEP} -e STANDARD=${STANDARD} -v /cvmfs:/cvmfs:shared -d clicdp/cc7-lcg bash 
+  - docker run -ti --name CI_CONTAINER -v $PKGDIR:/workspace  -e SETUPSCRIPT=${SETUPSCRIPT}  -e BUILD_DDG4EDM4HEP=${BUILD_DDG4EDM4HEP} -e STANDARD=${STANDARD} -v /cvmfs:/cvmfs:shared -d clicdp/cc7-lcg bash
   - if [[ "$PODIO_FROM" == "STACK" ]]; 
     then docker exec -ti CI_CONTAINER  /bin/bash -c "cd /workspace; pwd; ls; source ${SETUPSCRIPT}; source ./.edm4hep-ci.d/compile_and_test.sh";
     elif [[ "$PODIO_FROM" == "BUILD_HEAD_ONTHEFLY" ]];


### PR DESCRIPTION
After #94 the `BUILD_DELPHESEDM4HEP` option is no longer available and can be removed from the travis setup.