### PR TITLE
[cmake] add call to find_package_handle_standard_args to get a Found:…

### DIFF
--- a/cmake/EDM4HEPConfig.cmake.in
+++ b/cmake/EDM4HEPConfig.cmake.in
@@ -18,3 +18,6 @@ find_dependency(podio REQUIRED)
 # link to (libraries) or execute (programs)
 include("${CMAKE_CURRENT_LIST_DIR}/EDM4HEPTargets.cmake")
 
+
+get_property(TEST_EDM4HEP_LIBRARY TARGET EDM4HEP::edm4hep PROPERTY LOCATION)
+find_package_handle_standard_args(EDM4HEP DEFAULT_MSG CMAKE_CURRENT_LIST_FILE TEST_EDM4HEP_LIBRARY)

--- a/cmake/EDM4HEPConfig.cmake.in
+++ b/cmake/EDM4HEPConfig.cmake.in
@@ -18,6 +18,7 @@ find_dependency(podio REQUIRED)
 # link to (libraries) or execute (programs)
 include("${CMAKE_CURRENT_LIST_DIR}/EDM4HEPTargets.cmake")
 
-
+# print the default "Found:" message and check library location
+include(FindPackageHandleStandardArgs)
 get_property(TEST_EDM4HEP_LIBRARY TARGET EDM4HEP::edm4hep PROPERTY LOCATION)
 find_package_handle_standard_args(EDM4HEP DEFAULT_MSG CMAKE_CURRENT_LIST_FILE TEST_EDM4HEP_LIBRARY)


### PR DESCRIPTION

BEGINRELEASENOTES
- [cmake] add call to find_package_handle_standard_args to get a Found:… msg

ENDRELEASENOTES

This PR will add the standard printout

```
  -- Found EDM4HEP: /cvmfs/sw.hsf.org/spackages/linux-ubuntu20.04-broadwell/gcc-9.3.0/edm4hep-...
```
when downstream packages call `find_package(EDM4HEP)` (unless QUIET is added). 