### PR TITLE
[WIP] example code for a simple user defined float collection

### DIFF
--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -407,3 +407,11 @@ datatypes :
      - edm4hep::TrackerHit rec    // reference to the reconstructed hit
      - edm4hep::SimTrackerHit sim // reference to the simulated hit
      
+
+
+  edm4hep::UserFloat:
+      Description: "A simple struct with one user defined float value"
+      Author : "F.Gaede"
+      Members:
+        - float value      // the single float value for extra user data
+

--- a/test/read_events.h
+++ b/test/read_events.h
@@ -6,6 +6,7 @@
 #include "edm4hep/SimTrackerHitCollection.h"
 #include "edm4hep/CaloHitContributionCollection.h"
 #include "edm4hep/SimCalorimeterHitCollection.h"
+#include "edm4hep/UserFloatCollection.h"
 
 // podio specific includes
 #include "podio/EventStore.h"
@@ -21,6 +22,7 @@ void processEvent(podio::EventStore& store, bool verboser, unsigned eventNum) {
   auto& sths   = store.get<edm4hep::SimTrackerHitCollection>("SimTrackerHits");
   auto& schs   = store.get<edm4hep::SimCalorimeterHitCollection>("SimCalorimeterHits");
   auto& sccons = store.get<edm4hep::CaloHitContributionCollection>("SimCalorimeterHitContributions");
+  auto& usrflts = store.get<edm4hep::UserFloatCollection>("UserFloats");
 
 
   if( mcps.isValid() ){
@@ -60,6 +62,27 @@ void processEvent(podio::EventStore& store, bool verboser, unsigned eventNum) {
     auto mcp2 = mcps[1] ;
     if( mcp2.getGeneratorStatus() != 3 ) throw std::runtime_error("wrong genStat for 2. particle - should be 3" );
     // and so on ...
+
+
+    // check user float data for MCParticles
+    int nmcp = mcps.size() ;
+    int nflts = usrflts.size() ;
+
+    if( nmcp != nflts ) throw std::runtime_error("number of user floats not equal to number of MCParticles");
+
+    for(int i=0 ; i<nmcp ; ++i){
+
+      auto pv = mcps[i].getMomentum() ;
+
+      float pp = sqrt( pv[0] * pv[0] +  pv[1] * pv[1] +  pv[2] * pv[2] );
+
+      float upp = usrflts[i].getValue() ;
+
+      if( pp != upp ){
+	std::cout << " incorrect user momentum stored: " << upp << " should be pp " << std::endl ;
+	throw std::runtime_error(" test failed...") ;
+      }
+    }
 
   } else {
     throw std::runtime_error("Collection 'MCParticles' should be present");

--- a/test/write_events.h
+++ b/test/write_events.h
@@ -6,6 +6,8 @@
 #include "edm4hep/SimTrackerHitCollection.h"
 #include "edm4hep/CaloHitContributionCollection.h"
 #include "edm4hep/SimCalorimeterHitCollection.h"
+#include "edm4hep/SimCalorimeterHitCollection.h"
+#include "edm4hep/UserFloatCollection.h"
 
 // STL
 #include <iostream>
@@ -33,6 +35,9 @@ void write(std::string outfilename) {
 
   auto& sccons = store.create<edm4hep::CaloHitContributionCollection>("SimCalorimeterHitContributions");
   writer.registerForWrite("SimCalorimeterHitContributions");
+
+  auto& usrflts  = store.create<edm4hep::UserFloatCollection>("UserFloats");
+  writer.registerForWrite("UserFloats");
 
 
   unsigned nevents = 10 ;
@@ -123,6 +128,19 @@ void write(std::string outfilename) {
     //fixme: should this become a utility function ?
     //-------------------------------------------------------------
 
+
+    //----  add a user float value per MCParticle as 'user data'
+
+    for( auto p : mcps ){
+
+      auto ufv =  usrflts.create();
+
+      auto pv = p.getMomentum() ;
+
+      float pp = sqrt( pv[0] * pv[0] +  pv[1] * pv[1] +  pv[2] * pv[2] );
+
+      ufv.setValue( pp  ) ;
+    }
 
     //-------- print particles for debugging:
     std::cout << "\n collection:  " << "MCParticles" <<  " of type " <<  mcps.getValueTypeName() << "\n\n"


### PR DESCRIPTION

BEGINRELEASENOTES
- simple example for a UserFloat class that holds one float value
     - could be used to store extra data (parallel to existing collections)

ENDRELEASENOTES

This is a simple example for how we could add extra user data that is not defined in the EDM.
It just adds a trivial data struct UserFloat with one float value to the yaml file. With this users could add one collection for any extra data attribute they would like to store in EDM4hep files.
Advantages: this is trivial to implement, self documenting if proper collection names are used, efficiently accessible in ROOT files as the floats are automatically stored in branches, ...
Disadvantages:  one would potentially need many extra collections, implementation via PODIO with three layers causes (at least) quite some code overhead for a single float value.
Of course this approach could be trivially extended to user defined ints, longs, doubles,...
For discussion in tomorrow's EDM4hep meeting.