### PR TITLE
Remove RecoParticleRef datatype

### DIFF
--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -382,13 +382,6 @@ datatypes :
      - edm4hep::ReconstructedParticle  rec  // reference to the reconstructed particle
      - edm4hep::MCParticle sim              // reference to the Monte-Carlo particle
 
-  edm4hep::RecoParticleRef:
-    Description: "Used to get a subset of reconstructed particles from a collection (or many collections)"
-    Author: "T. Madlener, DESY"
-    Members: {}
-    OneToOneRelations:
-      - edm4hep::ReconstructedParticle particle // reference to the reconstructed particle
-
   edm4hep::MCRecoCaloAssociation:
     Description: "Association between a CaloHit and the corresponding simulated CaloHit"
     Author: "C. Bernet, B. Hegner"


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove the `RecoParticleRef` datatype again because podio supports subset collections natively now (see AIDASoft/podio#197)

ENDRELEASENOTES

Needs AIDASoft/podio#197 to be merged before this can work.