### PR TITLE
Add github actions CI workflows 

### DIFF
--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -1,0 +1,38 @@
+name: key4hep
+
+on: [push, pull_request]
+
+jobs:
+  build-and-test-key4hep:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        release: ["sw.hsf.org/key4hep",
+                  "sw-nightlies.hsf.org/key4hep"]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: cvmfs-contrib/github-action-cvmfs@v2
+    - uses: aidasoft/run-lcg-view@v3
+      with:
+        container: centos7
+        view-path: /cvmfs/${{ matrix.release }}
+        run: |
+          mkdir build install
+          cd build
+          cmake .. -DCMAKE_CXX_STANDARD=17 \
+            -DCMAKE_INSTALL_PREFIX=../install \
+            -G Ninja
+          ninja -k0
+          ctest --output-on-failure
+          ninja install
+          cd -
+          echo "Test downstream usage"
+          export CMAKE_PREFIX_PATH=$PWD/install:$CMAKE_PREFIX_PATH
+          cd test/downstream-project-cmake-test
+          mkdir build
+          cd build
+          cmake .. -DCMAKE_CXX_STANDARD=17 \
+            -DCMAKE_INSTALL_PREFIX=../install \
+            -G Ninja
+          ninja -k0

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,39 @@
+name: linux
+
+on: [push, pull_request]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        LCG: ["LCG_99/x86_64-centos7-gcc8-opt",
+              "LCG_99/x86_64-centos7-gcc10-opt",
+              "LCG_99/x86_64-centos7-clang10-opt",
+              "LCG_99/x86_64-ubuntu2004-gcc9-opt"]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: cvmfs-contrib/github-action-cvmfs@v2
+    - uses: aidasoft/run-lcg-view@v3
+      with:
+        release-platform: ${{ matrix.LCG }}
+        run: |
+          mkdir build install
+          cd build
+          cmake .. -DCMAKE_CXX_STANDARD=17 \
+            -DCMAKE_INSTALL_PREFIX=../install \
+            -G Ninja
+          ninja -k0
+          ctest --output-on-failure
+          ninja install
+          cd -
+          echo "Test downstream usage"
+          export CMAKE_PREFIX_PATH=$PWD/install:$CMAKE_PREFIX_PATH
+          cd test/downstream-project-cmake-test
+          mkdir build
+          cd build
+          cmake .. -DCMAKE_CXX_STANDARD=17 \
+            -DCMAKE_INSTALL_PREFIX=../install \
+            -G Ninja
+          ninja -k0

--- a/.github/workflows/linux_with_podio.yml
+++ b/.github/workflows/linux_with_podio.yml
@@ -1,0 +1,59 @@
+name: linux_with_podio
+
+on: [push, pull_request]
+
+jobs:
+  build-and-test-with-podio:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        LCG: ["LCG_99/x86_64-centos7-gcc10-opt",
+              "dev3/x86_64-centos7-clang10-opt",
+              "dev4/x86_64-centos7-gcc10-opt",
+              "dev4/x86_64-centos7-clang10-opt"]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: cvmfs-contrib/github-action-cvmfs@v2
+    - uses: aidasoft/run-lcg-view@v3
+      with:
+        release-platform: ${{ matrix.LCG }}
+        run: |
+          STARTDIR=$(pwd)
+          echo "Building podio @"$(git log -1 --format=%H)
+          git clone --depth 1 https://github.com/AIDASoft/podio
+          cd podio
+          mkdir build install
+          cd build
+          cmake .. -DCMAKE_CXX_STANDARD=17 \
+            -DENABLE_SIO=ON \
+            -DBUILD_TESTING=OFF \
+            -DCMAKE_INSTALL_PREFIX=$(pwd)/../install \
+            -G Ninja
+          ninja -k0
+          ninja install
+          cd ..
+          export ROOT_INCLUDE_PATH=$(pwd)/install/include:$ROOT_INCLUDE_PATH:$CPATH
+          unset CPATH
+          export CMAKE_PREFIX_PATH=$(pwd)/install:$CMAKE_PREFIX_PATH
+          export LD_LIBRARY_PATH=$(pwd)/install/lib:$(pwd)/install/lib64:$LD_LIBRARY_PATH
+          cd $STARTDIR
+          echo "Building edm4hep"
+          mkdir build install
+          cd build
+          cmake .. -DCMAKE_CXX_STANDARD=17 \
+            -DCMAKE_INSTALL_PREFIX=../install \
+            -G Ninja
+          ninja -k0
+          ctest --output-on-failure
+          ninja install
+          cd -
+          echo "Test downstream usage"
+          export CMAKE_PREFIX_PATH=$PWD/install:$CMAKE_PREFIX_PATH
+          cd test/downstream-project-cmake-test
+          mkdir build
+          cd build
+          cmake .. -DCMAKE_CXX_STANDARD=17 \
+            -DCMAKE_INSTALL_PREFIX=../install \
+            -G Ninja
+          ninja -k0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 
 [![Build Status](https://travis-ci.com/key4hep/EDM4HEP.svg?branch=master)](https://travis-ci.com/key4hep/EDM4HEP)
+[![linux](https://github.com/key4hep/EDM4hep/workflows/linux.yml/badge.svg)](https://github.com/key4hep/EDM4hep/actions/workflows/linux.yml)
+[![key4hep](https://github.com/key4hep/EDM4hep/workflows/key4hep.yml/badge.svg)](https://github.com/key4hep/EDM4hep/actions/workflows/key4hep.yml)
 
 # EDM4hep
 

--- a/test/edm4hep_tricktrack.cc
+++ b/test/edm4hep_tricktrack.cc
@@ -3,12 +3,6 @@
 #include <vector>
 #include <functional>
 
-
-// podio specific includes
-#include "podio/EventStore.h"
-#include "podio/ROOTReader.h"
-
-
 #include "tricktrack/HitChainMaker.h"
 #include "tricktrack/HitDoublets.h"
 #include "tricktrack/TripletFilter.h"


### PR DESCRIPTION

BEGINRELEASENOTES
- Add github actions CI workflows
- Fix issue with CI builds that build podio on the fly

ENDRELEASENOTES

Should we keep the travis CI workflows for now and remove them later, or should we migrate to github actions fully in this PR?

The linking problems that the "on-the-fly podio build" has, can easily be fixed by removing the unnecessary includes in the tricktrack test (`#include "podio/ROOTReader.h"` would need the `podio::podioRootIO` target to link against).