### PR TITLE
Add first kinematics utilities

### DIFF
--- a/.github/workflows/lcg_linux.yml
+++ b/.github/workflows/lcg_linux.yml
@@ -23,6 +23,7 @@ jobs:
           cd build
           cmake .. -DCMAKE_CXX_STANDARD=17 \
             -DCMAKE_INSTALL_PREFIX=../install \
+            -DUSE_EXTERNAL_CATCH2=OFF \
             -G Ninja
           ninja -k0
           ctest --output-on-failure

--- a/.github/workflows/lcg_linux_with_podio.yml
+++ b/.github/workflows/lcg_linux_with_podio.yml
@@ -43,6 +43,7 @@ jobs:
           cd build
           cmake .. -DCMAKE_CXX_STANDARD=17 \
             -DCMAKE_INSTALL_PREFIX=../install \
+            -DUSE_EXTERNAL_CATCH2=OFF \
             -G Ninja
           ninja -k0
           ctest --output-on-failure

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,10 @@ tricktrack/
 *.exe
 *.out
 *.app
+
+# spack related folders/files
+spack*
+
+# Tooling
+/.clangd/
+/compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,6 @@ find_package(podio REQUIRED HINTS $ENV{PODIO})
 list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 find_package(ROOT REQUIRED COMPONENTS RIO Tree Physics)
-set(ROOT_genreflex_cmd ${ROOT_genreflex_CMD})
 
 #--- Define basic build settings -----------------------------------------------
 # - Use GNU-style hierarchy for installing build products
@@ -103,7 +102,7 @@ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE
 add_subdirectory(edm4hep)
 add_subdirectory(test)
 add_subdirectory(dataframe)
-
+add_subdirectory(utils)
 
 #--- create uninstall target ---------------------------------------------------
 include(cmake/EDM4HEPUninstall.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,9 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDROP_CGAL")
 
 option(BUILD_DOCS "Whether or not to create doxygen doc target.")
 
+option(USE_EXTERNAL_CATCH2 "Link against an external Catch2 v3 static
+library, otherwise build it locally" ON)
+
 #--- enable unit testing capabilities ------------------------------------------
 include(CTest)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -83,3 +83,5 @@ if(HepMC_FOUND AND HepPDT_FOUND )
     ENVIRONMENT LD_LIBRARY_PATH=$<TARGET_FILE_DIR:edm4hep>:$<TARGET_FILE_DIR:podio::podio>:$ENV{LD_LIBRARY_PATH}
     )
 endif()
+
+add_subdirectory(utils)

--- a/test/downstream-project-cmake-test/CMakeLists.txt
+++ b/test/downstream-project-cmake-test/CMakeLists.txt
@@ -6,4 +6,4 @@ project(DownstreamProjectUsingEDM4hep)
 find_package(EDM4HEP)
 
 add_executable(appUsingEDM4hep main.cxx)
-target_link_libraries(appUsingEDM4hep EDM4HEP::edm4hep)
+target_link_libraries(appUsingEDM4hep EDM4HEP::edm4hep EDM4HEP::utils)

--- a/test/downstream-project-cmake-test/main.cxx
+++ b/test/downstream-project-cmake-test/main.cxx
@@ -1,12 +1,14 @@
-
 ///  make sure that downstream projects can include and link edm4hep properly
 
 
 
 #include "edm4hep/MCParticle.h"
+#include "edm4hep/kinematics.h"
 
 int main() {
 
   auto a = edm4hep::MCParticle();
+  const auto p4 = edm4hep::utils::p4(a);
+
   return 0;
 }

--- a/test/utils/CMakeLists.txt
+++ b/test/utils/CMakeLists.txt
@@ -1,0 +1,21 @@
+if(USE_EXTERNAL_CATCH2)
+  find_package(Catch2 REQUIRED)
+else()
+  message(STATUS "Fetching local copy of Catch2 library for unit-tests...")
+
+  include(FetchContent)
+  FetchContent_Declare(
+    Catch2
+    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+    GIT_TAG        6f21a3609cea360846a0ca93be55877cca14c86d
+  )
+  FetchContent_MakeAvailable(Catch2)
+  set(CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras ${CMAKE_MODULE_PATH})
+endif()
+
+include(Catch)
+
+add_executable(unittests
+  test_kinematics.cpp)
+target_link_libraries(unittests edm4hep EDM4HEP::utils Catch2::Catch2 Catch2::Catch2WithMain)
+catch_discover_tests(unittests)

--- a/test/utils/test_kinematics.cpp
+++ b/test/utils/test_kinematics.cpp
@@ -1,0 +1,123 @@
+#define CATCH_CONFIG_FAST_COMPILE
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include "edm4hep/kinematics.h"
+
+#include "edm4hep/MCParticle.h"
+#include "edm4hep/ReconstructedParticle.h"
+
+#include "Math/Vector4D.h"
+
+#include <tuple>
+
+using ParticleTypes = std::tuple<edm4hep::MCParticle, edm4hep::ReconstructedParticle>;
+
+TEMPLATE_LIST_TEST_CASE( "pT: transverse momentum", "[pT][kinematics]", ParticleTypes)
+{
+  using namespace edm4hep;
+  TestType particle;
+
+  particle.setMomentum({3.0f, 4.0f, 0.0f});
+  REQUIRE(utils::pT(particle) == 5.0f);
+
+  particle.setMomentum({3.0f, 4.0f, 125.0f});
+  REQUIRE(utils::pT(particle) == 5.0f);
+
+  particle.setMomentum({-3.0f, 4.0f, 10.0f});
+  REQUIRE(utils::pt(particle) == 5.0f);
+
+  particle.setMomentum({-4.0f, -3.0f, std::nanf("")});
+  REQUIRE(utils::pt(particle) == 5.0f);
+
+  particle.setMomentum({std::nanf(""), -3.0f, 0});
+  REQUIRE(std::isnan(utils::pt(particle)));
+}
+
+TEMPLATE_LIST_TEST_CASE( "p: momentum", "[p][kinematics]", ParticleTypes )
+{
+  using namespace edm4hep;
+  TestType particle;
+
+  particle.setMomentum({1.0f, 2.0f, 3.0f});
+  REQUIRE(utils::p(particle) == Catch::Approx(std::sqrt(14)));
+
+  particle.setMomentum({1.0f, -2.0f, 3.0f});
+  REQUIRE(utils::p(particle) == Catch::Approx(std::sqrt(14)));
+
+  particle.setMomentum({1.0f, 2.0f, -3.0f});
+  REQUIRE(utils::p(particle) == Catch::Approx(std::sqrt(14)));
+
+  particle.setMomentum({-12.0f, 0.0f, 0.0f});
+  REQUIRE(utils::p(particle) == 12.0f);
+
+  particle.setMomentum({0.0f, -10.0f, -10.f});
+  REQUIRE(utils::p(particle) == Catch::Approx(std::sqrt(200.0)));
+
+  particle.setMomentum({std::nanf(""), 2.0f, 3.0f});
+  REQUIRE(std::isnan(utils::p(particle)));
+}
+
+TEST_CASE( "p4: four momentum - MCParticle", "[p4][kinematics][MCParticle]" )
+{
+  using namespace edm4hep;
+  MCParticle particle;
+  particle.setMomentum({1.0f, 2.0f, 3.0f});
+  particle.setMass(42);
+  REQUIRE(utils::p4(particle) == LorentzVectorM{1, 2, 3, 42});
+
+  // this basically just tests that the internal calculation of the energy works as expected
+  REQUIRE(utils::p4(particle, utils::UseEnergy) == LorentzVectorE{1, 2, 3, std::sqrt(14 + 42*42)});
+}
+
+TEST_CASE( "p4: four momentum - ReconstructedParticle", "[p4][kinematics][ReconstructedParticle]" )
+{
+  using namespace edm4hep;
+  ReconstructedParticle particle;
+  particle.setMomentum({1.0f, 2.0f, 3.0f});
+  particle.setMass(125);
+
+  // By default we use the mass
+  REQUIRE(utils::p4(particle) == LorentzVectorM{1, 2, 3, 125});
+
+  // In the case of ReconstructedParticle, the 4-momentum state is not kept
+  // consistent internally! So, when using the energy we will have a different 4
+  // momentum vector
+  REQUIRE(utils::p4(particle, utils::UseEnergy) == LorentzVectorE{1, 2, 3, 0});
+
+  // Setting the Energy does not affect the mass
+  particle.setEnergy(42);
+  REQUIRE(utils::p4(particle, utils::UseMass) == LorentzVectorM{1, 2, 3, 125});
+  REQUIRE(utils::p4(particle, utils::UseEnergy) == LorentzVectorE{1, 2, 3, 42});
+}
+
+TEST_CASE( "p4 with user set values", "[p4][kinematics][user set values]" ) {
+  using namespace edm4hep;
+  ReconstructedParticle particle;
+  particle.setMomentum({1.0f, 2.0f, 3.0f});
+  particle.setMass(125.0f);
+  particle.setEnergy(42.0f);
+
+  // Requiring a dedicated mass value gives us a 4-vector with that mass value
+  REQUIRE(utils::p4(particle, utils::SetMass{3.096f}) == LorentzVectorM{1.0f, 2.0f, 3.0f, 3.096f});
+  // The mass of the particle itself remains unchanged!
+  REQUIRE(particle.getMass() == 125.f);
+
+  // Similar with the energy, if we want a dedicated value we get it in the 4 vector
+  REQUIRE(utils::p4(particle, utils::SetEnergy{1.23f}) == LorentzVectorE{1.0f, 2.0f, 3.0f, 1.23f});
+  // But the underlying particle energy remains unchanged
+  REQUIRE(particle.getEnergy() == 42.f);
+
+  // Make sure everything still works with the MC particle
+  MCParticle mcPart;
+  mcPart.setMomentum({-1.0f, -2.0f, -3.0f});
+  mcPart.setMass(125.0f);
+
+  REQUIRE(utils::p4(mcPart, utils::SetMass{3.096f}) == LorentzVectorM{-1.0f, -2.0f, -3.0f, 3.096f});
+  REQUIRE(mcPart.getMass() == 125.0f); // mass remains unchanged
+
+  // everything needs to work with const classes as well
+  const auto mcPart2 = mcPart;
+  REQUIRE(utils::p4(mcPart2, utils::SetMass{3.096f}) == LorentzVectorM{-1.0f, -2.0f, -3.0f, 3.096f});
+}

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,0 +1,21 @@
+add_library(kinematics INTERFACE)
+add_library(EDM4HEP::kinematics ALIAS kinematics)
+
+target_include_directories(kinematics
+  INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/utils>)
+
+target_link_libraries(kinematics PUBLIC INTERFACE ROOT::Core)
+target_compile_features(kinematics INTERFACE cxx_std_17)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/utils
+  PATTERN "CMakeLists.txt" EXCLUDE)
+
+
+add_library(utils INTERFACE)
+add_library(EDM4HEP::utils ALIAS utils)
+target_link_libraries(utils INTERFACE kinematics)
+
+install(TARGETS utils kinematics
+  EXPORT EDM4HEPTargets
+  )

--- a/utils/include/edm4hep/kinematics.h
+++ b/utils/include/edm4hep/kinematics.h
@@ -1,0 +1,138 @@
+#ifndef EDM4HEP_UTILS_KINEMATICS_H
+#define EDM4HEP_UTILS_KINEMATICS_H
+
+#include "Math/Vector4D.h"
+
+#include <cmath>
+
+namespace edm4hep {
+/**
+ * A LorentzVector with (px, py, pz) and M
+ */
+using LorentzVectorM = ROOT::Math::PxPyPzMVector;
+
+/**
+ * A LorentzVector with (px, py, pz) and E
+ */
+using LorentzVectorE = ROOT::Math::PxPyPzEVector;
+
+namespace utils {
+
+/**
+ * Get the transverse momentum from a Particle
+ */
+template<typename ParticleT>
+inline float pT(ParticleT const& p) {
+  return std::sqrt(p.getMomentum()[0] * p.getMomentum()[0] + p.getMomentum()[1] * p.getMomentum()[1]);
+}
+
+/**
+ * Get the transverse momentum from a Particle
+ */
+template<typename ParticleT>
+inline float pt(ParticleT const& p) {
+  return pT(p);
+}
+
+/**
+ * Get the total momentum from a Particle
+ */
+template<typename ParticleT>
+inline float p(ParticleT const& part) {
+  const auto mom = part.getMomentum();
+  return std::sqrt(mom[0]*mom[0] + mom[1]*mom[1] + mom[2]*mom[2]);
+}
+
+namespace detail {
+/**
+ * Tag struct for getting 4-momenta with momentum + mass
+ */
+struct UseMassTag {
+  using type = ::edm4hep::LorentzVectorM;
+  static constexpr bool has_value = false;
+};
+
+/**
+ * Tag struct for getting 4-momenta with momentum + energy
+ */
+struct UseEnergyTag {
+  using type = ::edm4hep::LorentzVectorE;
+  static constexpr bool has_value = false;
+};
+
+/**
+ * Tag struct holding an additional value for getting 4 momenta with arbitrary
+ * values instead of the one from the Particle.
+ */
+template<typename T, typename TagT>
+struct TaggedUserValue {
+  using type = typename TagT::type;
+  static constexpr bool has_value = true;
+  T value;
+};
+
+/**
+ * Tag-dispatched implementation for getting the 4-momentum from a particle
+ * according to the desired type.
+ */
+template<typename ParticleT, typename LorentzVectorTypeTag>
+inline typename LorentzVectorTypeTag::type p4(ParticleT const& part,
+                                              [[maybe_unused]] LorentzVectorTypeTag* tag) {
+  const auto mom = part.getMomentum();
+  // Either the user wants to set a specific value
+  if constexpr(LorentzVectorTypeTag::has_value) {
+    return typename LorentzVectorTypeTag::type{mom[0], mom[1], mom[2], tag->value};
+  }
+
+  // Or we take the one from the underying particle
+  if constexpr(std::is_same_v<typename LorentzVectorTypeTag::type, LorentzVectorM>) {
+    return LorentzVectorM{mom[0], mom[1], mom[2], part.getMass()};
+  }
+  if constexpr(std::is_same_v<typename LorentzVectorTypeTag::type, LorentzVectorE>) {
+    return LorentzVectorE{mom[0], mom[1], mom[2], part.getEnergy()};
+  }
+}
+} // namespace detail
+
+using UseMassTag = detail::UseMassTag;
+/**
+ * Static tag to select the mass in 4 momentum vectors
+ */
+constexpr static UseMassTag UseMass;
+
+using UseEnergyTag = detail::UseEnergyTag;
+/**
+ * Static tag to select the energy in 4 momentum vectors
+ */
+constexpr static UseEnergyTag UseEnergy;
+
+/**
+ * Class to inject a user-defined mass into 4 momentum vectors in the call to
+ * p4
+ */
+using SetMass = detail::TaggedUserValue<float, UseMassTag>;
+
+/**
+ * Class to inject a user-defined energy into 4 momentum vectors in the call to
+ * p4
+ */
+using SetEnergy = detail::TaggedUserValue<float, UseEnergyTag>;
+
+/**
+ * Get the 4 momentum vector from a Particle. By default using the momentum and
+ * the mass, but can be switched to using the energy when using the UseEnergy as
+ * second argument. Additionally it is possible to take the momentum from the
+ * particle but set a specific mass or energy value by using SetMass or
+ * SetEnergy as the second argument. The underlying particle will not be changed
+ * in this case.
+ */
+template<typename ParticleT, typename LorentzVectorTag=UseMassTag>
+inline typename LorentzVectorTag::type p4(ParticleT const& part, LorentzVectorTag tag=UseMass) {
+  return detail::p4(part, &tag);
+}
+
+
+}} // namespace edm4hep::utils
+
+
+#endif


### PR DESCRIPTION
BEGINRELEASENOTES
- Add first utility functionality for kinematics living in namespace `edm4hep::utils`:
  - `edm4hep::utils::p` returns the total momentum for the passed particle
  - `edm4hep::utils::pt` and `edm4hep::utils::pT` returns the transverse momentum for the passed particle
  - `edm4hep::utils::p4` returns the four momentum of the passed particle, depending on the (optional) second argument it uses the momentum of the passed particle and either
    - the mass of the passed particle if the second argument is `edm4hep::utils::UseMass` (**default**)
    - the energy of the passed particle if the second argument is `edm4hep::utils::UseEnergy`
    - an arbitrary value for either the mass or the energy if the second argument is `edm4hep::utils::SetMass{value}` or `edm4hep::utils::SetEnergy{value}` respectively.

ENDRELEASENOTES

Copied everything from key4hep/EDM4hep-utils#1 and made the necessary adaptions to make it compile.

The kinematic utilities are currently a header-only "library" and live in `utils/include/edm4hep`, they are installed to `<prefix>/include/utils/edm4hep`. The `EDM4HEP::kinematics` target is exported for the `kinematics.h` header, additionally a `EDM4HEP::utils` target is exported that contains all utilities (to be further populated in the future).