### PR TITLE
Make necessary changes for podio mutable classes

### DIFF
--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -12,7 +12,7 @@ components:
         - float x
         - float y
         - float z
-      ExtraCode :
+      ExtraCode:
         declaration: "
         Vector3f() : x(0),y(0),z(0) {}\n
         Vector3f(float xx, float yy, float zz) : x(xx),y(yy),z(zz) {}\n
@@ -27,7 +27,7 @@ components:
         - double x
         - double y
         - double z
-      ExtraCode :
+      ExtraCode:
         declaration: "
         Vector3d() : x(0),y(0),z(0) {}\n
         Vector3d(double xx, double yy, double zz) : x(xx),y(yy),z(zz) {}\n
@@ -56,7 +56,7 @@ components:
       Members:
         - float a
         - float b
-      ExtraCode :
+      ExtraCode:
         declaration: "
         Vector2f() : a(0),b(0) {}\n
         Vector2f(float aa,float bb) : a(aa),b(bb) {}\n
@@ -76,7 +76,7 @@ components:
         - float tanLambda // lambda is the dip angle of the track in r-z
         - edm4hep::Vector3f referencePoint // Reference point of the track parameters, e.g. the origin at the IP, or the position  of the first/last hits or the entry point into the calorimeter.
         - std::array<float, 15> covMatrix // lower triangular covariance matrix of the track parameters.  the order of parameters is  d0, phi, omega, z0, tan(lambda). the array is a row-major flattening of the matrix.
-      ExtraCode :
+      ExtraCode:
         declaration: "
         static const int AtOther = 0 ; // any location other than the ones defined below\n   
         static const int AtIP = 1 ;\n
@@ -132,7 +132,7 @@ datatypes :
     OneToManyRelations:
       - edm4hep::MCParticle parents // The parents of this particle.
       - edm4hep::MCParticle daughters // The daughters this particle.
-    ExtraCode :
+    MutableExtraCode:
       includes: "#include <cmath>"
       declaration: "
       int32_t  set_bit(int32_t val, int num, bool bitval){ return (val & ~(1<<num)) | (bitval << num); }                               \n
@@ -146,7 +146,7 @@ datatypes :
       void setOverlay(bool bitval) { setSimulatorStatus( set_bit( getSimulatorStatus() , BITOverlay , bitval ) ) ;   }         \n 
       "
 
-    ConstExtraCode:
+    ExtraCode:
       declaration: "
       // define the bit positions for the simulation flag\n
       static const int BITEndpoint = 31;\n
@@ -195,14 +195,14 @@ datatypes :
       - edm4hep::Vector3f momentum     //the 3-momentum of the particle at the hits position in [GeV]
     OneToOneRelations:
       - edm4hep::MCParticle MCParticle //MCParticle that caused the hit.
-    ExtraCode :
+    MutableExtraCode:
       includes: "#include <cmath>"
       declaration: "
       int32_t  set_bit(int32_t val, int num, bool bitval){ return (val & ~(1<<num)) | (bitval << num); }\n
       void setOverlay(bool val) { setQuality( set_bit( getQuality() , BITOverlay , val ) ) ;   }\n
       void setProducedBySecondary(bool val) { setQuality( set_bit( getQuality() , BITProducedBySecondary , val ) ) ;   }\n
       "
-    ConstExtraCode:
+    ExtraCode:
       declaration: "
       static const int  BITOverlay = 31;\n
       static const int  BITProducedBySecondary = 30;\n
@@ -403,7 +403,7 @@ datatypes :
       - edm4hep::Track                 tracks       //tracks that have been used for this particle. 
       - edm4hep::ReconstructedParticle particles    //reconstructed particles that have been combined to this particle.
       - edm4hep::ParticleID            particleIDs  //particle Ids (not sorted by their likelihood) 
-    ExtraCode:
+    MutableExtraCode:
       declaration: "
       bool isCompound() { return particles_size() > 0 ;}\n
       //vertex where the particle decays This method actually returns the start vertex from the first daughter particle found.\n 
@@ -481,4 +481,3 @@ datatypes :
     OneToOneRelations:
      - edm4hep::ReconstructedParticle rec // reference to the reconstructed particle
      - edm4hep::Vertex vertex             // reference to the vertex
-

--- a/test/hepmc/edm4hep_testhepmc.cc
+++ b/test/hepmc/edm4hep_testhepmc.cc
@@ -22,8 +22,8 @@
 
 using namespace HepMC3;
 
- edm4hep::MCParticle convert(std::shared_ptr<GenParticle> hepmcParticle) {
-    auto edm_particle = edm4hep::MCParticle();
+ edm4hep::MutableMCParticle convert(std::shared_ptr<GenParticle> hepmcParticle) {
+    auto edm_particle = edm4hep::MutableMCParticle();
     edm_particle.setPDG(hepmcParticle->pdg_id());
     edm_particle.setGeneratorStatus(hepmcParticle->status());
     // look up charge from pdg_id
@@ -127,8 +127,8 @@ int main() {
     auto writer = podio::ROOTWriter("edm4hep_testhepmc.root", &store);
     auto& edm_particle_collection = store.create<edm4hep::MCParticleCollection>("TestParticles2");
     writer.registerForWrite("TestParticles2");
-    std::unordered_map<unsigned int, edm4hep::MCParticle> hepmcToEdmMap;
-    unsigned int particle_counter;
+    std::unordered_map<unsigned int, edm4hep::MutableMCParticle> hepmcToEdmMap;
+    unsigned int particle_counter{0};
     for (auto particle_i: evt->particles()) {
       std::cout << "Converting particle with PDG ID: " << particle_i->pdg_id() << std::endl;
       std::cout << "\t and id: " << particle_i->id() << std::endl;

--- a/test/utils/test_kinematics.cpp
+++ b/test/utils/test_kinematics.cpp
@@ -5,14 +5,14 @@
 
 #include "edm4hep/kinematics.h"
 
-#include "edm4hep/MCParticle.h"
-#include "edm4hep/ReconstructedParticle.h"
+#include "edm4hep/MutableMCParticle.h"
+#include "edm4hep/MutableReconstructedParticle.h"
 
 #include "Math/Vector4D.h"
 
 #include <tuple>
 
-using ParticleTypes = std::tuple<edm4hep::MCParticle, edm4hep::ReconstructedParticle>;
+using ParticleTypes = std::tuple<edm4hep::MutableMCParticle, edm4hep::MutableReconstructedParticle>;
 
 TEMPLATE_LIST_TEST_CASE( "pT: transverse momentum", "[pT][kinematics]", ParticleTypes)
 {
@@ -62,7 +62,7 @@ TEMPLATE_LIST_TEST_CASE( "p: momentum", "[p][kinematics]", ParticleTypes )
 TEST_CASE( "p4: four momentum - MCParticle", "[p4][kinematics][MCParticle]" )
 {
   using namespace edm4hep;
-  MCParticle particle;
+  MutableMCParticle particle;
   particle.setMomentum({1.0f, 2.0f, 3.0f});
   particle.setMass(42);
   REQUIRE(utils::p4(particle) == LorentzVectorM{1, 2, 3, 42});
@@ -74,7 +74,7 @@ TEST_CASE( "p4: four momentum - MCParticle", "[p4][kinematics][MCParticle]" )
 TEST_CASE( "p4: four momentum - ReconstructedParticle", "[p4][kinematics][ReconstructedParticle]" )
 {
   using namespace edm4hep;
-  ReconstructedParticle particle;
+  MutableReconstructedParticle particle;
   particle.setMomentum({1.0f, 2.0f, 3.0f});
   particle.setMass(125);
 
@@ -94,7 +94,7 @@ TEST_CASE( "p4: four momentum - ReconstructedParticle", "[p4][kinematics][Recons
 
 TEST_CASE( "p4 with user set values", "[p4][kinematics][user set values]" ) {
   using namespace edm4hep;
-  ReconstructedParticle particle;
+  MutableReconstructedParticle particle;
   particle.setMomentum({1.0f, 2.0f, 3.0f});
   particle.setMass(125.0f);
   particle.setEnergy(42.0f);
@@ -110,7 +110,7 @@ TEST_CASE( "p4 with user set values", "[p4][kinematics][user set values]" ) {
   REQUIRE(particle.getEnergy() == 42.f);
 
   // Make sure everything still works with the MC particle
-  MCParticle mcPart;
+  MutableMCParticle mcPart;
   mcPart.setMomentum({-1.0f, -2.0f, -3.0f});
   mcPart.setMass(125.0f);
 

--- a/test/write_events.h
+++ b/test/write_events.h
@@ -158,7 +158,7 @@ void write(std::string outfilename) {
       sch1.setEnergy( j * 0.1 );
       sch1.setPosition( { j*100.f , j*200.f, j*50.f } ) ;
 
-      auto cont1 =  edm4hep::CaloHitContribution(11, j * 0.1f ,j*1e-9f, { j*100.01f , j*200.01f, j*50.01f } );
+      auto cont1 =  edm4hep::MutableCaloHitContribution(11, j * 0.1f ,j*1e-9f, { j*100.01f , j*200.01f, j*50.01f } );
       sccons.push_back( cont1 ) ;
       cont1.setParticle( mcp7 ) ;
       sch1.addToContributions( cont1 ) ;
@@ -168,7 +168,7 @@ void write(std::string outfilename) {
       sch2.setPosition( { -j*100.f , -j*200.f, -j*50.f } ) ;
       sch2.setEnergy( j * .2 );
 
-      auto cont2 =  edm4hep::CaloHitContribution(-11, j*0.2f , j*1e-9f, { -j*100.01f , -j*200.01f, -j*50.01f } );
+      auto cont2 =  edm4hep::MutableCaloHitContribution(-11, j*0.2f , j*1e-9f, { -j*100.01f , -j*200.01f, -j*50.01f } );
       sccons.push_back( cont2 ) ;
       cont2.setParticle( mcp8 ) ;
       sch2.addToContributions( cont2 ) ;


### PR DESCRIPTION

BEGINRELEASENOTES
- With AIDASoft/podio#205 the naming of the podio generated classes has changed and the immutable classes are now default, while mutable classes now have a `Mutable` prefix.

ENDRELEASENOTES