### PR TITLE
Update supported c++ standards

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ endif()
 # - Define the C++ Standard to use (Simplest Possible)
 set(CMAKE_CXX_STANDARD 17 CACHE STRING "")
 
-if(NOT CMAKE_CXX_STANDARD MATCHES "14|17")
+if(NOT CMAKE_CXX_STANDARD MATCHES "17|20")
   message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD}")
 endif()
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Update the supported c++ standards in the CMake configuration (17 and 20 at the moment).

ENDRELEASENOTES

podio generated code requires at least c++17.