### PR TITLE
Adding Time in edm4hep::TrackState

### DIFF
--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -74,8 +74,9 @@ components:
         - float omega // is the signed curvature of the track in [1/mm].
         - float Z0 // longitudinal impact parameter
         - float tanLambda // lambda is the dip angle of the track in r-z
+        - float time // time of the track at this trackstate
         - edm4hep::Vector3f referencePoint // Reference point of the track parameters, e.g. the origin at the IP, or the position  of the first/last hits or the entry point into the calorimeter.
-        - std::array<float, 15> covMatrix // lower triangular covariance matrix of the track parameters.  the order of parameters is  d0, phi, omega, z0, tan(lambda). the array is a row-major flattening of the matrix.
+        - std::array<float, 21> covMatrix // lower triangular covariance matrix of the track parameters.  the order of parameters is  d0, phi, omega, z0, tan(lambda), time. the array is a row-major flattening of the matrix.
       ExtraCode:
         declaration: "
         static const int AtOther = 0 ; // any location other than the ones defined below\n   


### PR DESCRIPTION
As discussed several times, the time of the track is needed. For example, ACTS tracking code does. In addition, this time in ```edm4hep::TrackState``` can be used to obtain the time of the tracks at different points
BEGINRELEASENOTES
- TrackState: add time related entries to the covarianceMatrix

ENDRELEASENOTES

TODO:
- [x] @vvolkl to check if array size increase is possible with root's schema evolution
- [ ] cf. https://github.com/key4hep/EDM4hep/issues/154