### PR TITLE
CI: update compilers for LCG dev builds

### DIFF
--- a/.github/workflows/lcg_linux_with_podio.yml
+++ b/.github/workflows/lcg_linux_with_podio.yml
@@ -9,9 +9,9 @@ jobs:
       fail-fast: false
       matrix:
         LCG: ["LCG_99/x86_64-centos7-gcc10-opt",
-              "dev3/x86_64-centos7-clang10-opt",
-              "dev4/x86_64-centos7-gcc10-opt",
-              "dev4/x86_64-centos7-clang10-opt"]
+              "dev3/x86_64-centos7-clang11-opt",
+              "dev4/x86_64-centos7-gcc11-opt",
+              "dev4/x86_64-centos7-clang12-opt"]
     steps:
     - uses: actions/checkout@v2
     - uses: cvmfs-contrib/github-action-cvmfs@v2

--- a/.github/workflows/lcg_linux_with_podio.yml
+++ b/.github/workflows/lcg_linux_with_podio.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         LCG: ["LCG_99/x86_64-centos7-gcc10-opt",
-              "dev3/x86_64-centos7-clang11-opt",
+              "dev3/x86_64-centos7-clang12-opt",
               "dev4/x86_64-centos7-gcc11-opt",
               "dev4/x86_64-centos7-clang12-opt"]
     steps:


### PR DESCRIPTION

BEGINRELEASENOTES
- Update the compilers that are used for the `dev` based CI workflows

ENDRELEASENOTES

See also: AIDASoft/podio#265