### PR TITLE
Utilities for vector components

### DIFF
--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -14,11 +14,11 @@ components:
         - float z
       ExtraCode:
         declaration: "
-        Vector3f() : x(0),y(0),z(0) {}\n
-        Vector3f(float xx, float yy, float zz) : x(xx),y(yy),z(zz) {}\n
-        Vector3f(const float* v) : x(v[0]),y(v[1]),z(v[2]) {}\n
-        bool operator==(const Vector3f& v) const { return (x==v.x&&y==v.y&&z==v.z) ; }\n
-        float operator[](unsigned i) const { return *( &x + i ) ; }\n
+        constexpr Vector3f() : x(0),y(0),z(0) {}\n
+        constexpr Vector3f(float xx, float yy, float zz) : x(xx),y(yy),z(zz) {}\n
+        constexpr Vector3f(const float* v) : x(v[0]),y(v[1]),z(v[2]) {}\n
+        constexpr bool operator==(const Vector3f& v) const { return (x==v.x&&y==v.y&&z==v.z) ; }\n
+        constexpr float operator[](unsigned i) const { return *( &x + i ) ; }\n
         "
 
     # Vector3D with doubles
@@ -29,12 +29,12 @@ components:
         - double z
       ExtraCode:
         declaration: "
-        Vector3d() : x(0),y(0),z(0) {}\n
-        Vector3d(double xx, double yy, double zz) : x(xx),y(yy),z(zz) {}\n
-        Vector3d(const double* v) : x(v[0]),y(v[1]),z(v[2]) {}\n
-        Vector3d(const float* v) : x(v[0]),y(v[1]),z(v[2]) {}\n
-        bool operator==(const Vector3d& v) const { return (x==v.x&&y==v.y&&z==v.z) ; }\n
-        double operator[](unsigned i) const { return *( &x + i ) ; }\n
+        constexpr Vector3d() : x(0),y(0),z(0) {}\n
+        constexpr Vector3d(double xx, double yy, double zz) : x(xx),y(yy),z(zz) {}\n
+        constexpr Vector3d(const double* v) : x(v[0]),y(v[1]),z(v[2]) {}\n
+        constexpr Vector3d(const float* v) : x(v[0]),y(v[1]),z(v[2]) {}\n
+        constexpr bool operator==(const Vector3d& v) const { return (x==v.x&&y==v.y&&z==v.z) ; }\n
+        constexpr double operator[](unsigned i) const { return *( &x + i ) ; }\n
         "
 
     # Vector2D with ints
@@ -44,11 +44,11 @@ components:
         - int32_t b
       ExtraCode :
         declaration: "
-        Vector2i() : a(0),b(0) {}\n
-        Vector2i(int32_t aa, int32_t bb) : a(aa),b(bb) {}\n
-        Vector2i( const int32_t* v) : a(v[0]), b(v[1]) {}\n
-        bool operator==(const Vector2i& v) const { return (a==v.a&&b==v.b) ; }\n
-        int operator[](unsigned i) const { return *( &a + i ) ; }\n
+        constexpr Vector2i() : a(0),b(0) {}\n
+        constexpr Vector2i(int32_t aa, int32_t bb) : a(aa),b(bb) {}\n
+        constexpr Vector2i( const int32_t* v) : a(v[0]), b(v[1]) {}\n
+        constexpr bool operator==(const Vector2i& v) const { return (a==v.a&&b==v.b) ; }\n
+        constexpr int operator[](unsigned i) const { return *( &a + i ) ; }\n
         "
 
     # Vector2D with floats
@@ -58,11 +58,11 @@ components:
         - float b
       ExtraCode:
         declaration: "
-        Vector2f() : a(0),b(0) {}\n
-        Vector2f(float aa,float bb) : a(aa),b(bb) {}\n
-        Vector2f(const float* v) : a(v[0]), b(v[1]) {}\n
-        bool operator==(const Vector2f& v) const { return (a==v.a&&b==v.b) ; }\n
-        float operator[](unsigned i) const { return *( &a + i ) ; }\n
+        constexpr Vector2f() : a(0),b(0) {}\n
+        constexpr Vector2f(float aa,float bb) : a(aa),b(bb) {}\n
+        constexpr Vector2f(const float* v) : a(v[0]), b(v[1]) {}\n
+        constexpr bool operator==(const Vector2f& v) const { return (a==v.a&&b==v.b) ; }\n
+        constexpr float operator[](unsigned i) const { return *( &a + i ) ; }\n
         "
 
       # Parametrized description of a particle track

--- a/test/utils/CMakeLists.txt
+++ b/test/utils/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 include(Catch)
 
 add_executable(unittests
-  test_kinematics.cpp)
+  test_kinematics.cpp test_vector_utils.cpp)
 target_link_libraries(unittests edm4hep EDM4HEP::utils Catch2::Catch2 Catch2::Catch2WithMain)
 catch_discover_tests(unittests)
 

--- a/test/utils/test_vector_utils.cpp
+++ b/test/utils/test_vector_utils.cpp
@@ -1,0 +1,83 @@
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include "edm4hep/utils/vector_utils.h"
+
+#include "edm4hep/Vector2f.h"
+#include "edm4hep/Vector2i.h"
+#include "edm4hep/Vector3d.h"
+#include "edm4hep/Vector3f.h"
+
+#include <tuple>
+#include <type_traits>
+
+using AllVectorTypes = std::tuple<edm4hep::Vector3f, edm4hep::Vector3d, edm4hep::Vector2i, edm4hep::Vector2f>;
+
+template <typename V>
+constexpr V create();
+
+template <>
+constexpr edm4hep::Vector3f create() {
+  return edm4hep::Vector3f{1.0f, 2.0f, 3.0f};
+}
+
+template <>
+constexpr edm4hep::Vector3d create() {
+  return edm4hep::Vector3d{1.0, 2.0, 3.0};
+}
+
+template <>
+constexpr edm4hep::Vector2f create() {
+  return edm4hep::Vector2f{1.0f, 2.0f};
+}
+
+template <>
+constexpr edm4hep::Vector2i create() {
+  return edm4hep::Vector2i{1, 2};
+}
+
+TEMPLATE_LIST_TEST_CASE("Vector uniform getters", "[vector_utils]", AllVectorTypes) {
+  using namespace edm4hep;
+
+  constexpr auto vector = create<TestType>();
+
+  STATIC_REQUIRE(utils::vector_x(vector) == utils::ValueType<TestType>(1.0));
+  STATIC_REQUIRE(utils::vector_y(vector) == utils::ValueType<TestType>(2.0));
+  // 2D vectors fill z component with 0
+  if constexpr (std::is_same_v<TestType, edm4hep::Vector2i> || std::is_same_v<TestType, edm4hep::Vector2f>) {
+    STATIC_REQUIRE(utils::vector_z(vector) == utils::ValueType<TestType>(0.0));
+  } else {
+    STATIC_REQUIRE(utils::vector_z(vector) == utils::ValueType<TestType>(3.0));
+  }
+}
+
+TEST_CASE("Vector ValueType", "[vector_utils]") {
+  using namespace edm4hep;
+  STATIC_REQUIRE(std::is_same_v<int32_t, utils::ValueType<Vector2i>>);
+  STATIC_REQUIRE(std::is_same_v<float, utils::ValueType<Vector2f>>);
+  STATIC_REQUIRE(std::is_same_v<float, utils::ValueType<Vector3f>>);
+  STATIC_REQUIRE(std::is_same_v<double, utils::ValueType<Vector3d>>);
+}
+
+TEMPLATE_LIST_TEST_CASE("Vector operators", "[vector_utils]", AllVectorTypes) {
+  using namespace edm4hep;
+
+  constexpr auto vector1 = create<TestType>();
+  constexpr auto vector2 = create<TestType>();
+
+  // Some very basic tests to check addition and multiplication / division by a factor
+  constexpr auto sumV = vector1 + vector2;
+  STATIC_REQUIRE(sumV == 2 * vector1);
+  STATIC_REQUIRE(sumV == vector1 * 2); // check that both orders of args work
+  STATIC_REQUIRE(sumV / 2 == vector2);
+
+  // check that subtraction works
+  STATIC_REQUIRE(sumV - vector1 == vector2);
+
+  // Vector product (depends again on whether it is 2D or 3D)
+  if constexpr (std::is_same_v<TestType, edm4hep::Vector2i> || std::is_same_v<TestType, edm4hep::Vector2f>) {
+    STATIC_REQUIRE(vector1 * vector2 == utils::ValueType<TestType>(5));
+  } else {
+    STATIC_REQUIRE(vector1 * vector2 == utils::ValueType<TestType>(14));
+  }
+}

--- a/utils/include/edm4hep/utils/vector_utils.h
+++ b/utils/include/edm4hep/utils/vector_utils.h
@@ -208,7 +208,6 @@ namespace utils {
   }
 
 } // namespace utils
-} // namespace edm4hep
 
 template <edm4hep::Vector2D V>
 inline constexpr V operator+(const V& v1, const V& v2) {
@@ -267,6 +266,8 @@ template <edm4hep::VectorND V>
 inline constexpr V operator/(const V& v, const double d) {
   return (1. / d) * v;
 }
+
+} // namespace edm4hep
 
 #endif
 #endif

--- a/utils/include/edm4hep/utils/vector_utils.h
+++ b/utils/include/edm4hep/utils/vector_utils.h
@@ -12,24 +12,42 @@
 
 namespace edm4hep {
 
-template <class V> concept VectorHasX = requires(V v) { v.x; };
-template <class V> concept VectorHasY = requires(V v) { v.y; };
-template <class V> concept VectorHasZ = requires(V v) { v.z; };
-template <class V> concept VectorHasA = requires(V v) { v.a; };
-template <class V> concept VectorHasB = requires(V v) { v.b; };
-template <class V> concept ClassVector = requires(V v) { v.x(); };
 template <class V>
-concept Vector2D_XY =
-    VectorHasX<V>&& VectorHasY<V> && !VectorHasZ<V> && !ClassVector<V>;
+concept VectorHasX = requires(V v) {
+  v.x;
+};
 template <class V>
-concept Vector2D_AB =
-    VectorHasA<V>&& VectorHasB<V> && !VectorHasZ<V> && !ClassVector<V>;
-template <class V> concept Vector2D = Vector2D_XY<V> || Vector2D_AB<V>;
+concept VectorHasY = requires(V v) {
+  v.y;
+};
 template <class V>
-concept Vector3D =
-    VectorHasX<V>&& VectorHasY<V>&& VectorHasZ<V> && !ClassVector<V>;
-template <class V> concept VectorND = Vector2D<V> || Vector3D<V>;
-template <class V> concept VectorND_XYZ = Vector2D_XY<V> || Vector3D<V>;
+concept VectorHasZ = requires(V v) {
+  v.z;
+};
+template <class V>
+concept VectorHasA = requires(V v) {
+  v.a;
+};
+template <class V>
+concept VectorHasB = requires(V v) {
+  v.b;
+};
+template <class V>
+concept ClassVector = requires(V v) {
+  v.x();
+};
+template <class V>
+concept Vector2D_XY = VectorHasX<V>&& VectorHasY<V> && !VectorHasZ<V> && !ClassVector<V>;
+template <class V>
+concept Vector2D_AB = VectorHasA<V>&& VectorHasB<V> && !VectorHasZ<V> && !ClassVector<V>;
+template <class V>
+concept Vector2D = Vector2D_XY<V> || Vector2D_AB<V>;
+template <class V>
+concept Vector3D = VectorHasX<V>&& VectorHasY<V>&& VectorHasZ<V> && !ClassVector<V>;
+template <class V>
+concept VectorND = Vector2D<V> || Vector3D<V>;
+template <class V>
+concept VectorND_XYZ = Vector2D_XY<V> || Vector3D<V>;
 
 inline double etaToAngle(const double eta) {
   return std::atan(std::exp(-eta)) * 2.;
@@ -39,11 +57,26 @@ inline double angleToEta(const double theta) {
 }
 
 // Utility getters to accomodate different vector types
-template <VectorND_XYZ V> auto vector_x(const V& v) { return v.x; }
-template <VectorND_XYZ V> auto vector_y(const V& v) { return v.y; }
-template <Vector3D V> auto vector_z(const V& v) { return v.z; }
-template <Vector2D_AB V> auto vector_x(const V& v) { return v.a; }
-template <Vector2D_AB V> auto vector_y(const V& v) { return v.b; }
+template <VectorND_XYZ V>
+auto vector_x(const V& v) {
+  return v.x;
+}
+template <VectorND_XYZ V>
+auto vector_y(const V& v) {
+  return v.y;
+}
+template <Vector3D V>
+auto vector_z(const V& v) {
+  return v.z;
+}
+template <Vector2D_AB V>
+auto vector_x(const V& v) {
+  return v.a;
+}
+template <Vector2D_AB V>
+auto vector_y(const V& v) {
+  return v.b;
+}
 
 // inline edm4hep::Vector2f VectorFromPolar(const double r, const double theta)
 // {
@@ -62,42 +95,53 @@ V sphericalToVector(const double r, const double theta, const double phi) {
   return {x, y, z};
 }
 
-template <Vector3D V> double anglePolar(const V& v) {
+template <Vector3D V>
+double anglePolar(const V& v) {
   return std::atan2(std::hypot(vector_x(v), vector_y(v)), vector_z(v));
 }
-template <VectorND V> double angleAzimuthal(const V& v) {
+template <VectorND V>
+double angleAzimuthal(const V& v) {
   return std::atan2(vector_y(v), vector_x(v));
 }
-template <Vector3D V> double eta(const V& v) {
+template <Vector3D V>
+double eta(const V& v) {
   return angleToEta(anglePolar(v));
 }
-template <Vector2D V> double magnitude(const V& v) {
+template <Vector2D V>
+double magnitude(const V& v) {
   return std::hypot(vector_x(v), vector_y(v));
 }
-template <Vector3D V> double magnitude(const V& v) {
+template <Vector3D V>
+double magnitude(const V& v) {
   return std::hypot(vector_x(v), vector_y(v), vector_z(v));
 }
-template <Vector3D V> double magnitudeTransverse(const V& v) {
+template <Vector3D V>
+double magnitudeTransverse(const V& v) {
   return std::hypot(vector_x(v), vector_y(v));
 }
-template <Vector3D V> double magnitudeLongitudinal(const V& v) {
+template <Vector3D V>
+double magnitudeLongitudinal(const V& v) {
   return vector_z(v);
 }
-template <VectorND V> V normalizeVector(const V& v, double norm = 1.) {
+template <VectorND V>
+V normalizeVector(const V& v, double norm = 1.) {
   const double old = magnitude(v);
   if (old == 0) {
     return v;
   }
   return (norm > 0) ? v * norm / old : v * 0;
 }
-template <Vector3D V> V vectorTransverse(const V& v) {
+template <Vector3D V>
+V vectorTransverse(const V& v) {
   return {vector_x(v), vector_y(v), 0};
 }
-template <Vector3D V> V vectorLongitudinal(const V& v) {
+template <Vector3D V>
+V vectorLongitudinal(const V& v) {
   return {0, 0, vector_z(v)};
 }
 // Two vector functions
-template <VectorND V> double angleBetween(const V& v1, const V& v2) {
+template <VectorND V>
+double angleBetween(const V& v1, const V& v2) {
   const double dot = v1 * v2;
   if (dot == 0) {
     return 0.;
@@ -105,7 +149,8 @@ template <VectorND V> double angleBetween(const V& v1, const V& v2) {
   return acos(dot / (magnitude(v1) * magnitude(v2)));
 }
 // Project v onto v1
-template <Vector3D V> double projection(const V& v, const V& v1) {
+template <Vector3D V>
+double projection(const V& v, const V& v1) {
   const double norm = magnitude(v1);
   if (norm == 0) {
     return magnitude(v);
@@ -114,40 +159,46 @@ template <Vector3D V> double projection(const V& v, const V& v1) {
 }
 
 } // namespace edm4hep
-template <edm4hep::Vector2D V> V operator+(const V& v1, const V& v2) {
-  return {edm4hep::vector_x(v1) + edm4hep::vector_x(v2),
-          edm4hep::vector_y(v1) + edm4hep::vector_y(v2)};
+template <edm4hep::Vector2D V>
+V operator+(const V& v1, const V& v2) {
+  return {edm4hep::vector_x(v1) + edm4hep::vector_x(v2), edm4hep::vector_y(v1) + edm4hep::vector_y(v2)};
 }
-template <edm4hep::Vector3D V> V operator+(const V& v1, const V& v2) {
-  return {edm4hep::vector_x(v1) + edm4hep::vector_x(v2),
-          edm4hep::vector_y(v1) + edm4hep::vector_y(v2),
+template <edm4hep::Vector3D V>
+V operator+(const V& v1, const V& v2) {
+  return {edm4hep::vector_x(v1) + edm4hep::vector_x(v2), edm4hep::vector_y(v1) + edm4hep::vector_y(v2),
           edm4hep::vector_z(v1) + edm4hep::vector_z(v2)};
 }
-template <edm4hep::Vector2D V> double operator*(const V& v1, const V& v2) {
-  return edm4hep::vector_x(v1) * edm4hep::vector_x(v2) +
-         edm4hep::vector_y(v1) * edm4hep::vector_y(v2);
+template <edm4hep::Vector2D V>
+double operator*(const V& v1, const V& v2) {
+  return edm4hep::vector_x(v1) * edm4hep::vector_x(v2) + edm4hep::vector_y(v1) * edm4hep::vector_y(v2);
 }
-template <edm4hep::Vector3D V> double operator*(const V& v1, const V& v2) {
-  return edm4hep::vector_x(v1) * edm4hep::vector_x(v2) +
-         edm4hep::vector_y(v1) * edm4hep::vector_y(v2) +
-         edm4hep::vector_z(v1) * edm4hep::vector_z(v2);
+template <edm4hep::Vector3D V>
+double operator*(const V& v1, const V& v2) {
+  return edm4hep::vector_x(v1) * edm4hep::vector_x(v2) + edm4hep::vector_y(v1) * edm4hep::vector_y(v2) +
+      edm4hep::vector_z(v1) * edm4hep::vector_z(v2);
 }
-template <edm4hep::Vector2D V> V operator*(const double d, const V& v) {
+template <edm4hep::Vector2D V>
+V operator*(const double d, const V& v) {
   return {d * edm4hep::vector_x(v), d * edm4hep::vector_y(v)};
 }
-template <edm4hep::Vector3D V> V operator*(const double d, const V& v) {
+template <edm4hep::Vector3D V>
+V operator*(const double d, const V& v) {
   return {d * edm4hep::vector_x(v), d * edm4hep::vector_y(v), d * edm4hep::vector_z(v)};
 }
-template <edm4hep::Vector2D V> V operator*(const V& v, const double d) {
+template <edm4hep::Vector2D V>
+V operator*(const V& v, const double d) {
   return {d * edm4hep::vector_x(v), d * edm4hep::vector_y(v)};
 }
-template <edm4hep::Vector3D V> V operator*(const V& v, const double d) {
+template <edm4hep::Vector3D V>
+V operator*(const V& v, const double d) {
   return {d * edm4hep::vector_x(v), d * edm4hep::vector_y(v), d * edm4hep::vector_z(v)};
 }
-template <edm4hep::VectorND V> V operator-(const V& v1, const V& v2) {
+template <edm4hep::VectorND V>
+V operator-(const V& v1, const V& v2) {
   return v1 + (-1. * v2);
 }
-template <edm4hep::VectorND V> V operator/(const V& v, const double d) {
+template <edm4hep::VectorND V>
+V operator/(const V& v, const double d) {
   return (1. / d) * v;
 }
 #endif

--- a/utils/include/edm4hep/utils/vector_utils.h
+++ b/utils/include/edm4hep/utils/vector_utils.h
@@ -1,0 +1,154 @@
+#ifndef EDM4HEP_UTILS_VECTOR_HH
+#define EDM4HEP_UTILS_VECTOR_HH
+
+// These ultilies require concepts. If not available, use the fallback
+// vector_utils_legacy.h instead to capture most functionality.
+#if !__cpp_concepts
+#include <edm4hep/vector_utils_legacy.h>
+#else
+#include <cmath>
+
+#include <edm4hep/Vector3f.h>
+
+namespace edm4hep {
+
+template <class V> concept VectorHasX = requires(V v) { v.x; };
+template <class V> concept VectorHasY = requires(V v) { v.y; };
+template <class V> concept VectorHasZ = requires(V v) { v.z; };
+template <class V> concept VectorHasA = requires(V v) { v.a; };
+template <class V> concept VectorHasB = requires(V v) { v.b; };
+template <class V> concept ClassVector = requires(V v) { v.x(); };
+template <class V>
+concept Vector2D_XY =
+    VectorHasX<V>&& VectorHasY<V> && !VectorHasZ<V> && !ClassVector<V>;
+template <class V>
+concept Vector2D_AB =
+    VectorHasA<V>&& VectorHasB<V> && !VectorHasZ<V> && !ClassVector<V>;
+template <class V> concept Vector2D = Vector2D_XY<V> || Vector2D_AB<V>;
+template <class V>
+concept Vector3D =
+    VectorHasX<V>&& VectorHasY<V>&& VectorHasZ<V> && !ClassVector<V>;
+template <class V> concept VectorND = Vector2D<V> || Vector3D<V>;
+template <class V> concept VectorND_XYZ = Vector2D_XY<V> || Vector3D<V>;
+
+inline double etaToAngle(const double eta) {
+  return std::atan(std::exp(-eta)) * 2.;
+}
+inline double angleToEta(const double theta) {
+  return -std::log(std::tan(0.5 * theta));
+}
+
+// Utility getters to accomodate different vector types
+template <VectorND_XYZ V> auto vector_x(const V& v) { return v.x; }
+template <VectorND_XYZ V> auto vector_y(const V& v) { return v.y; }
+template <Vector3D V> auto vector_z(const V& v) { return v.z; }
+template <Vector2D_AB V> auto vector_x(const V& v) { return v.a; }
+template <Vector2D_AB V> auto vector_y(const V& v) { return v.b; }
+
+// inline edm4hep::Vector2f VectorFromPolar(const double r, const double theta)
+// {
+//  return {r * sin(theta), r * cos(theta)};
+//}
+template <Vector3D V = edm4hep::Vector3f>
+V sphericalToVector(const double r, const double theta, const double phi) {
+  using FloatType = decltype(vector_x(V()));
+  const double sth = sin(theta);
+  const double cth = cos(theta);
+  const double sph = sin(phi);
+  const double cph = cos(phi);
+  const FloatType x = r * sth * cph;
+  const FloatType y = r * sth * sph;
+  const FloatType z = r * cth;
+  return {x, y, z};
+}
+
+template <Vector3D V> double anglePolar(const V& v) {
+  return std::atan2(std::hypot(vector_x(v), vector_y(v)), vector_z(v));
+}
+template <VectorND V> double angleAzimuthal(const V& v) {
+  return std::atan2(vector_y(v), vector_x(v));
+}
+template <Vector3D V> double eta(const V& v) {
+  return angleToEta(anglePolar(v));
+}
+template <Vector2D V> double magnitude(const V& v) {
+  return std::hypot(vector_x(v), vector_y(v));
+}
+template <Vector3D V> double magnitude(const V& v) {
+  return std::hypot(vector_x(v), vector_y(v), vector_z(v));
+}
+template <Vector3D V> double magnitudeTransverse(const V& v) {
+  return std::hypot(vector_x(v), vector_y(v));
+}
+template <Vector3D V> double magnitudeLongitudinal(const V& v) {
+  return vector_z(v);
+}
+template <VectorND V> V normalizeVector(const V& v, double norm = 1.) {
+  const double old = magnitude(v);
+  if (old == 0) {
+    return v;
+  }
+  return (norm > 0) ? v * norm / old : v * 0;
+}
+template <Vector3D V> V vectorTransverse(const V& v) {
+  return {vector_x(v), vector_y(v), 0};
+}
+template <Vector3D V> V vectorLongitudinal(const V& v) {
+  return {0, 0, vector_z(v)};
+}
+// Two vector functions
+template <VectorND V> double angleBetween(const V& v1, const V& v2) {
+  const double dot = v1 * v2;
+  if (dot == 0) {
+    return 0.;
+  }
+  return acos(dot / (magnitude(v1) * magnitude(v2)));
+}
+// Project v onto v1
+template <Vector3D V> double projection(const V& v, const V& v1) {
+  const double norm = magnitude(v1);
+  if (norm == 0) {
+    return magnitude(v);
+  }
+  return v * v1 / norm;
+}
+
+} // namespace edm4hep
+template <edm4hep::Vector2D V> V operator+(const V& v1, const V& v2) {
+  return {edm4hep::vector_x(v1) + edm4hep::vector_x(v2),
+          edm4hep::vector_y(v1) + edm4hep::vector_y(v2)};
+}
+template <edm4hep::Vector3D V> V operator+(const V& v1, const V& v2) {
+  return {edm4hep::vector_x(v1) + edm4hep::vector_x(v2),
+          edm4hep::vector_y(v1) + edm4hep::vector_y(v2),
+          edm4hep::vector_z(v1) + edm4hep::vector_z(v2)};
+}
+template <edm4hep::Vector2D V> double operator*(const V& v1, const V& v2) {
+  return edm4hep::vector_x(v1) * edm4hep::vector_x(v2) +
+         edm4hep::vector_y(v1) * edm4hep::vector_y(v2);
+}
+template <edm4hep::Vector3D V> double operator*(const V& v1, const V& v2) {
+  return edm4hep::vector_x(v1) * edm4hep::vector_x(v2) +
+         edm4hep::vector_y(v1) * edm4hep::vector_y(v2) +
+         edm4hep::vector_z(v1) * edm4hep::vector_z(v2);
+}
+template <edm4hep::Vector2D V> V operator*(const double d, const V& v) {
+  return {d * edm4hep::vector_x(v), d * edm4hep::vector_y(v)};
+}
+template <edm4hep::Vector3D V> V operator*(const double d, const V& v) {
+  return {d * edm4hep::vector_x(v), d * edm4hep::vector_y(v), d * edm4hep::vector_z(v)};
+}
+template <edm4hep::Vector2D V> V operator*(const V& v, const double d) {
+  return {d * edm4hep::vector_x(v), d * edm4hep::vector_y(v)};
+}
+template <edm4hep::Vector3D V> V operator*(const V& v, const double d) {
+  return {d * edm4hep::vector_x(v), d * edm4hep::vector_y(v), d * edm4hep::vector_z(v)};
+}
+template <edm4hep::VectorND V> V operator-(const V& v1, const V& v2) {
+  return v1 + (-1. * v2);
+}
+template <edm4hep::VectorND V> V operator/(const V& v, const double d) {
+  return (1. / d) * v;
+}
+#endif
+#endif

--- a/utils/include/edm4hep/utils/vector_utils.h
+++ b/utils/include/edm4hep/utils/vector_utils.h
@@ -62,14 +62,6 @@ template <class V>
 concept VectorND_XYZ = Vector2D_XY<V> || Vector3D<V>;
 
 namespace utils {
-  inline double etaToAngle(const double eta) {
-    return std::atan(std::exp(-eta)) * 2.;
-  }
-
-  inline double angleToEta(const double theta) {
-    return -std::log(std::tan(0.5 * theta));
-  }
-
   // Utility getters to accomodate different vector types
   template <VectorND_XYZ V>
   constexpr auto vector_x(const V& v) {
@@ -118,6 +110,21 @@ namespace utils {
   //  return {r * sin(theta), r * cos(theta)};
   //}
 
+} // namespace utils
+
+/// A vector that uses floating point numbers to represent its members
+template <typename V>
+concept FloatVectorND = std::floating_point<utils::ValueType<V>> && (Vector2D<V> || Vector3D<V>);
+
+namespace utils {
+  inline double etaToAngle(const double eta) {
+    return std::atan(std::exp(-eta)) * 2.;
+  }
+
+  inline double angleToEta(const double theta) {
+    return -std::log(std::tan(0.5 * theta));
+  }
+
   template <Vector3D V = edm4hep::Vector3f>
   V sphericalToVector(const double r, const double theta, const double phi) {
     using FloatType = ValueType<V>;
@@ -146,12 +153,7 @@ namespace utils {
     return angleToEta(anglePolar(v));
   }
 
-  template <Vector2D V>
-  double magnitude(const V& v) {
-    return std::hypot(vector_x(v), vector_y(v));
-  }
-
-  template <Vector3D V>
+  template <VectorND V>
   double magnitude(const V& v) {
     return std::hypot(vector_x(v), vector_y(v), vector_z(v));
   }
@@ -166,7 +168,7 @@ namespace utils {
     return vector_z(v);
   }
 
-  template <VectorND V>
+  template <FloatVectorND V>
   V normalizeVector(const V& v, double norm = 1.) {
     const double old = magnitude(v);
     if (old == 0) {
@@ -196,7 +198,7 @@ namespace utils {
   }
 
   // Project v onto v1
-  template <Vector3D V>
+  template <VectorND V>
   double projection(const V& v, const V& v1) {
     const double norm = magnitude(v1);
     if (norm == 0) {

--- a/utils/include/edm4hep/utils/vector_utils.h
+++ b/utils/include/edm4hep/utils/vector_utils.h
@@ -58,23 +58,23 @@ inline double angleToEta(const double theta) {
 
 // Utility getters to accomodate different vector types
 template <VectorND_XYZ V>
-auto vector_x(const V& v) {
+constexpr auto vector_x(const V& v) {
   return v.x;
 }
 template <VectorND_XYZ V>
-auto vector_y(const V& v) {
+constexpr auto vector_y(const V& v) {
   return v.y;
 }
 template <Vector3D V>
-auto vector_z(const V& v) {
+constexpr auto vector_z(const V& v) {
   return v.z;
 }
 template <Vector2D_AB V>
-auto vector_x(const V& v) {
+constexpr auto vector_x(const V& v) {
   return v.a;
 }
 template <Vector2D_AB V>
-auto vector_y(const V& v) {
+constexpr auto vector_y(const V& v) {
   return v.b;
 }
 
@@ -132,11 +132,11 @@ V normalizeVector(const V& v, double norm = 1.) {
   return (norm > 0) ? v * norm / old : v * 0;
 }
 template <Vector3D V>
-V vectorTransverse(const V& v) {
+constexpr V vectorTransverse(const V& v) {
   return {vector_x(v), vector_y(v), 0};
 }
 template <Vector3D V>
-V vectorLongitudinal(const V& v) {
+constexpr V vectorLongitudinal(const V& v) {
   return {0, 0, vector_z(v)};
 }
 // Two vector functions
@@ -160,45 +160,45 @@ double projection(const V& v, const V& v1) {
 
 } // namespace edm4hep
 template <edm4hep::Vector2D V>
-V operator+(const V& v1, const V& v2) {
+constexpr V operator+(const V& v1, const V& v2) {
   return {edm4hep::vector_x(v1) + edm4hep::vector_x(v2), edm4hep::vector_y(v1) + edm4hep::vector_y(v2)};
 }
 template <edm4hep::Vector3D V>
-V operator+(const V& v1, const V& v2) {
+constexpr V operator+(const V& v1, const V& v2) {
   return {edm4hep::vector_x(v1) + edm4hep::vector_x(v2), edm4hep::vector_y(v1) + edm4hep::vector_y(v2),
           edm4hep::vector_z(v1) + edm4hep::vector_z(v2)};
 }
 template <edm4hep::Vector2D V>
-double operator*(const V& v1, const V& v2) {
+constexpr double operator*(const V& v1, const V& v2) {
   return edm4hep::vector_x(v1) * edm4hep::vector_x(v2) + edm4hep::vector_y(v1) * edm4hep::vector_y(v2);
 }
 template <edm4hep::Vector3D V>
-double operator*(const V& v1, const V& v2) {
+constexpr double operator*(const V& v1, const V& v2) {
   return edm4hep::vector_x(v1) * edm4hep::vector_x(v2) + edm4hep::vector_y(v1) * edm4hep::vector_y(v2) +
       edm4hep::vector_z(v1) * edm4hep::vector_z(v2);
 }
 template <edm4hep::Vector2D V>
-V operator*(const double d, const V& v) {
+constexpr V operator*(const double d, const V& v) {
   return {d * edm4hep::vector_x(v), d * edm4hep::vector_y(v)};
 }
 template <edm4hep::Vector3D V>
-V operator*(const double d, const V& v) {
+constexpr V operator*(const double d, const V& v) {
   return {d * edm4hep::vector_x(v), d * edm4hep::vector_y(v), d * edm4hep::vector_z(v)};
 }
 template <edm4hep::Vector2D V>
-V operator*(const V& v, const double d) {
+constexpr V operator*(const V& v, const double d) {
   return {d * edm4hep::vector_x(v), d * edm4hep::vector_y(v)};
 }
 template <edm4hep::Vector3D V>
-V operator*(const V& v, const double d) {
+constexpr V operator*(const V& v, const double d) {
   return {d * edm4hep::vector_x(v), d * edm4hep::vector_y(v), d * edm4hep::vector_z(v)};
 }
 template <edm4hep::VectorND V>
-V operator-(const V& v1, const V& v2) {
+constexpr V operator-(const V& v1, const V& v2) {
   return v1 + (-1. * v2);
 }
 template <edm4hep::VectorND V>
-V operator/(const V& v, const double d) {
+constexpr V operator/(const V& v, const double d) {
   return (1. / d) * v;
 }
 #endif

--- a/utils/include/edm4hep/utils/vector_utils.h
+++ b/utils/include/edm4hep/utils/vector_utils.h
@@ -120,7 +120,7 @@ namespace utils {
 
   template <Vector3D V = edm4hep::Vector3f>
   V sphericalToVector(const double r, const double theta, const double phi) {
-    using FloatType = decltype(vector_x(V()));
+    using FloatType = ValueType<V>;
     const double sth = sin(theta);
     const double cth = cos(theta);
     const double sph = sin(phi);

--- a/utils/include/edm4hep/utils/vector_utils.h
+++ b/utils/include/edm4hep/utils/vector_utils.h
@@ -4,7 +4,7 @@
 // These ultilies require concepts. If not available, use the fallback
 // vector_utils_legacy.h instead to capture most functionality.
 #if !__cpp_concepts
-#include <edm4hep/vector_utils_legacy.h>
+#include <edm4hep/utils/vector_utils_legacy.h>
 #else
 #include <cmath>
 

--- a/utils/include/edm4hep/utils/vector_utils.h
+++ b/utils/include/edm4hep/utils/vector_utils.h
@@ -16,42 +16,54 @@ template <class V>
 concept VectorHasX = requires(V v) {
   v.x;
 };
+
 template <class V>
 concept VectorHasY = requires(V v) {
   v.y;
 };
+
 template <class V>
 concept VectorHasZ = requires(V v) {
   v.z;
 };
+
 template <class V>
 concept VectorHasA = requires(V v) {
   v.a;
 };
+
 template <class V>
 concept VectorHasB = requires(V v) {
   v.b;
 };
+
 template <class V>
 concept ClassVector = requires(V v) {
   v.x();
 };
+
 template <class V>
 concept Vector2D_XY = VectorHasX<V>&& VectorHasY<V> && !VectorHasZ<V> && !ClassVector<V>;
+
 template <class V>
 concept Vector2D_AB = VectorHasA<V>&& VectorHasB<V> && !VectorHasZ<V> && !ClassVector<V>;
+
 template <class V>
 concept Vector2D = Vector2D_XY<V> || Vector2D_AB<V>;
+
 template <class V>
 concept Vector3D = VectorHasX<V>&& VectorHasY<V>&& VectorHasZ<V> && !ClassVector<V>;
+
 template <class V>
 concept VectorND = Vector2D<V> || Vector3D<V>;
+
 template <class V>
 concept VectorND_XYZ = Vector2D_XY<V> || Vector3D<V>;
 
 inline double etaToAngle(const double eta) {
   return std::atan(std::exp(-eta)) * 2.;
 }
+
 inline double angleToEta(const double theta) {
   return -std::log(std::tan(0.5 * theta));
 }
@@ -61,18 +73,22 @@ template <VectorND_XYZ V>
 constexpr auto vector_x(const V& v) {
   return v.x;
 }
+
 template <VectorND_XYZ V>
 constexpr auto vector_y(const V& v) {
   return v.y;
 }
+
 template <Vector3D V>
 constexpr auto vector_z(const V& v) {
   return v.z;
 }
+
 template <Vector2D_AB V>
 constexpr auto vector_x(const V& v) {
   return v.a;
 }
+
 template <Vector2D_AB V>
 constexpr auto vector_y(const V& v) {
   return v.b;
@@ -82,6 +98,7 @@ constexpr auto vector_y(const V& v) {
 // {
 //  return {r * sin(theta), r * cos(theta)};
 //}
+
 template <Vector3D V = edm4hep::Vector3f>
 V sphericalToVector(const double r, const double theta, const double phi) {
   using FloatType = decltype(vector_x(V()));
@@ -99,30 +116,37 @@ template <Vector3D V>
 double anglePolar(const V& v) {
   return std::atan2(std::hypot(vector_x(v), vector_y(v)), vector_z(v));
 }
+
 template <VectorND V>
 double angleAzimuthal(const V& v) {
   return std::atan2(vector_y(v), vector_x(v));
 }
+
 template <Vector3D V>
 double eta(const V& v) {
   return angleToEta(anglePolar(v));
 }
+
 template <Vector2D V>
 double magnitude(const V& v) {
   return std::hypot(vector_x(v), vector_y(v));
 }
+
 template <Vector3D V>
 double magnitude(const V& v) {
   return std::hypot(vector_x(v), vector_y(v), vector_z(v));
 }
+
 template <Vector3D V>
 double magnitudeTransverse(const V& v) {
   return std::hypot(vector_x(v), vector_y(v));
 }
+
 template <Vector3D V>
 double magnitudeLongitudinal(const V& v) {
   return vector_z(v);
 }
+
 template <VectorND V>
 V normalizeVector(const V& v, double norm = 1.) {
   const double old = magnitude(v);
@@ -131,14 +155,17 @@ V normalizeVector(const V& v, double norm = 1.) {
   }
   return (norm > 0) ? v * norm / old : v * 0;
 }
+
 template <Vector3D V>
 constexpr V vectorTransverse(const V& v) {
   return {vector_x(v), vector_y(v), 0};
 }
+
 template <Vector3D V>
 constexpr V vectorLongitudinal(const V& v) {
   return {0, 0, vector_z(v)};
 }
+
 // Two vector functions
 template <VectorND V>
 double angleBetween(const V& v1, const V& v2) {
@@ -148,6 +175,7 @@ double angleBetween(const V& v1, const V& v2) {
   }
   return acos(dot / (magnitude(v1) * magnitude(v2)));
 }
+
 // Project v onto v1
 template <Vector3D V>
 double projection(const V& v, const V& v1) {
@@ -159,47 +187,58 @@ double projection(const V& v, const V& v1) {
 }
 
 } // namespace edm4hep
+
 template <edm4hep::Vector2D V>
 constexpr V operator+(const V& v1, const V& v2) {
   return {edm4hep::vector_x(v1) + edm4hep::vector_x(v2), edm4hep::vector_y(v1) + edm4hep::vector_y(v2)};
 }
+
 template <edm4hep::Vector3D V>
 constexpr V operator+(const V& v1, const V& v2) {
   return {edm4hep::vector_x(v1) + edm4hep::vector_x(v2), edm4hep::vector_y(v1) + edm4hep::vector_y(v2),
           edm4hep::vector_z(v1) + edm4hep::vector_z(v2)};
 }
+
 template <edm4hep::Vector2D V>
 constexpr double operator*(const V& v1, const V& v2) {
   return edm4hep::vector_x(v1) * edm4hep::vector_x(v2) + edm4hep::vector_y(v1) * edm4hep::vector_y(v2);
 }
+
 template <edm4hep::Vector3D V>
 constexpr double operator*(const V& v1, const V& v2) {
   return edm4hep::vector_x(v1) * edm4hep::vector_x(v2) + edm4hep::vector_y(v1) * edm4hep::vector_y(v2) +
       edm4hep::vector_z(v1) * edm4hep::vector_z(v2);
 }
+
 template <edm4hep::Vector2D V>
 constexpr V operator*(const double d, const V& v) {
   return {d * edm4hep::vector_x(v), d * edm4hep::vector_y(v)};
 }
+
 template <edm4hep::Vector3D V>
 constexpr V operator*(const double d, const V& v) {
   return {d * edm4hep::vector_x(v), d * edm4hep::vector_y(v), d * edm4hep::vector_z(v)};
 }
+
 template <edm4hep::Vector2D V>
 constexpr V operator*(const V& v, const double d) {
   return {d * edm4hep::vector_x(v), d * edm4hep::vector_y(v)};
 }
+
 template <edm4hep::Vector3D V>
 constexpr V operator*(const V& v, const double d) {
   return {d * edm4hep::vector_x(v), d * edm4hep::vector_y(v), d * edm4hep::vector_z(v)};
 }
+
 template <edm4hep::VectorND V>
 constexpr V operator-(const V& v1, const V& v2) {
   return v1 + (-1. * v2);
 }
+
 template <edm4hep::VectorND V>
 constexpr V operator/(const V& v, const double d) {
   return (1. / d) * v;
 }
+
 #endif
 #endif

--- a/utils/include/edm4hep/utils/vector_utils.h
+++ b/utils/include/edm4hep/utils/vector_utils.h
@@ -6,9 +6,10 @@
 #if !__cpp_concepts
 #include <edm4hep/utils/vector_utils_legacy.h>
 #else
-#include <cmath>
 
 #include <edm4hep/Vector3f.h>
+
+#include <cmath>
 
 namespace edm4hep {
 
@@ -60,183 +61,208 @@ concept VectorND = Vector2D<V> || Vector3D<V>;
 template <class V>
 concept VectorND_XYZ = Vector2D_XY<V> || Vector3D<V>;
 
-inline double etaToAngle(const double eta) {
-  return std::atan(std::exp(-eta)) * 2.;
-}
-
-inline double angleToEta(const double theta) {
-  return -std::log(std::tan(0.5 * theta));
-}
-
-// Utility getters to accomodate different vector types
-template <VectorND_XYZ V>
-constexpr auto vector_x(const V& v) {
-  return v.x;
-}
-
-template <VectorND_XYZ V>
-constexpr auto vector_y(const V& v) {
-  return v.y;
-}
-
-template <Vector3D V>
-constexpr auto vector_z(const V& v) {
-  return v.z;
-}
-
-template <Vector2D_AB V>
-constexpr auto vector_x(const V& v) {
-  return v.a;
-}
-
-template <Vector2D_AB V>
-constexpr auto vector_y(const V& v) {
-  return v.b;
-}
-
-// inline edm4hep::Vector2f VectorFromPolar(const double r, const double theta)
-// {
-//  return {r * sin(theta), r * cos(theta)};
-//}
-
-template <Vector3D V = edm4hep::Vector3f>
-V sphericalToVector(const double r, const double theta, const double phi) {
-  using FloatType = decltype(vector_x(V()));
-  const double sth = sin(theta);
-  const double cth = cos(theta);
-  const double sph = sin(phi);
-  const double cph = cos(phi);
-  const FloatType x = r * sth * cph;
-  const FloatType y = r * sth * sph;
-  const FloatType z = r * cth;
-  return {x, y, z};
-}
-
-template <Vector3D V>
-double anglePolar(const V& v) {
-  return std::atan2(std::hypot(vector_x(v), vector_y(v)), vector_z(v));
-}
-
-template <VectorND V>
-double angleAzimuthal(const V& v) {
-  return std::atan2(vector_y(v), vector_x(v));
-}
-
-template <Vector3D V>
-double eta(const V& v) {
-  return angleToEta(anglePolar(v));
-}
-
-template <Vector2D V>
-double magnitude(const V& v) {
-  return std::hypot(vector_x(v), vector_y(v));
-}
-
-template <Vector3D V>
-double magnitude(const V& v) {
-  return std::hypot(vector_x(v), vector_y(v), vector_z(v));
-}
-
-template <Vector3D V>
-double magnitudeTransverse(const V& v) {
-  return std::hypot(vector_x(v), vector_y(v));
-}
-
-template <Vector3D V>
-double magnitudeLongitudinal(const V& v) {
-  return vector_z(v);
-}
-
-template <VectorND V>
-V normalizeVector(const V& v, double norm = 1.) {
-  const double old = magnitude(v);
-  if (old == 0) {
-    return v;
+namespace utils {
+  inline double etaToAngle(const double eta) {
+    return std::atan(std::exp(-eta)) * 2.;
   }
-  return (norm > 0) ? v * norm / old : v * 0;
-}
 
-template <Vector3D V>
-constexpr V vectorTransverse(const V& v) {
-  return {vector_x(v), vector_y(v), 0};
-}
-
-template <Vector3D V>
-constexpr V vectorLongitudinal(const V& v) {
-  return {0, 0, vector_z(v)};
-}
-
-// Two vector functions
-template <VectorND V>
-double angleBetween(const V& v1, const V& v2) {
-  const double dot = v1 * v2;
-  if (dot == 0) {
-    return 0.;
+  inline double angleToEta(const double theta) {
+    return -std::log(std::tan(0.5 * theta));
   }
-  return acos(dot / (magnitude(v1) * magnitude(v2)));
-}
 
-// Project v onto v1
-template <Vector3D V>
-double projection(const V& v, const V& v1) {
-  const double norm = magnitude(v1);
-  if (norm == 0) {
-    return magnitude(v);
+  // Utility getters to accomodate different vector types
+  template <VectorND_XYZ V>
+  constexpr auto vector_x(const V& v) {
+    return v.x;
   }
-  return v * v1 / norm;
-}
 
+  template <VectorND_XYZ V>
+  constexpr auto vector_y(const V& v) {
+    return v.y;
+  }
+
+  template <Vector3D V>
+  constexpr auto vector_z(const V& v) {
+    return v.z;
+  }
+
+  template <Vector2D_AB V>
+  constexpr auto vector_x(const V& v) {
+    return v.a;
+  }
+
+  template <Vector2D_AB V>
+  constexpr auto vector_y(const V& v) {
+    return v.b;
+  }
+
+  template <Vector2D V>
+  constexpr auto vector_z(const V&) {
+    return 0;
+  }
+
+  namespace detail {
+    /// Helper struct to determine the underlying type of edm4hep vector types
+    template <typename V>
+    struct ValueTypeHelper {
+      using type = decltype(vector_x(std::declval<V>()));
+    };
+  } // namespace detail
+
+  /// Type alias that returns the underlying type of edm4hep
+  template <typename V>
+  using ValueType = typename detail::ValueTypeHelper<V>::type;
+
+  // inline edm4hep::Vector2f VectorFromPolar(const double r, const double theta)
+  // {
+  //  return {r * sin(theta), r * cos(theta)};
+  //}
+
+  template <Vector3D V = edm4hep::Vector3f>
+  V sphericalToVector(const double r, const double theta, const double phi) {
+    using FloatType = decltype(vector_x(V()));
+    const double sth = sin(theta);
+    const double cth = cos(theta);
+    const double sph = sin(phi);
+    const double cph = cos(phi);
+    const FloatType x = r * sth * cph;
+    const FloatType y = r * sth * sph;
+    const FloatType z = r * cth;
+    return {x, y, z};
+  }
+
+  template <Vector3D V>
+  double anglePolar(const V& v) {
+    return std::atan2(std::hypot(vector_x(v), vector_y(v)), vector_z(v));
+  }
+
+  template <VectorND V>
+  double angleAzimuthal(const V& v) {
+    return std::atan2(vector_y(v), vector_x(v));
+  }
+
+  template <Vector3D V>
+  double eta(const V& v) {
+    return angleToEta(anglePolar(v));
+  }
+
+  template <Vector2D V>
+  double magnitude(const V& v) {
+    return std::hypot(vector_x(v), vector_y(v));
+  }
+
+  template <Vector3D V>
+  double magnitude(const V& v) {
+    return std::hypot(vector_x(v), vector_y(v), vector_z(v));
+  }
+
+  template <Vector3D V>
+  double magnitudeTransverse(const V& v) {
+    return std::hypot(vector_x(v), vector_y(v));
+  }
+
+  template <Vector3D V>
+  double magnitudeLongitudinal(const V& v) {
+    return vector_z(v);
+  }
+
+  template <VectorND V>
+  V normalizeVector(const V& v, double norm = 1.) {
+    const double old = magnitude(v);
+    if (old == 0) {
+      return v;
+    }
+    return (norm > 0) ? v * norm / old : v * 0;
+  }
+
+  template <Vector3D V>
+  constexpr V vectorTransverse(const V& v) {
+    return {vector_x(v), vector_y(v), 0};
+  }
+
+  template <Vector3D V>
+  constexpr V vectorLongitudinal(const V& v) {
+    return {0, 0, vector_z(v)};
+  }
+
+  // Two vector functions
+  template <VectorND V>
+  double angleBetween(const V& v1, const V& v2) {
+    const double dot = v1 * v2;
+    if (dot == 0) {
+      return 0.;
+    }
+    return acos(dot / (magnitude(v1) * magnitude(v2)));
+  }
+
+  // Project v onto v1
+  template <Vector3D V>
+  double projection(const V& v, const V& v1) {
+    const double norm = magnitude(v1);
+    if (norm == 0) {
+      return magnitude(v);
+    }
+    return v * v1 / norm;
+  }
+
+} // namespace utils
 } // namespace edm4hep
 
 template <edm4hep::Vector2D V>
-constexpr V operator+(const V& v1, const V& v2) {
-  return {edm4hep::vector_x(v1) + edm4hep::vector_x(v2), edm4hep::vector_y(v1) + edm4hep::vector_y(v2)};
+inline constexpr V operator+(const V& v1, const V& v2) {
+  return {edm4hep::utils::vector_x(v1) + edm4hep::utils::vector_x(v2),
+          edm4hep::utils::vector_y(v1) + edm4hep::utils::vector_y(v2)};
 }
 
 template <edm4hep::Vector3D V>
-constexpr V operator+(const V& v1, const V& v2) {
-  return {edm4hep::vector_x(v1) + edm4hep::vector_x(v2), edm4hep::vector_y(v1) + edm4hep::vector_y(v2),
-          edm4hep::vector_z(v1) + edm4hep::vector_z(v2)};
+inline constexpr V operator+(const V& v1, const V& v2) {
+  return {edm4hep::utils::vector_x(v1) + edm4hep::utils::vector_x(v2),
+          edm4hep::utils::vector_y(v1) + edm4hep::utils::vector_y(v2),
+          edm4hep::utils::vector_z(v1) + edm4hep::utils::vector_z(v2)};
 }
 
 template <edm4hep::Vector2D V>
-constexpr double operator*(const V& v1, const V& v2) {
-  return edm4hep::vector_x(v1) * edm4hep::vector_x(v2) + edm4hep::vector_y(v1) * edm4hep::vector_y(v2);
+inline constexpr auto operator*(const V& v1, const V& v2) {
+  return edm4hep::utils::vector_x(v1) * edm4hep::utils::vector_x(v2) +
+      edm4hep::utils::vector_y(v1) * edm4hep::utils::vector_y(v2);
 }
 
 template <edm4hep::Vector3D V>
-constexpr double operator*(const V& v1, const V& v2) {
-  return edm4hep::vector_x(v1) * edm4hep::vector_x(v2) + edm4hep::vector_y(v1) * edm4hep::vector_y(v2) +
-      edm4hep::vector_z(v1) * edm4hep::vector_z(v2);
+inline constexpr auto operator*(const V& v1, const V& v2) {
+  return edm4hep::utils::vector_x(v1) * edm4hep::utils::vector_x(v2) +
+      edm4hep::utils::vector_y(v1) * edm4hep::utils::vector_y(v2) +
+      edm4hep::utils::vector_z(v1) * edm4hep::utils::vector_z(v2);
 }
 
 template <edm4hep::Vector2D V>
-constexpr V operator*(const double d, const V& v) {
-  return {d * edm4hep::vector_x(v), d * edm4hep::vector_y(v)};
+inline constexpr V operator*(const double d, const V& v) {
+  using VT = edm4hep::utils::ValueType<V>;
+  const VT x = d * edm4hep::utils::vector_x(v);
+  const VT y = d * edm4hep::utils::vector_y(v);
+  return {x, y};
 }
 
 template <edm4hep::Vector3D V>
-constexpr V operator*(const double d, const V& v) {
-  return {d * edm4hep::vector_x(v), d * edm4hep::vector_y(v), d * edm4hep::vector_z(v)};
-}
-
-template <edm4hep::Vector2D V>
-constexpr V operator*(const V& v, const double d) {
-  return {d * edm4hep::vector_x(v), d * edm4hep::vector_y(v)};
-}
-
-template <edm4hep::Vector3D V>
-constexpr V operator*(const V& v, const double d) {
-  return {d * edm4hep::vector_x(v), d * edm4hep::vector_y(v), d * edm4hep::vector_z(v)};
+inline constexpr V operator*(const double d, const V& v) {
+  using VT = edm4hep::utils::ValueType<V>;
+  const VT x = d * edm4hep::utils::vector_x(v);
+  const VT y = d * edm4hep::utils::vector_y(v);
+  const VT z = d * edm4hep::utils::vector_z(v);
+  return {x, y, z};
 }
 
 template <edm4hep::VectorND V>
-constexpr V operator-(const V& v1, const V& v2) {
+inline constexpr V operator*(const V& v, const double d) {
+  return d * v;
+}
+
+template <edm4hep::VectorND V>
+inline constexpr V operator-(const V& v1, const V& v2) {
   return v1 + (-1. * v2);
 }
 
 template <edm4hep::VectorND V>
-constexpr V operator/(const V& v, const double d) {
+inline constexpr V operator/(const V& v, const double d) {
   return (1. / d) * v;
 }
 

--- a/utils/include/edm4hep/utils/vector_utils_legacy.h
+++ b/utils/include/edm4hep/utils/vector_utils_legacy.h
@@ -22,29 +22,29 @@ inline double angleToEta(const double theta) {
 
 // Utility getters to accomodate different vector types
 template <class V>
-auto vector_x(const V& v) {
+constexpr auto vector_x(const V& v) {
   return v.x;
 }
 template <class V>
-auto vector_y(const V& v) {
+constexpr auto vector_y(const V& v) {
   return v.y;
 }
 template <class V>
-auto vector_z(const V& v) {
+constexpr auto vector_z(const V& v) {
   return v.z;
 }
 // Vector2f uses a,b instead of x,y
 template <>
-inline auto vector_x<edm4hep::Vector2f>(const edm4hep::Vector2f& v) {
+inline constexpr auto vector_x<edm4hep::Vector2f>(const edm4hep::Vector2f& v) {
   return v.a;
 }
 template <>
-inline auto vector_y<edm4hep::Vector2f>(const edm4hep::Vector2f& v) {
+inline constexpr auto vector_y<edm4hep::Vector2f>(const edm4hep::Vector2f& v) {
   return v.b;
 }
 // no z-component for 2D vectors
 template <>
-inline auto vector_z<edm4hep::Vector2f>(const edm4hep::Vector2f& v) {
+inline constexpr auto vector_z<edm4hep::Vector2f>(const edm4hep::Vector2f& v) {
   return 0;
 }
 
@@ -98,11 +98,11 @@ V normalizeVector(const V& v, double norm = 1.) {
   return (norm > 0) ? v * norm / old : v * 0;
 }
 template <class V>
-V vectorTransverse(const V& v) {
+constexpr V vectorTransverse(const V& v) {
   return {edm4hep::vector_x(v), edm4hep::vector_y(v), 0};
 }
 template <class V>
-V vectorLongitudinal(const V& v) {
+constexpr V vectorLongitudinal(const V& v) {
   return {0, 0, edm4hep::vector_z(v)};
 }
 // Two vector functions
@@ -126,56 +126,57 @@ double projection(const V& v, const V& v1) {
 
 } // namespace edm4hep
 
-inline edm4hep::Vector2f operator+(const edm4hep::Vector2f& v1, const edm4hep::Vector2f& v2) {
+inline constexpr edm4hep::Vector2f operator+(const edm4hep::Vector2f& v1, const edm4hep::Vector2f& v2) {
   using ValueType = decltype(edm4hep::vector_x(edm4hep::Vector2f()));
   const ValueType x = edm4hep::vector_x(v1) + edm4hep::vector_x(v2);
   const ValueType y = edm4hep::vector_y(v1) + edm4hep::vector_y(v2);
   return {x, y};
 }
-inline edm4hep::Vector3f operator+(const edm4hep::Vector3f& v1, const edm4hep::Vector3f& v2) {
+inline constexpr edm4hep::Vector3f operator+(const edm4hep::Vector3f& v1, const edm4hep::Vector3f& v2) {
   using ValueType = decltype(edm4hep::vector_x(edm4hep::Vector3f()));
   const ValueType x = edm4hep::vector_x(v1) + edm4hep::vector_x(v2);
   const ValueType y = edm4hep::vector_y(v1) + edm4hep::vector_y(v2);
   const ValueType z = edm4hep::vector_z(v1) + edm4hep::vector_z(v2);
   return {x, y, z};
 }
-inline double operator*(const edm4hep::Vector2f& v1, const edm4hep::Vector2f& v2) {
+inline constexpr double operator*(const edm4hep::Vector2f& v1, const edm4hep::Vector2f& v2) {
   return edm4hep::vector_x(v1) * edm4hep::vector_x(v2) + edm4hep::vector_y(v1) * edm4hep::vector_y(v2);
 }
-inline double operator*(const edm4hep::Vector3f& v1, const edm4hep::Vector3f& v2) {
+inline constexpr double operator*(const edm4hep::Vector3f& v1, const edm4hep::Vector3f& v2) {
   return edm4hep::vector_x(v1) * edm4hep::vector_x(v2) + edm4hep::vector_y(v1) * edm4hep::vector_y(v2) +
       edm4hep::vector_z(v1) * edm4hep::vector_z(v2);
 }
-inline edm4hep::Vector2f operator*(const double d, const edm4hep::Vector2f& v) {
+inline constexpr edm4hep::Vector2f operator*(const double d, const edm4hep::Vector2f& v) {
   using ValueType = decltype(edm4hep::vector_x(edm4hep::Vector2f()));
   const ValueType x = d * edm4hep::vector_x(v);
   const ValueType y = d * edm4hep::vector_y(v);
   return {x, y};
 }
-inline edm4hep::Vector3f operator*(const double d, const edm4hep::Vector3f& v) {
+inline constexpr edm4hep::Vector3f operator*(const double d, const edm4hep::Vector3f& v) {
   using ValueType = decltype(edm4hep::vector_x(edm4hep::Vector3f()));
   const ValueType x = d * edm4hep::vector_x(v);
   const ValueType y = d * edm4hep::vector_y(v);
   const ValueType z = d * edm4hep::vector_z(v);
   return {x, y, z};
 }
-inline edm4hep::Vector2f operator*(const edm4hep::Vector2f& v, const double d) {
+inline constexpr edm4hep::Vector2f operator*(const edm4hep::Vector2f& v, const double d) {
   return d * v;
 }
-inline edm4hep::Vector3f operator*(const edm4hep::Vector3f& v, const double d) {
+inline constexpr edm4hep::Vector3f operator*(const edm4hep::Vector3f& v, const double d) {
   return d * v;
 }
-inline edm4hep::Vector2f operator-(const edm4hep::Vector2f& v1, const edm4hep::Vector2f& v2) {
+inline constexpr edm4hep::Vector2f operator-(const edm4hep::Vector2f& v1, const edm4hep::Vector2f& v2) {
   return v1 + (-1. * v2);
 }
-inline edm4hep::Vector3f operator-(const edm4hep::Vector3f& v1, const edm4hep::Vector3f& v2) {
+inline constexpr edm4hep::Vector3f operator-(const edm4hep::Vector3f& v1, const edm4hep::Vector3f& v2) {
   return v1 + (-1. * v2);
 }
-inline edm4hep::Vector2f operator/(const edm4hep::Vector2f& v, const double d) {
+inline constexpr edm4hep::Vector2f operator/(const edm4hep::Vector2f& v, const double d) {
   return (1. / d) * v;
 }
-inline edm4hep::Vector3f operator/(const edm4hep::Vector3f& v, const double d) {
+inline constexpr edm4hep::Vector3f operator/(const edm4hep::Vector3f& v, const double d) {
   return (1. / d) * v;
 }
+
 #endif
 #endif

--- a/utils/include/edm4hep/utils/vector_utils_legacy.h
+++ b/utils/include/edm4hep/utils/vector_utils_legacy.h
@@ -16,6 +16,7 @@ namespace edm4hep {
 inline double etaToAngle(const double eta) {
   return std::atan(std::exp(-eta)) * 2.;
 }
+
 inline double angleToEta(const double theta) {
   return -std::log(std::tan(0.5 * theta));
 }
@@ -25,23 +26,28 @@ template <class V>
 constexpr auto vector_x(const V& v) {
   return v.x;
 }
+
 template <class V>
 constexpr auto vector_y(const V& v) {
   return v.y;
 }
+
 template <class V>
 constexpr auto vector_z(const V& v) {
   return v.z;
 }
+
 // Vector2f uses a,b instead of x,y
 template <>
 inline constexpr auto vector_x<edm4hep::Vector2f>(const edm4hep::Vector2f& v) {
   return v.a;
 }
+
 template <>
 inline constexpr auto vector_y<edm4hep::Vector2f>(const edm4hep::Vector2f& v) {
   return v.b;
 }
+
 // no z-component for 2D vectors
 template <>
 inline constexpr auto vector_z<edm4hep::Vector2f>(const edm4hep::Vector2f& v) {
@@ -69,26 +75,32 @@ template <class V>
 double anglePolar(const V& v) {
   return std::atan2(std::hypot(edm4hep::vector_x(v), edm4hep::vector_y(v)), edm4hep::vector_z(v));
 }
+
 template <class V>
 double angleAzimuthal(const V& v) {
   return std::atan2(edm4hep::vector_y(v), edm4hep::vector_x(v));
 }
+
 template <class V>
 double eta(const V& v) {
   return angleToEta(anglePolar(v));
 }
+
 template <class V>
 double magnitude(const V& v) {
   return std::hypot(edm4hep::vector_x(v), edm4hep::vector_y(v), edm4hep::vector_z(v));
 }
+
 template <class V>
 double magnitudeTransverse(const V& v) {
   return std::hypot(edm4hep::vector_x(v), edm4hep::vector_y(v));
 }
+
 template <class V>
 double magnitudeLongitudinal(const V& v) {
   return edm4hep::vector_z(v);
 }
+
 template <class V>
 V normalizeVector(const V& v, double norm = 1.) {
   const double old = magnitude(v);
@@ -97,14 +109,17 @@ V normalizeVector(const V& v, double norm = 1.) {
   }
   return (norm > 0) ? v * norm / old : v * 0;
 }
+
 template <class V>
 constexpr V vectorTransverse(const V& v) {
   return {edm4hep::vector_x(v), edm4hep::vector_y(v), 0};
 }
+
 template <class V>
 constexpr V vectorLongitudinal(const V& v) {
   return {0, 0, edm4hep::vector_z(v)};
 }
+
 // Two vector functions
 template <class V>
 double angleBetween(const V& v1, const V& v2) {
@@ -114,6 +129,7 @@ double angleBetween(const V& v1, const V& v2) {
   }
   return acos(dot / (magnitude(v1) * magnitude(v2)));
 }
+
 // Project v onto v1
 template <class V>
 double projection(const V& v, const V& v1) {
@@ -132,6 +148,7 @@ inline constexpr edm4hep::Vector2f operator+(const edm4hep::Vector2f& v1, const 
   const ValueType y = edm4hep::vector_y(v1) + edm4hep::vector_y(v2);
   return {x, y};
 }
+
 inline constexpr edm4hep::Vector3f operator+(const edm4hep::Vector3f& v1, const edm4hep::Vector3f& v2) {
   using ValueType = decltype(edm4hep::vector_x(edm4hep::Vector3f()));
   const ValueType x = edm4hep::vector_x(v1) + edm4hep::vector_x(v2);
@@ -139,19 +156,23 @@ inline constexpr edm4hep::Vector3f operator+(const edm4hep::Vector3f& v1, const 
   const ValueType z = edm4hep::vector_z(v1) + edm4hep::vector_z(v2);
   return {x, y, z};
 }
+
 inline constexpr double operator*(const edm4hep::Vector2f& v1, const edm4hep::Vector2f& v2) {
   return edm4hep::vector_x(v1) * edm4hep::vector_x(v2) + edm4hep::vector_y(v1) * edm4hep::vector_y(v2);
 }
+
 inline constexpr double operator*(const edm4hep::Vector3f& v1, const edm4hep::Vector3f& v2) {
   return edm4hep::vector_x(v1) * edm4hep::vector_x(v2) + edm4hep::vector_y(v1) * edm4hep::vector_y(v2) +
       edm4hep::vector_z(v1) * edm4hep::vector_z(v2);
 }
+
 inline constexpr edm4hep::Vector2f operator*(const double d, const edm4hep::Vector2f& v) {
   using ValueType = decltype(edm4hep::vector_x(edm4hep::Vector2f()));
   const ValueType x = d * edm4hep::vector_x(v);
   const ValueType y = d * edm4hep::vector_y(v);
   return {x, y};
 }
+
 inline constexpr edm4hep::Vector3f operator*(const double d, const edm4hep::Vector3f& v) {
   using ValueType = decltype(edm4hep::vector_x(edm4hep::Vector3f()));
   const ValueType x = d * edm4hep::vector_x(v);
@@ -159,24 +180,30 @@ inline constexpr edm4hep::Vector3f operator*(const double d, const edm4hep::Vect
   const ValueType z = d * edm4hep::vector_z(v);
   return {x, y, z};
 }
+
 inline constexpr edm4hep::Vector2f operator*(const edm4hep::Vector2f& v, const double d) {
   return d * v;
 }
+
 inline constexpr edm4hep::Vector3f operator*(const edm4hep::Vector3f& v, const double d) {
   return d * v;
 }
+
 inline constexpr edm4hep::Vector2f operator-(const edm4hep::Vector2f& v1, const edm4hep::Vector2f& v2) {
   return v1 + (-1. * v2);
 }
+
 inline constexpr edm4hep::Vector3f operator-(const edm4hep::Vector3f& v1, const edm4hep::Vector3f& v2) {
   return v1 + (-1. * v2);
 }
+
 inline constexpr edm4hep::Vector2f operator/(const edm4hep::Vector2f& v, const double d) {
   return (1. / d) * v;
 }
+
 inline constexpr edm4hep::Vector3f operator/(const edm4hep::Vector3f& v, const double d) {
   return (1. / d) * v;
 }
 
 #endif
-#endif
+#endif // EDM4HEP_UTILS_VECTOR_LEGACY_HH

--- a/utils/include/edm4hep/utils/vector_utils_legacy.h
+++ b/utils/include/edm4hep/utils/vector_utils_legacy.h
@@ -100,6 +100,7 @@ namespace utils {
   using EDM4hepVectorTypes = std::tuple<edm4hep::Vector3f, edm4hep::Vector3d, edm4hep::Vector2i, edm4hep::Vector2f>;
   using EDM4hepVector3DTypes = std::tuple<edm4hep::Vector3f, edm4hep::Vector3d>;
   using EDM4hepVector2DTypes = std::tuple<edm4hep::Vector2f, edm4hep::Vector2i>;
+  using EDM4hepFloatVectorTypes = std::tuple<edm4hep::Vector2f, edm4hep::Vector3f, edm4hep::Vector3d>;
 
   template <typename V>
   using EnableIfEDM4hepVectorType = std::enable_if_t<detail::isInTuple<V, EDM4hepVectorTypes>, bool>;
@@ -109,6 +110,9 @@ namespace utils {
 
   template <typename V>
   using EnableIfEDM4hepVector3DType = std::enable_if_t<detail::isInTuple<V, EDM4hepVector3DTypes>, bool>;
+
+  template <typename V>
+  using EnableIfEDM4hepFloatVectorType = std::enable_if_t<detail::isInTuple<V, EDM4hepFloatVectorTypes>, bool>;
 
   // inline edm4hep::Vector2f VectorFromPolar(const double r, const double theta)
   // {
@@ -145,20 +149,20 @@ namespace utils {
 
   template <class V, typename = EnableIfEDM4hepVectorType<V>>
   double magnitude(const V& v) {
-    return std::hypot(vector_y(v), vector_z(v));
+    return std::hypot(vector_x(v), vector_y(v), vector_z(v));
   }
 
-  template <class V, typename = EnableIfEDM4hepVectorType<V>>
+  template <class V, typename = EnableIfEDM4hepVector3DType<V>>
   double magnitudeTransverse(const V& v) {
     return std::hypot(vector_x(v), vector_y(v));
   }
 
-  template <class V, typename = EnableIfEDM4hepVectorType<V>>
+  template <class V, typename = EnableIfEDM4hepVector3DType<V>>
   double magnitudeLongitudinal(const V& v) {
     return vector_z(v);
   }
 
-  template <class V, typename = EnableIfEDM4hepVectorType<V>>
+  template <class V, typename = EnableIfEDM4hepFloatVectorType<V>>
   V normalizeVector(const V& v, double norm = 1.) {
     const double old = magnitude(v);
     if (old == 0) {
@@ -167,12 +171,12 @@ namespace utils {
     return (norm > 0) ? v * norm / old : v * 0;
   }
 
-  template <class V, typename = EnableIfEDM4hepVectorType<V>>
+  template <class V, typename = EnableIfEDM4hepVector3DType<V>>
   constexpr V vectorTransverse(const V& v) {
     return {vector_x(v), vector_y(v), 0};
   }
 
-  template <class V, typename = EnableIfEDM4hepVectorType<V>>
+  template <class V, typename = EnableIfEDM4hepVector3DType<V>>
   constexpr V vectorLongitudinal(const V& v) {
     return {0, 0, vector_z(v)};
   }
@@ -196,8 +200,8 @@ namespace utils {
     }
     return v * v1 / norm;
   }
-} // namespace utils
 
+} // namespace utils
 } // namespace edm4hep
 
 template <typename V, edm4hep::utils::EnableIfEDM4hepVector2DType<V> = false>

--- a/utils/include/edm4hep/utils/vector_utils_legacy.h
+++ b/utils/include/edm4hep/utils/vector_utils_legacy.h
@@ -202,7 +202,6 @@ namespace utils {
   }
 
 } // namespace utils
-} // namespace edm4hep
 
 template <typename V, edm4hep::utils::EnableIfEDM4hepVector2DType<V> = false>
 inline constexpr V operator+(const V& v1, const V& v2) {
@@ -263,6 +262,8 @@ template <typename V>
 inline constexpr V operator/(const V& v, const double d) {
   return (1. / d) * v;
 }
+
+} // namespace edm4hep
 
 #endif
 #endif // EDM4HEP_UTILS_VECTOR_LEGACY_HH

--- a/utils/include/edm4hep/utils/vector_utils_legacy.h
+++ b/utils/include/edm4hep/utils/vector_utils_legacy.h
@@ -6,202 +6,257 @@
 #if __cpp_concepts
 #include <edm4hep/utils/vector_utils.h>
 #else
-#include <cmath>
 
 #include <edm4hep/Vector2f.h>
+#include <edm4hep/Vector2i.h>
+#include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
+
+#include <cmath>
+#include <tuple>
+#include <type_traits>
 
 namespace edm4hep {
 
-inline double etaToAngle(const double eta) {
-  return std::atan(std::exp(-eta)) * 2.;
-}
+namespace utils {
 
-inline double angleToEta(const double theta) {
-  return -std::log(std::tan(0.5 * theta));
-}
-
-// Utility getters to accomodate different vector types
-template <class V>
-constexpr auto vector_x(const V& v) {
-  return v.x;
-}
-
-template <class V>
-constexpr auto vector_y(const V& v) {
-  return v.y;
-}
-
-template <class V>
-constexpr auto vector_z(const V& v) {
-  return v.z;
-}
-
-// Vector2f uses a,b instead of x,y
-template <>
-inline constexpr auto vector_x<edm4hep::Vector2f>(const edm4hep::Vector2f& v) {
-  return v.a;
-}
-
-template <>
-inline constexpr auto vector_y<edm4hep::Vector2f>(const edm4hep::Vector2f& v) {
-  return v.b;
-}
-
-// no z-component for 2D vectors
-template <>
-inline constexpr auto vector_z<edm4hep::Vector2f>(const edm4hep::Vector2f& v) {
-  return 0;
-}
-
-// inline edm4hep::Vector2f VectorFromPolar(const double r, const double theta)
-// {
-//  return {r * sin(theta), r * cos(theta)};
-//}
-template <class V = edm4hep::Vector3f>
-V sphericalToVector(const double r, const double theta, const double phi) {
-  using FloatType = decltype(edm4hep::vector_x(V()));
-  const double sth = sin(theta);
-  const double cth = cos(theta);
-  const double sph = sin(phi);
-  const double cph = cos(phi);
-  const FloatType x = r * sth * cph;
-  const FloatType y = r * sth * sph;
-  const FloatType z = r * cth;
-  return {x, y, z};
-}
-
-template <class V>
-double anglePolar(const V& v) {
-  return std::atan2(std::hypot(edm4hep::vector_x(v), edm4hep::vector_y(v)), edm4hep::vector_z(v));
-}
-
-template <class V>
-double angleAzimuthal(const V& v) {
-  return std::atan2(edm4hep::vector_y(v), edm4hep::vector_x(v));
-}
-
-template <class V>
-double eta(const V& v) {
-  return angleToEta(anglePolar(v));
-}
-
-template <class V>
-double magnitude(const V& v) {
-  return std::hypot(edm4hep::vector_x(v), edm4hep::vector_y(v), edm4hep::vector_z(v));
-}
-
-template <class V>
-double magnitudeTransverse(const V& v) {
-  return std::hypot(edm4hep::vector_x(v), edm4hep::vector_y(v));
-}
-
-template <class V>
-double magnitudeLongitudinal(const V& v) {
-  return edm4hep::vector_z(v);
-}
-
-template <class V>
-V normalizeVector(const V& v, double norm = 1.) {
-  const double old = magnitude(v);
-  if (old == 0) {
-    return v;
+  inline double etaToAngle(const double eta) {
+    return std::atan(std::exp(-eta)) * 2.;
   }
-  return (norm > 0) ? v * norm / old : v * 0;
-}
 
-template <class V>
-constexpr V vectorTransverse(const V& v) {
-  return {edm4hep::vector_x(v), edm4hep::vector_y(v), 0};
-}
-
-template <class V>
-constexpr V vectorLongitudinal(const V& v) {
-  return {0, 0, edm4hep::vector_z(v)};
-}
-
-// Two vector functions
-template <class V>
-double angleBetween(const V& v1, const V& v2) {
-  const double dot = v1 * v2;
-  if (dot == 0) {
-    return 0.;
+  inline double angleToEta(const double theta) {
+    return -std::log(std::tan(0.5 * theta));
   }
-  return acos(dot / (magnitude(v1) * magnitude(v2)));
-}
 
-// Project v onto v1
-template <class V>
-double projection(const V& v, const V& v1) {
-  const double norm = magnitude(v1);
-  if (norm == 0) {
-    return magnitude(v);
+  // Utility getters to accomodate different vector types
+  template <class V>
+  constexpr auto vector_x(const V& v) {
+    return v.x;
   }
-  return v * v1 / norm;
-}
+
+  template <class V>
+  constexpr auto vector_y(const V& v) {
+    return v.y;
+  }
+
+  template <class V>
+  constexpr auto vector_z(const V& v) {
+    return v.z;
+  }
+
+  // 2D vector uses a,b instead of x,y
+  template <>
+  inline constexpr auto vector_x<edm4hep::Vector2i>(const edm4hep::Vector2i& v) {
+    return v.a;
+  }
+
+  template <>
+  inline constexpr auto vector_y<edm4hep::Vector2i>(const edm4hep::Vector2i& v) {
+    return v.b;
+  }
+
+  template <>
+  inline constexpr auto vector_x<edm4hep::Vector2f>(const edm4hep::Vector2f& v) {
+    return v.a;
+  }
+
+  template <>
+  inline constexpr auto vector_y<edm4hep::Vector2f>(const edm4hep::Vector2f& v) {
+    return v.b;
+  }
+  // no z-component for 2D vectors
+  template <>
+  inline constexpr auto vector_z<edm4hep::Vector2f>(const edm4hep::Vector2f& v) {
+    return 0;
+  }
+
+  template <>
+  inline constexpr auto vector_z<edm4hep::Vector2i>(const edm4hep::Vector2i& v) {
+    return 0;
+  }
+
+  namespace detail {
+    /// Helper struct to determine the underlying type of edm4hep vector types
+    template <typename V>
+    struct ValueTypeHelper {
+      using type = decltype(vector_x(std::declval<V>()));
+    };
+
+    /// Helper struct to determine whether a type is in a tuple of other types
+    template <typename T, typename>
+    struct TypeInTupleHelper : std::false_type {};
+
+    template <typename T, typename... Ts>
+    struct TypeInTupleHelper<T, std::tuple<Ts...>> : std::bool_constant<(std::is_same_v<T, Ts> || ...)> {};
+
+    template <typename T, typename Tuple>
+    constexpr static bool isInTuple = TypeInTupleHelper<T, Tuple>::value;
+  } // namespace detail
+
+  /// Type alias that returns the underlying type of edm4hep
+  template <typename V>
+  using ValueType = typename detail::ValueTypeHelper<V>::type;
+
+  using EDM4hepVectorTypes = std::tuple<edm4hep::Vector3f, edm4hep::Vector3d, edm4hep::Vector2i, edm4hep::Vector2f>;
+  using EDM4hepVector3DTypes = std::tuple<edm4hep::Vector3f, edm4hep::Vector3d>;
+  using EDM4hepVector2DTypes = std::tuple<edm4hep::Vector2f, edm4hep::Vector2i>;
+
+  template <typename V>
+  using EnableIfEDM4hepVectorType = std::enable_if_t<detail::isInTuple<V, EDM4hepVectorTypes>, bool>;
+
+  template <typename V>
+  using EnableIfEDM4hepVector2DType = std::enable_if_t<detail::isInTuple<V, EDM4hepVector2DTypes>, bool>;
+
+  template <typename V>
+  using EnableIfEDM4hepVector3DType = std::enable_if_t<detail::isInTuple<V, EDM4hepVector3DTypes>, bool>;
+
+  // inline edm4hep::Vector2f VectorFromPolar(const double r, const double theta)
+  // {
+  //  return {r * sin(theta), r * cos(theta)};
+  //}
+
+  template <class V = edm4hep::Vector3f, typename = EnableIfEDM4hepVector3DType<V>>
+  V sphericalToVector(const double r, const double theta, const double phi) {
+    using FloatType = ValueType<V>;
+    const double sth = sin(theta);
+    const double cth = cos(theta);
+    const double sph = sin(phi);
+    const double cph = cos(phi);
+    const FloatType x = r * sth * cph;
+    const FloatType y = r * sth * sph;
+    const FloatType z = r * cth;
+    return {x, y, z};
+  }
+
+  template <class V, typename = EnableIfEDM4hepVectorType<V>>
+  double anglePolar(const V& v) {
+    return std::atan2(std::hypot(vector_x(v), vector_y(v)), vector_z(v));
+  }
+
+  template <class V, typename = EnableIfEDM4hepVectorType<V>>
+  double angleAzimuthal(const V& v) {
+    return std::atan2(vector_y(v), vector_x(v));
+  }
+
+  template <class V, typename = EnableIfEDM4hepVectorType<V>>
+  double eta(const V& v) {
+    return angleToEta(anglePolar(v));
+  }
+
+  template <class V, typename = EnableIfEDM4hepVectorType<V>>
+  double magnitude(const V& v) {
+    return std::hypot(vector_y(v), vector_z(v));
+  }
+
+  template <class V, typename = EnableIfEDM4hepVectorType<V>>
+  double magnitudeTransverse(const V& v) {
+    return std::hypot(vector_x(v), vector_y(v));
+  }
+
+  template <class V, typename = EnableIfEDM4hepVectorType<V>>
+  double magnitudeLongitudinal(const V& v) {
+    return vector_z(v);
+  }
+
+  template <class V, typename = EnableIfEDM4hepVectorType<V>>
+  V normalizeVector(const V& v, double norm = 1.) {
+    const double old = magnitude(v);
+    if (old == 0) {
+      return v;
+    }
+    return (norm > 0) ? v * norm / old : v * 0;
+  }
+
+  template <class V, typename = EnableIfEDM4hepVectorType<V>>
+  constexpr V vectorTransverse(const V& v) {
+    return {vector_x(v), vector_y(v), 0};
+  }
+
+  template <class V, typename = EnableIfEDM4hepVectorType<V>>
+  constexpr V vectorLongitudinal(const V& v) {
+    return {0, 0, vector_z(v)};
+  }
+
+  // Two vector functions
+  template <class V, typename = EnableIfEDM4hepVectorType<V>>
+  double angleBetween(const V& v1, const V& v2) {
+    const double dot = v1 * v2;
+    if (dot == 0) {
+      return 0.;
+    }
+    return acos(dot / (magnitude(v1) * magnitude(v2)));
+  }
+
+  // Project v onto v1
+  template <class V, typename = EnableIfEDM4hepVectorType<V>>
+  double projection(const V& v, const V& v1) {
+    const double norm = magnitude(v1);
+    if (norm == 0) {
+      return magnitude(v);
+    }
+    return v * v1 / norm;
+  }
+} // namespace utils
 
 } // namespace edm4hep
 
-inline constexpr edm4hep::Vector2f operator+(const edm4hep::Vector2f& v1, const edm4hep::Vector2f& v2) {
-  using ValueType = decltype(edm4hep::vector_x(edm4hep::Vector2f()));
-  const ValueType x = edm4hep::vector_x(v1) + edm4hep::vector_x(v2);
-  const ValueType y = edm4hep::vector_y(v1) + edm4hep::vector_y(v2);
+template <typename V, edm4hep::utils::EnableIfEDM4hepVector2DType<V> = false>
+inline constexpr V operator+(const V& v1, const V& v2) {
+  const auto x = edm4hep::utils::vector_x(v1) + edm4hep::utils::vector_x(v2);
+  const auto y = edm4hep::utils::vector_y(v1) + edm4hep::utils::vector_y(v2);
   return {x, y};
 }
 
-inline constexpr edm4hep::Vector3f operator+(const edm4hep::Vector3f& v1, const edm4hep::Vector3f& v2) {
-  using ValueType = decltype(edm4hep::vector_x(edm4hep::Vector3f()));
-  const ValueType x = edm4hep::vector_x(v1) + edm4hep::vector_x(v2);
-  const ValueType y = edm4hep::vector_y(v1) + edm4hep::vector_y(v2);
-  const ValueType z = edm4hep::vector_z(v1) + edm4hep::vector_z(v2);
+template <typename V, edm4hep::utils::EnableIfEDM4hepVector3DType<V> = false>
+inline constexpr V operator+(const V& v1, const V& v2) {
+  const auto x = edm4hep::utils::vector_x(v1) + edm4hep::utils::vector_x(v2);
+  const auto y = edm4hep::utils::vector_y(v1) + edm4hep::utils::vector_y(v2);
+  const auto z = edm4hep::utils::vector_z(v1) + edm4hep::utils::vector_z(v2);
   return {x, y, z};
 }
 
-inline constexpr double operator*(const edm4hep::Vector2f& v1, const edm4hep::Vector2f& v2) {
-  return edm4hep::vector_x(v1) * edm4hep::vector_x(v2) + edm4hep::vector_y(v1) * edm4hep::vector_y(v2);
+template <typename V, edm4hep::utils::EnableIfEDM4hepVector2DType<V> = false>
+inline constexpr double operator*(const V& v1, const V& v2) {
+  return edm4hep::utils::vector_x(v1) * edm4hep::utils::vector_x(v2) +
+      edm4hep::utils::vector_y(v1) * edm4hep::utils::vector_y(v2);
 }
 
-inline constexpr double operator*(const edm4hep::Vector3f& v1, const edm4hep::Vector3f& v2) {
-  return edm4hep::vector_x(v1) * edm4hep::vector_x(v2) + edm4hep::vector_y(v1) * edm4hep::vector_y(v2) +
-      edm4hep::vector_z(v1) * edm4hep::vector_z(v2);
+template <typename V, edm4hep::utils::EnableIfEDM4hepVector3DType<V> = false>
+inline constexpr double operator*(const V& v1, const V& v2) {
+  return edm4hep::utils::vector_x(v1) * edm4hep::utils::vector_x(v2) +
+      edm4hep::utils::vector_y(v1) * edm4hep::utils::vector_y(v2) +
+      edm4hep::utils::vector_z(v1) * edm4hep::utils::vector_z(v2);
 }
 
-inline constexpr edm4hep::Vector2f operator*(const double d, const edm4hep::Vector2f& v) {
-  using ValueType = decltype(edm4hep::vector_x(edm4hep::Vector2f()));
-  const ValueType x = d * edm4hep::vector_x(v);
-  const ValueType y = d * edm4hep::vector_y(v);
+template <typename V, edm4hep::utils::EnableIfEDM4hepVector2DType<V> = false>
+inline constexpr V operator*(const double d, const V& v) {
+  using VT = edm4hep::utils::ValueType<V>;
+  const VT x = d * edm4hep::utils::vector_x(v);
+  const VT y = d * edm4hep::utils::vector_y(v);
   return {x, y};
 }
 
-inline constexpr edm4hep::Vector3f operator*(const double d, const edm4hep::Vector3f& v) {
-  using ValueType = decltype(edm4hep::vector_x(edm4hep::Vector3f()));
-  const ValueType x = d * edm4hep::vector_x(v);
-  const ValueType y = d * edm4hep::vector_y(v);
-  const ValueType z = d * edm4hep::vector_z(v);
+template <typename V, edm4hep::utils::EnableIfEDM4hepVector3DType<V> = false>
+inline constexpr V operator*(const double d, const V& v) {
+  using VT = edm4hep::utils::ValueType<V>;
+  const VT x = d * edm4hep::utils::vector_x(v);
+  const VT y = d * edm4hep::utils::vector_y(v);
+  const VT z = d * edm4hep::utils::vector_z(v);
   return {x, y, z};
 }
 
-inline constexpr edm4hep::Vector2f operator*(const edm4hep::Vector2f& v, const double d) {
+template <typename V>
+inline constexpr V operator*(const V& v, const double d) {
   return d * v;
 }
 
-inline constexpr edm4hep::Vector3f operator*(const edm4hep::Vector3f& v, const double d) {
-  return d * v;
-}
-
-inline constexpr edm4hep::Vector2f operator-(const edm4hep::Vector2f& v1, const edm4hep::Vector2f& v2) {
+template <typename V>
+inline constexpr V operator-(const V& v1, const V& v2) {
   return v1 + (-1. * v2);
 }
 
-inline constexpr edm4hep::Vector3f operator-(const edm4hep::Vector3f& v1, const edm4hep::Vector3f& v2) {
-  return v1 + (-1. * v2);
-}
-
-inline constexpr edm4hep::Vector2f operator/(const edm4hep::Vector2f& v, const double d) {
-  return (1. / d) * v;
-}
-
-inline constexpr edm4hep::Vector3f operator/(const edm4hep::Vector3f& v, const double d) {
+template <typename V>
+inline constexpr V operator/(const V& v, const double d) {
   return (1. / d) * v;
 }
 

--- a/utils/include/edm4hep/utils/vector_utils_legacy.h
+++ b/utils/include/edm4hep/utils/vector_utils_legacy.h
@@ -21,9 +21,18 @@ inline double angleToEta(const double theta) {
 }
 
 // Utility getters to accomodate different vector types
-template <class V> auto vector_x(const V& v) { return v.x; }
-template <class V> auto vector_y(const V& v) { return v.y; }
-template <class V> auto vector_z(const V& v) { return v.z; }
+template <class V>
+auto vector_x(const V& v) {
+  return v.x;
+}
+template <class V>
+auto vector_y(const V& v) {
+  return v.y;
+}
+template <class V>
+auto vector_z(const V& v) {
+  return v.z;
+}
 // Vector2f uses a,b instead of x,y
 template <>
 inline auto vector_x<edm4hep::Vector2f>(const edm4hep::Vector2f& v) {
@@ -56,38 +65,49 @@ V sphericalToVector(const double r, const double theta, const double phi) {
   return {x, y, z};
 }
 
-template <class V> double anglePolar(const V& v) {
-  return std::atan2(std::hypot(edm4hep::vector_x(v), edm4hep::vector_y(v)),
-                    edm4hep::vector_z(v));
+template <class V>
+double anglePolar(const V& v) {
+  return std::atan2(std::hypot(edm4hep::vector_x(v), edm4hep::vector_y(v)), edm4hep::vector_z(v));
 }
-template <class V> double angleAzimuthal(const V& v) {
+template <class V>
+double angleAzimuthal(const V& v) {
   return std::atan2(edm4hep::vector_y(v), edm4hep::vector_x(v));
 }
-template <class V> double eta(const V& v) { return angleToEta(anglePolar(v)); }
-template <class V> double magnitude(const V& v) {
+template <class V>
+double eta(const V& v) {
+  return angleToEta(anglePolar(v));
+}
+template <class V>
+double magnitude(const V& v) {
   return std::hypot(edm4hep::vector_x(v), edm4hep::vector_y(v), edm4hep::vector_z(v));
 }
-template <class V> double magnitudeTransverse(const V& v) {
+template <class V>
+double magnitudeTransverse(const V& v) {
   return std::hypot(edm4hep::vector_x(v), edm4hep::vector_y(v));
 }
-template <class V> double magnitudeLongitudinal(const V& v) {
+template <class V>
+double magnitudeLongitudinal(const V& v) {
   return edm4hep::vector_z(v);
 }
-template <class V> V normalizeVector(const V& v, double norm = 1.) {
+template <class V>
+V normalizeVector(const V& v, double norm = 1.) {
   const double old = magnitude(v);
   if (old == 0) {
     return v;
   }
   return (norm > 0) ? v * norm / old : v * 0;
 }
-template <class V> V vectorTransverse(const V& v) {
+template <class V>
+V vectorTransverse(const V& v) {
   return {edm4hep::vector_x(v), edm4hep::vector_y(v), 0};
 }
-template <class V> V vectorLongitudinal(const V& v) {
+template <class V>
+V vectorLongitudinal(const V& v) {
   return {0, 0, edm4hep::vector_z(v)};
 }
 // Two vector functions
-template <class V> double angleBetween(const V& v1, const V& v2) {
+template <class V>
+double angleBetween(const V& v1, const V& v2) {
   const double dot = v1 * v2;
   if (dot == 0) {
     return 0.;
@@ -95,7 +115,8 @@ template <class V> double angleBetween(const V& v1, const V& v2) {
   return acos(dot / (magnitude(v1) * magnitude(v2)));
 }
 // Project v onto v1
-template <class V> double projection(const V& v, const V& v1) {
+template <class V>
+double projection(const V& v, const V& v1) {
   const double norm = magnitude(v1);
   if (norm == 0) {
     return magnitude(v);
@@ -105,15 +126,13 @@ template <class V> double projection(const V& v, const V& v1) {
 
 } // namespace edm4hep
 
-inline edm4hep::Vector2f operator+(const edm4hep::Vector2f& v1,
-                                   const edm4hep::Vector2f& v2) {
+inline edm4hep::Vector2f operator+(const edm4hep::Vector2f& v1, const edm4hep::Vector2f& v2) {
   using ValueType = decltype(edm4hep::vector_x(edm4hep::Vector2f()));
   const ValueType x = edm4hep::vector_x(v1) + edm4hep::vector_x(v2);
   const ValueType y = edm4hep::vector_y(v1) + edm4hep::vector_y(v2);
   return {x, y};
 }
-inline edm4hep::Vector3f operator+(const edm4hep::Vector3f& v1,
-                                   const edm4hep::Vector3f& v2) {
+inline edm4hep::Vector3f operator+(const edm4hep::Vector3f& v1, const edm4hep::Vector3f& v2) {
   using ValueType = decltype(edm4hep::vector_x(edm4hep::Vector3f()));
   const ValueType x = edm4hep::vector_x(v1) + edm4hep::vector_x(v2);
   const ValueType y = edm4hep::vector_y(v1) + edm4hep::vector_y(v2);
@@ -121,13 +140,11 @@ inline edm4hep::Vector3f operator+(const edm4hep::Vector3f& v1,
   return {x, y, z};
 }
 inline double operator*(const edm4hep::Vector2f& v1, const edm4hep::Vector2f& v2) {
-  return edm4hep::vector_x(v1) * edm4hep::vector_x(v2) +
-         edm4hep::vector_y(v1) * edm4hep::vector_y(v2);
+  return edm4hep::vector_x(v1) * edm4hep::vector_x(v2) + edm4hep::vector_y(v1) * edm4hep::vector_y(v2);
 }
 inline double operator*(const edm4hep::Vector3f& v1, const edm4hep::Vector3f& v2) {
-  return edm4hep::vector_x(v1) * edm4hep::vector_x(v2) +
-         edm4hep::vector_y(v1) * edm4hep::vector_y(v2) +
-         edm4hep::vector_z(v1) * edm4hep::vector_z(v2);
+  return edm4hep::vector_x(v1) * edm4hep::vector_x(v2) + edm4hep::vector_y(v1) * edm4hep::vector_y(v2) +
+      edm4hep::vector_z(v1) * edm4hep::vector_z(v2);
 }
 inline edm4hep::Vector2f operator*(const double d, const edm4hep::Vector2f& v) {
   using ValueType = decltype(edm4hep::vector_x(edm4hep::Vector2f()));
@@ -148,12 +165,10 @@ inline edm4hep::Vector2f operator*(const edm4hep::Vector2f& v, const double d) {
 inline edm4hep::Vector3f operator*(const edm4hep::Vector3f& v, const double d) {
   return d * v;
 }
-inline edm4hep::Vector2f operator-(const edm4hep::Vector2f& v1,
-                                   const edm4hep::Vector2f& v2) {
+inline edm4hep::Vector2f operator-(const edm4hep::Vector2f& v1, const edm4hep::Vector2f& v2) {
   return v1 + (-1. * v2);
 }
-inline edm4hep::Vector3f operator-(const edm4hep::Vector3f& v1,
-                                   const edm4hep::Vector3f& v2) {
+inline edm4hep::Vector3f operator-(const edm4hep::Vector3f& v1, const edm4hep::Vector3f& v2) {
   return v1 + (-1. * v2);
 }
 inline edm4hep::Vector2f operator/(const edm4hep::Vector2f& v, const double d) {

--- a/utils/include/edm4hep/utils/vector_utils_legacy.h
+++ b/utils/include/edm4hep/utils/vector_utils_legacy.h
@@ -1,0 +1,166 @@
+#ifndef EDM4HEP_UTILS_VECTOR_LEGACY_HH
+#define EDM4HEP_UTILS_VECTOR_LEGACY_HH
+
+// This is the legacy implementation of vector_utils. If possible, use
+// the better vector_utils.h instead (if concepts are available).
+#if __cpp_concepts
+#include <edm4hep/vector_utils.h>
+#else
+#include <cmath>
+
+#include <edm4hep/Vector2f.h>
+#include <edm4hep/Vector3f.h>
+
+namespace edm4hep {
+
+inline double etaToAngle(const double eta) {
+  return std::atan(std::exp(-eta)) * 2.;
+}
+inline double angleToEta(const double theta) {
+  return -std::log(std::tan(0.5 * theta));
+}
+
+// Utility getters to accomodate different vector types
+template <class V> auto vector_x(const V& v) { return v.x; }
+template <class V> auto vector_y(const V& v) { return v.y; }
+template <class V> auto vector_z(const V& v) { return v.z; }
+// Vector2f uses a,b instead of x,y
+template <>
+inline auto vector_x<edm4hep::Vector2f>(const edm4hep::Vector2f& v) {
+  return v.a;
+}
+template <>
+inline auto vector_y<edm4hep::Vector2f>(const edm4hep::Vector2f& v) {
+  return v.b;
+}
+// no z-component for 2D vectors
+template <>
+inline auto vector_z<edm4hep::Vector2f>(const edm4hep::Vector2f& v) {
+  return 0;
+}
+
+// inline edm4hep::Vector2f VectorFromPolar(const double r, const double theta)
+// {
+//  return {r * sin(theta), r * cos(theta)};
+//}
+template <class V = edm4hep::Vector3f>
+V sphericalToVector(const double r, const double theta, const double phi) {
+  using FloatType = decltype(edm4hep::vector_x(V()));
+  const double sth = sin(theta);
+  const double cth = cos(theta);
+  const double sph = sin(phi);
+  const double cph = cos(phi);
+  const FloatType x = r * sth * cph;
+  const FloatType y = r * sth * sph;
+  const FloatType z = r * cth;
+  return {x, y, z};
+}
+
+template <class V> double anglePolar(const V& v) {
+  return std::atan2(std::hypot(edm4hep::vector_x(v), edm4hep::vector_y(v)),
+                    edm4hep::vector_z(v));
+}
+template <class V> double angleAzimuthal(const V& v) {
+  return std::atan2(edm4hep::vector_y(v), edm4hep::vector_x(v));
+}
+template <class V> double eta(const V& v) { return angleToEta(anglePolar(v)); }
+template <class V> double magnitude(const V& v) {
+  return std::hypot(edm4hep::vector_x(v), edm4hep::vector_y(v), edm4hep::vector_z(v));
+}
+template <class V> double magnitudeTransverse(const V& v) {
+  return std::hypot(edm4hep::vector_x(v), edm4hep::vector_y(v));
+}
+template <class V> double magnitudeLongitudinal(const V& v) {
+  return edm4hep::vector_z(v);
+}
+template <class V> V normalizeVector(const V& v, double norm = 1.) {
+  const double old = magnitude(v);
+  if (old == 0) {
+    return v;
+  }
+  return (norm > 0) ? v * norm / old : v * 0;
+}
+template <class V> V vectorTransverse(const V& v) {
+  return {edm4hep::vector_x(v), edm4hep::vector_y(v), 0};
+}
+template <class V> V vectorLongitudinal(const V& v) {
+  return {0, 0, edm4hep::vector_z(v)};
+}
+// Two vector functions
+template <class V> double angleBetween(const V& v1, const V& v2) {
+  const double dot = v1 * v2;
+  if (dot == 0) {
+    return 0.;
+  }
+  return acos(dot / (magnitude(v1) * magnitude(v2)));
+}
+// Project v onto v1
+template <class V> double projection(const V& v, const V& v1) {
+  const double norm = magnitude(v1);
+  if (norm == 0) {
+    return magnitude(v);
+  }
+  return v * v1 / norm;
+}
+
+} // namespace edm4hep
+
+inline edm4hep::Vector2f operator+(const edm4hep::Vector2f& v1,
+                                   const edm4hep::Vector2f& v2) {
+  using ValueType = decltype(edm4hep::vector_x(edm4hep::Vector2f()));
+  const ValueType x = edm4hep::vector_x(v1) + edm4hep::vector_x(v2);
+  const ValueType y = edm4hep::vector_y(v1) + edm4hep::vector_y(v2);
+  return {x, y};
+}
+inline edm4hep::Vector3f operator+(const edm4hep::Vector3f& v1,
+                                   const edm4hep::Vector3f& v2) {
+  using ValueType = decltype(edm4hep::vector_x(edm4hep::Vector3f()));
+  const ValueType x = edm4hep::vector_x(v1) + edm4hep::vector_x(v2);
+  const ValueType y = edm4hep::vector_y(v1) + edm4hep::vector_y(v2);
+  const ValueType z = edm4hep::vector_z(v1) + edm4hep::vector_z(v2);
+  return {x, y, z};
+}
+inline double operator*(const edm4hep::Vector2f& v1, const edm4hep::Vector2f& v2) {
+  return edm4hep::vector_x(v1) * edm4hep::vector_x(v2) +
+         edm4hep::vector_y(v1) * edm4hep::vector_y(v2);
+}
+inline double operator*(const edm4hep::Vector3f& v1, const edm4hep::Vector3f& v2) {
+  return edm4hep::vector_x(v1) * edm4hep::vector_x(v2) +
+         edm4hep::vector_y(v1) * edm4hep::vector_y(v2) +
+         edm4hep::vector_z(v1) * edm4hep::vector_z(v2);
+}
+inline edm4hep::Vector2f operator*(const double d, const edm4hep::Vector2f& v) {
+  using ValueType = decltype(edm4hep::vector_x(edm4hep::Vector2f()));
+  const ValueType x = d * edm4hep::vector_x(v);
+  const ValueType y = d * edm4hep::vector_y(v);
+  return {x, y};
+}
+inline edm4hep::Vector3f operator*(const double d, const edm4hep::Vector3f& v) {
+  using ValueType = decltype(edm4hep::vector_x(edm4hep::Vector3f()));
+  const ValueType x = d * edm4hep::vector_x(v);
+  const ValueType y = d * edm4hep::vector_y(v);
+  const ValueType z = d * edm4hep::vector_z(v);
+  return {x, y, z};
+}
+inline edm4hep::Vector2f operator*(const edm4hep::Vector2f& v, const double d) {
+  return d * v;
+}
+inline edm4hep::Vector3f operator*(const edm4hep::Vector3f& v, const double d) {
+  return d * v;
+}
+inline edm4hep::Vector2f operator-(const edm4hep::Vector2f& v1,
+                                   const edm4hep::Vector2f& v2) {
+  return v1 + (-1. * v2);
+}
+inline edm4hep::Vector3f operator-(const edm4hep::Vector3f& v1,
+                                   const edm4hep::Vector3f& v2) {
+  return v1 + (-1. * v2);
+}
+inline edm4hep::Vector2f operator/(const edm4hep::Vector2f& v, const double d) {
+  return (1. / d) * v;
+}
+inline edm4hep::Vector3f operator/(const edm4hep::Vector3f& v, const double d) {
+  return (1. / d) * v;
+}
+#endif
+#endif

--- a/utils/include/edm4hep/utils/vector_utils_legacy.h
+++ b/utils/include/edm4hep/utils/vector_utils_legacy.h
@@ -4,7 +4,7 @@
 // This is the legacy implementation of vector_utils. If possible, use
 // the better vector_utils.h instead (if concepts are available).
 #if __cpp_concepts
-#include <edm4hep/vector_utils.h>
+#include <edm4hep/utils/vector_utils.h>
 #else
 #include <cmath>
 


### PR DESCRIPTION
As discussed in https://github.com/key4hep/EDM4hep/issues/144, these are some utility classes on vectors to ensure common operations are available. The utils with concepts are more maintainable, but a legacy version is attached too.

Credit to @sly2j

BEGINRELEASENOTES
- Add utilities to work with `Vector` component classes including
  - (`constexpr`) `operator` overloads for basic arithmetic with vectors
  - utility functionality that is commonly used with vectors
  - concepts to work with in generic vector related code.
- Include `edm4hep/utils/vector_utils.h` and work with functionality in `edm4hep::utils` namespace
  - This include will automatically use the concept powered version if supported by the compiler and fall back to a legacy implementation if not.

ENDRELEASENOTES