### PR TITLE
Prefer std::hypot over sqrt of sum of squares

### DIFF
--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -159,8 +159,7 @@ datatypes :
       static const int BITStopped = 24 ;    \n
       static const int BITOverlay = 23 ;    \n
       /// return energy computed from momentum and mass \n
-      double getEnergy() const { return sqrt( getMomentum()[0]*getMomentum()[0]+getMomentum()[1]*getMomentum()[1]+\n
-                                        getMomentum()[2]*getMomentum()[2] + getMass()*getMass()  )  ;} \n
+      double getEnergy() const { return std::hypot(getMomentum()[0], getMomentum()[1], getMomentum()[2], getMass()) ; } \n
 
       /// True if the particle has been created by the simulation program (rather than the generator).     \n
       bool isCreatedInSimulation() const { return ( getSimulatorStatus() & ( 0x1 << BITCreatedInSimulation ))  ; }    \n
@@ -211,7 +210,7 @@ datatypes :
       double x() const {return getPosition()[0];}\n
       double y() const {return getPosition()[1];}\n
       double z() const {return getPosition()[2];}\n
-      double rho() const {return sqrt(x()*x() + y()*y());}\n
+      double rho() const {return std::hypot(x(), y());}\n
       "
 
 


### PR DESCRIPTION
Though overflows are unlikely to occur here, this is likely more numerically stable for finite arguments that do occur in NHEP. "Implementations usually guarantee precision of less than 1 ulp" https://en.cppreference.com/w/cpp/numeric/math/hypot.

Ref. https://github.com/key4hep/EDM4hep/issues/145.

BEGINRELEASENOTES
- std::hypot for sqrt of sum of squares in geEnergy and rho

ENDRELEASENOTES