### PR TITLE
Make sure EDM4hep exports its version properly for downstream cmake usage

### DIFF
--- a/cmake/EDM4HEPConfig.cmake.in
+++ b/cmake/EDM4HEPConfig.cmake.in
@@ -1,8 +1,5 @@
 # - Config file for the EDM4HEP package
 
-# - Define exported version
-set(EDM4HEP_VERSION "@PROJECT_VERSION@")
-
 # - Init CMakePackageConfigHelpers
 @PACKAGE_INIT@
 

--- a/test/downstream-project-cmake-test/CMakeLists.txt
+++ b/test/downstream-project-cmake-test/CMakeLists.txt
@@ -5,5 +5,13 @@ project(DownstreamProjectUsingEDM4hep)
 
 find_package(EDM4HEP)
 
+# Use the EDM4HEP_VERSION in an if clause to trigger a cmake error in case it is
+# unset.
+if (${EDM4HEP_VERSION} VERSION_GREATER_EQUAL "0.4.1")
+  message(STATUS "The current exported EDM4HEP version is " ${EDM4HEP_VERSION})
+else()
+  message(STATUS "The current exported EDM4HEP version is " ${EDM4HEP_VERSION})
+endif()
+
 add_executable(appUsingEDM4hep main.cxx)
 target_link_libraries(appUsingEDM4hep EDM4HEP::edm4hep EDM4HEP::utils)


### PR DESCRIPTION

BEGINRELEASENOTES
- Make EDM4hep export its current version properly for usage in downstream CMake packages.
  - Make sure downstream package test covers this.

ENDRELEASENOTES

Fixes #155

Example failure of downstream package usage without properly exporting the version: https://github.com/tmadlener/EDM4hep/runs/6831190866?check_suite_focus=true#step:4:1029