### PR TITLE
feat: install edm4hep.yaml to CMAKE_INSTALL_DATADIR/edm4hep

### DIFF
--- a/cmake/EDM4HEPConfig.cmake.in
+++ b/cmake/EDM4HEPConfig.cmake.in
@@ -6,6 +6,7 @@
 # - Create relocatable paths to headers.
 # NOTE: Do not strictly need paths as all usage requirements are encoded in
 # the imported targets created later.
+set_and_check(EDM4HEP_DATA_DIR "@PACKAGE_CMAKE_INSTALL_DATADIR@")
 set_and_check(EDM4HEP_INCLUDE_DIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
 
 include(CMakeFindDependencyMacro)

--- a/cmake/EDM4HEPConfig.cmake.in
+++ b/cmake/EDM4HEPConfig.cmake.in
@@ -6,8 +6,10 @@
 # - Create relocatable paths to headers.
 # NOTE: Do not strictly need paths as all usage requirements are encoded in
 # the imported targets created later.
-set_and_check(EDM4HEP_DATA_DIR "@PACKAGE_CMAKE_INSTALL_DATADIR@/edm4hep")
 set_and_check(EDM4HEP_INCLUDE_DIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
+
+# - Create path to installed read-only data files (e.g. yaml files)
+set_and_check(EDM4HEP_DATA_DIR "@PACKAGE_CMAKE_INSTALL_DATADIR@/edm4hep")
 
 include(CMakeFindDependencyMacro)
 find_dependency(podio REQUIRED)

--- a/cmake/EDM4HEPConfig.cmake.in
+++ b/cmake/EDM4HEPConfig.cmake.in
@@ -6,7 +6,7 @@
 # - Create relocatable paths to headers.
 # NOTE: Do not strictly need paths as all usage requirements are encoded in
 # the imported targets created later.
-set_and_check(EDM4HEP_DATA_DIR "@PACKAGE_CMAKE_INSTALL_DATADIR@")
+set_and_check(EDM4HEP_DATA_DIR "@PACKAGE_CMAKE_INSTALL_DATADIR@/edm4hep")
 set_and_check(EDM4HEP_INCLUDE_DIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
 
 include(CMakeFindDependencyMacro)

--- a/cmake/EDM4HEPCreateConfig.cmake
+++ b/cmake/EDM4HEPCreateConfig.cmake
@@ -15,6 +15,7 @@ configure_package_config_file(${CMAKE_CURRENT_LIST_DIR}/EDM4HEPConfig.cmake.in
     CMAKE_INSTALL_BINDIR
     CMAKE_INSTALL_INCLUDEDIR
     CMAKE_INSTALL_LIBDIR
+    CMAKE_INSTALL_DATADIR
   )
 
 # - install and export

--- a/edm4hep/CMakeLists.txt
+++ b/edm4hep/CMakeLists.txt
@@ -29,7 +29,7 @@ install(FILES
 
 install(FILES
   ../edm4hep.yaml
-  DESTINATION "${CMAKE_INSTALL_DATADIR}" COMPONENT dev)
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/edm4hep" COMPONENT dev)
 
 if (${ROOT_VERSION} GREATER 6)
   install(FILES

--- a/edm4hep/CMakeLists.txt
+++ b/edm4hep/CMakeLists.txt
@@ -27,6 +27,10 @@ install(FILES
   "${PROJECT_BINARY_DIR}/edm4hep/edm4hepDictDict.rootmap"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT dev)
 
+install(FILES
+  ../edm4hep.yaml
+  DESTINATION "${CMAKE_INSTALL_DATADIR}" COMPONENT dev)
+
 if (${ROOT_VERSION} GREATER 6)
   install(FILES
       "${PROJECT_BINARY_DIR}/edm4hep/libedm4hepDict_rdict.pcm"


### PR DESCRIPTION
This installs the original yaml file to CMAKE_INSTALL_DATADIR/edm4hep` for use by data models that [extend EDM4hep](https://github.com/AIDASoft/podio/pull/317). This DATADIR is exposed to downstream packages as EDM4HEP_DATA_DIR, and can be used as follows:
```
find_package(EDM4HEP REQUIRED)
PODIO_GENERATE_DATAMODEL(eicd eic_data.yaml headers sources
  UPSTREAM_EDM edm4hep:${EDM4HEP_DATA_DIR}/edm4hep.yaml
  OUTPUT_FOLDER ${CMAKE_CURRENT_BINARY_DIR}
  )
```

The [Gnu standard targets](https://www.gnu.org/prep/standards/html_node/Directory-Variables.html) indicate that DATADIR is the "directory for installing idiosyncratic read-only architecture-independent data files" and "you should install your data in a subdirectory" (which seems to be suggest as lower case).

BEGINRELEASENOTES
- Install edm4hep.yaml to CMAKE_INSTALL_DATADIR/edm4hep. The `EDM4HEP_DATA_DIR` cmake variable points to this directory when using edm4hep via `find_package(EDM4HEP)`.

ENDRELEASENOTES