### PR TITLE
EDM4DIS derived datamodel

### DIFF
--- a/test/downstream-project-cmake-test/CMakeLists.txt
+++ b/test/downstream-project-cmake-test/CMakeLists.txt
@@ -28,9 +28,9 @@ else()
   PODIO_ADD_DATAMODEL_CORE_LIB(edm4dis "${headers}" "${sources}"
     OUTPUT_FOLDER ${CMAKE_CURRENT_BINARY_DIR}
   )
-target_link_libraries(edm4dis PUBLIC EDM4HEP::edm4hep)
+  target_link_libraries(edm4dis PUBLIC EDM4HEP::edm4hep)
 
-PODIO_ADD_ROOT_IO_DICT(edm4disDict edm4dis "${headers}" src/selection.xml
+  PODIO_ADD_ROOT_IO_DICT(edm4disDict edm4dis "${headers}" src/selection.xml
     OUTPUT_FOLDER ${CMAKE_CURRENT_BINARY_DIR}
   )
 endif()

--- a/test/downstream-project-cmake-test/CMakeLists.txt
+++ b/test/downstream-project-cmake-test/CMakeLists.txt
@@ -29,7 +29,7 @@ else()
     OUTPUT_FOLDER ${CMAKE_CURRENT_BINARY_DIR}
   )
 
-  PODIO_ADD_ROOT_IO_DICT(edm4disDict edm4dis "${headers}" ${CMAKE_CURRENT_BINARY_DIR}/src/selection.xml
+  PODIO_ADD_ROOT_IO_DICT(edm4disDict edm4dis "${headers}" src/selection.xml
     OUTPUT_FOLDER ${CMAKE_CURRENT_BINARY_DIR}
   )
 endif()

--- a/test/downstream-project-cmake-test/CMakeLists.txt
+++ b/test/downstream-project-cmake-test/CMakeLists.txt
@@ -28,7 +28,7 @@ else()
   PODIO_ADD_DATAMODEL_CORE_LIB(edm4dis "${headers}" "${sources}"
     OUTPUT_FOLDER ${CMAKE_CURRENT_BINARY_DIR}
   )
-
+target_link_libraries(edm4dis PUBLIC EDM4HEP::edm4hep)
   PODIO_ADD_ROOT_IO_DICT(edm4disDict edm4dis "${headers}" src/selection.xml
     OUTPUT_FOLDER ${CMAKE_CURRENT_BINARY_DIR}
   )

--- a/test/downstream-project-cmake-test/CMakeLists.txt
+++ b/test/downstream-project-cmake-test/CMakeLists.txt
@@ -13,5 +13,34 @@ else()
   message(STATUS "The current exported EDM4HEP version is " ${EDM4HEP_VERSION})
 endif()
 
+# Use the EDM4HEP_DATA_DIR to derive extended data model
+if (${EDM4HEP_DATA_DIR})
+  message(STATUS "Current EDM4HEP data model is available at ${EDM4HEP_DATA_DIR}.")
+  PODIO_GENERATE_DATAMODEL(EDM4DIS edm4dis.yaml headers sources
+    UPSTREAM_EDM edm4hep:${EDM4HEP_DATA_DIR}/edm4hep.yaml
+    OUTPUT_FOLDER ${CMAKE_CURRENT_BINARY_DIR}
+  )
+  add_library(EDM4DIS SHARED
+    ${sources}
+  )
+
+  target_link_libraries(EDM4DIS
+    PUBLIC EDM4HEP::edm4hep
+    PUBLIC podio::podio
+  )
+  target_include_directories(EDM4DIS
+    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+    $<INSTALL_INTERFACE:include>
+  )
+
+  PODIO_GENERATE_DICTIONARY(EDM4DIS ${headers} 
+    SELECTION ${CMAKE_CURRENT_BINARY_DIR}/src/selection.xml
+    OPTIONS --library ${CMAKE_SHARED_LIBRARY_PREFIX}EDM4DIS${CMAKE_SHARED_LIBRARY_SUFFIX}
+  )
+  set_target_properties(edm4dis-dictgen PROPERTIES EXCLUDE_FROM_ALL TRUE)
+else()
+  message(WARNING "Unable to extend data model since no installed yaml file found.")
+endif()
+
 add_executable(appUsingEDM4hep main.cxx)
 target_link_libraries(appUsingEDM4hep EDM4HEP::edm4hep EDM4HEP::utils)

--- a/test/downstream-project-cmake-test/CMakeLists.txt
+++ b/test/downstream-project-cmake-test/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 
 # Use the EDM4HEP_DATA_DIR to derive extended data model
 message(STATUS "${EDM4HEP_DATA_DIR}")
-if (${EDM4HEP_DATA_DIR} STREQUAL "")
+if ("${EDM4HEP_DATA_DIR}" STREQUAL "")
   message(WARNING "Unable to extend data model since no installed yaml file found.")
 else()
   message(STATUS "Current EDM4HEP data model is available at ${EDM4HEP_DATA_DIR}.")

--- a/test/downstream-project-cmake-test/CMakeLists.txt
+++ b/test/downstream-project-cmake-test/CMakeLists.txt
@@ -29,7 +29,8 @@ else()
     OUTPUT_FOLDER ${CMAKE_CURRENT_BINARY_DIR}
   )
 target_link_libraries(edm4dis PUBLIC EDM4HEP::edm4hep)
-  PODIO_ADD_ROOT_IO_DICT(edm4disDict edm4dis "${headers}" src/selection.xml
+
+PODIO_ADD_ROOT_IO_DICT(edm4disDict edm4dis "${headers}" src/selection.xml
     OUTPUT_FOLDER ${CMAKE_CURRENT_BINARY_DIR}
   )
 endif()

--- a/test/downstream-project-cmake-test/CMakeLists.txt
+++ b/test/downstream-project-cmake-test/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 # Use the EDM4HEP_DATA_DIR to derive extended data model
 message(STATUS "${EDM4HEP_DATA_DIR}")
 if ("${EDM4HEP_DATA_DIR}" STREQUAL "")
-  message(WARNING "Unable to extend data model since no installed yaml file found.")
+  message(FATAL_ERROR "Unable to extend data model since no installed yaml file found.")
 else()
   message(STATUS "Current EDM4HEP data model is available at ${EDM4HEP_DATA_DIR}.")
   PODIO_GENERATE_DATAMODEL(edm4dis edm4dis.yaml headers sources

--- a/test/downstream-project-cmake-test/CMakeLists.txt
+++ b/test/downstream-project-cmake-test/CMakeLists.txt
@@ -35,4 +35,4 @@ else()
 endif()
 
 add_executable(appUsingEDM4hep main.cxx)
-target_link_libraries(appUsingEDM4hep EDM4HEP::edm4hep EDM4HEP::utils)
+target_link_libraries(appUsingEDM4hep EDM4HEP::edm4hep EDM4HEP::utils edm4dis)

--- a/test/downstream-project-cmake-test/CMakeLists.txt
+++ b/test/downstream-project-cmake-test/CMakeLists.txt
@@ -14,32 +14,33 @@ else()
 endif()
 
 # Use the EDM4HEP_DATA_DIR to derive extended data model
-if (${EDM4HEP_DATA_DIR})
+message(STATUS "${EDM4HEP_DATA_DIR}")
+if (${EDM4HEP_DATA_DIR} STREQUAL "")
+  message(WARNING "Unable to extend data model since no installed yaml file found.")
+else()
   message(STATUS "Current EDM4HEP data model is available at ${EDM4HEP_DATA_DIR}.")
-  PODIO_GENERATE_DATAMODEL(EDM4DIS edm4dis.yaml headers sources
+  PODIO_GENERATE_DATAMODEL(edm4dis edm4dis.yaml headers sources
     UPSTREAM_EDM edm4hep:${EDM4HEP_DATA_DIR}/edm4hep.yaml
     OUTPUT_FOLDER ${CMAKE_CURRENT_BINARY_DIR}
   )
-  add_library(EDM4DIS SHARED
+  add_library(edm4dis SHARED
     ${sources}
   )
 
-  target_link_libraries(EDM4DIS
+  target_link_libraries(edm4dis
     PUBLIC EDM4HEP::edm4hep
     PUBLIC podio::podio
   )
-  target_include_directories(EDM4DIS
+  target_include_directories(edm4dis
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     $<INSTALL_INTERFACE:include>
   )
 
-  PODIO_GENERATE_DICTIONARY(EDM4DIS ${headers} 
+  PODIO_GENERATE_DICTIONARY(edm4dis ${headers} 
     SELECTION ${CMAKE_CURRENT_BINARY_DIR}/src/selection.xml
-    OPTIONS --library ${CMAKE_SHARED_LIBRARY_PREFIX}EDM4DIS${CMAKE_SHARED_LIBRARY_SUFFIX}
+    OPTIONS --library ${CMAKE_SHARED_LIBRARY_PREFIX}edm4dis${CMAKE_SHARED_LIBRARY_SUFFIX}
   )
   set_target_properties(edm4dis-dictgen PROPERTIES EXCLUDE_FROM_ALL TRUE)
-else()
-  message(WARNING "Unable to extend data model since no installed yaml file found.")
 endif()
 
 add_executable(appUsingEDM4hep main.cxx)

--- a/test/downstream-project-cmake-test/CMakeLists.txt
+++ b/test/downstream-project-cmake-test/CMakeLists.txt
@@ -25,9 +25,13 @@ else()
     IO_BACKEND_HANDLERS ${PODIO_IO_HANDLERS}
   )
 
-  PODIO_ADD_DATAMODEL_CORE_LIB(edm4dis "${headers}" "${sources}") 
-  
-  PODIO_ADD_ROOT_IO_DICT(edm4disDict edm4dis "${headers}" src/selection.xml) 
+  PODIO_ADD_DATAMODEL_CORE_LIB(edm4dis "${headers}" "${sources}"
+    OUTPUT_FOLDER ${CMAKE_CURRENT_BINARY_DIR}
+  )
+
+  PODIO_ADD_ROOT_IO_DICT(edm4disDict edm4dis "${headers}" ${CMAKE_CURRENT_BINARY_DIR}/src/selection.xml
+    OUTPUT_FOLDER ${CMAKE_CURRENT_BINARY_DIR}
+  )
 endif()
 
 add_executable(appUsingEDM4hep main.cxx)

--- a/test/downstream-project-cmake-test/CMakeLists.txt
+++ b/test/downstream-project-cmake-test/CMakeLists.txt
@@ -22,25 +22,12 @@ else()
   PODIO_GENERATE_DATAMODEL(edm4dis edm4dis.yaml headers sources
     UPSTREAM_EDM edm4hep:${EDM4HEP_DATA_DIR}/edm4hep.yaml
     OUTPUT_FOLDER ${CMAKE_CURRENT_BINARY_DIR}
-  )
-  add_library(edm4dis SHARED
-    ${sources}
+    IO_BACKEND_HANDLERS ${PODIO_IO_HANDLERS}
   )
 
-  target_link_libraries(edm4dis
-    PUBLIC EDM4HEP::edm4hep
-    PUBLIC podio::podio
-  )
-  target_include_directories(edm4dis
-    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-    $<INSTALL_INTERFACE:include>
-  )
-
-  PODIO_GENERATE_DICTIONARY(edm4dis ${headers} 
-    SELECTION ${CMAKE_CURRENT_BINARY_DIR}/src/selection.xml
-    OPTIONS --library ${CMAKE_SHARED_LIBRARY_PREFIX}edm4dis${CMAKE_SHARED_LIBRARY_SUFFIX}
-  )
-  set_target_properties(edm4dis-dictgen PROPERTIES EXCLUDE_FROM_ALL TRUE)
+  PODIO_ADD_DATAMODEL_CORE_LIB(edm4dis "${headers}" "${sources}") 
+  
+  PODIO_ADD_ROOT_IO_DICT(edm4disDict edm4dis "${headers}" src/selection.xml) 
 endif()
 
 add_executable(appUsingEDM4hep main.cxx)

--- a/test/downstream-project-cmake-test/edm4dis.yaml
+++ b/test/downstream-project-cmake-test/edm4dis.yaml
@@ -1,0 +1,24 @@
+---
+options :
+  # should getters / setters be prefixed with get / set?
+  getSyntax: True
+  # should POD members be exposed with getters/setters in classes that have them as members?
+  exposePODMembers: False
+  includeSubfolder: True
+
+datatypes:
+
+  ## ==========================================================================
+  ## Kinematic reconstruction
+  ## ==========================================================================
+  edm4dis::InclusiveKinematics:
+    Description: "Kinematic variables for DIS events"
+    Author: "S. Joosten, W. Deconinck"
+    Members:
+      - float             x                 // Bjorken x (Q2/2P.q)
+      - float             Q2                // Four-momentum transfer squared [GeV^2]
+      - float             W                 // Invariant mass of final state [GeV]
+      - float             y                 // Inelasticity (P.q/P.k)
+      - float             nu                // Energy transfer P.q/M [GeV]
+    OneToOneRelations:
+      - edm4hep::ReconstructedParticle scat // Associated scattered electron (if identified)

--- a/test/downstream-project-cmake-test/main.cxx
+++ b/test/downstream-project-cmake-test/main.cxx
@@ -5,10 +5,14 @@
 #include "edm4hep/MCParticle.h"
 #include "edm4hep/utils/kinematics.h"
 
+#include "edm4dis/InclusiveKinematics.h"
+
 int main() {
 
   auto a = edm4hep::MCParticle();
   const auto p4 = edm4hep::utils::p4(a);
+
+  auto k = edm4dis::InclusiveKinematics();
 
   return 0;
 }


### PR DESCRIPTION
This adds a very light-weight EDM4DIS data model which combines a new data type with EDM4hep data types.

BEGINRELEASENOTES
- test and example for data model derived from EDM4hep

ENDRELEASENOTES

Needs #164 and AIDASoft/podio#317