### PR TITLE
[wip] add `MeasurementND` classes

### DIFF
--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -418,6 +418,50 @@ datatypes :
       //TODO: edm4hep::Vertex  getEndVertex() { return  edm4hep::Vertex(  (getParticles(0).isAvailable() ? getParticles(0).getStartVertex() :  edm4hep::Vertex(0,0) ) ) ; }\n     
       "
 
+  edm4hep::Measurement2D:
+    Description: "Two dimensional measurement with covariance matrix"
+    Author: "T. Madlener, DESY"
+    Members:
+      - std::array<float, 2> vals    // The values of the measurement
+      - std::array<float, 3> covMatrix     // The (lower triangle) covariance matrix of the measurement
+      - std::array<uint16_t, 2> dims // The (encded) dimensions of the two values
+    ExtraCode:
+      includes: '#include "edm4hep/detail/enum_access.h"'
+      declaration: "
+      /// Get the value for the passed dimension\n
+      template<typename DimEnum>\n
+      float getValue(DimEnum e) const {\n
+        return detail::get_value(getVals(), e, getDims());\n
+      }\n
+      /// Get the value of the covariance matrix for the two passed dimensions\n
+      template<typename DimEnum>\n
+      float getCov(DimEnum ei, DimEnum ej) const {\n
+        return detail::get_cov(getCovMatrix(), ei, ej, getDims());\n
+      }\n
+      /// Get which dimensions are currently set for this measurement\n
+      template<typename DimEnum>\n
+      std::array<DimEnum, 2> getDimensions() const {\n
+        return {detail::to_enum<DimEnum>(getDims()[0]), detail::to_enum<DimEnum>(getDims()[1])};\n
+      }
+      "
+    MutableExtraCode:
+      includes: '#include "edm4hep/detail/enum_access.h"'
+      declaration: "
+      /// Set the value for the passed dimension\n
+      template<typename DimEnum>\n
+      void setValue(float val, DimEnum dim) {\n
+        detail::set_value(val, vals(), dim, getDims());\n
+      }\n
+      template<typename DimEnum>\n
+      void setCov(float val, DimEnum dimI, DimEnum dimJ) {\n
+        detail::set_cov(val, covMatrix(), dimI, dimJ, getDims());\n
+      }\n
+      template<typename DimEnum>\n
+      void setDimensions(DimEnum dim1, DimEnum dim2) {\n
+        setDims({detail::to_index(dim1), detail::to_index(dim2)});\n
+      }
+      "
+
   edm4hep::MCRecoParticleAssociation:
     Description: "Used to keep track of the correspondence between MC and reconstructed particles"
     Author: "C. Bernet, B. Hegner"

--- a/edm4hep/CMakeLists.txt
+++ b/edm4hep/CMakeLists.txt
@@ -4,6 +4,9 @@
 PODIO_GENERATE_DATAMODEL(edm4hep ../edm4hep.yaml headers sources IO_BACKEND_HANDLERS ${PODIO_IO_HANDLERS})
 
 PODIO_ADD_DATAMODEL_CORE_LIB(edm4hep "${headers}" "${sources}")
+target_include_directories(edm4hep PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+  )
 
 PODIO_ADD_ROOT_IO_DICT(edm4hepDict edm4hep "${headers}" src/selection.xml)
 add_library(edm4hep::edm4hepDict ALIAS edm4hepDict )

--- a/include/edm4hep/detail/enum_access.h
+++ b/include/edm4hep/detail/enum_access.h
@@ -1,0 +1,112 @@
+#ifndef EDM4HEP_DETAIL_ENUM_ACCESS_H
+#define EDM4HEP_DETAIL_ENUM_ACCESS_H
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <type_traits>
+
+namespace edm4hep {
+
+// Use 16 bits to encode the dimension
+// Could go to 8 bits, but would need a fix in podio first
+using DimType = std::uint16_t;
+
+namespace detail {
+// From c++23 this is functionality offerd by the STL
+#if __cpp_lib_to_underlying
+using to_index = std::to_underlying;
+#else
+// Otherwise it is simple enough to roll our own
+template <typename E> constexpr auto to_index(E e) {
+  return static_cast<std::underlying_type_t<E>>(e);
+}
+#endif
+
+/// Cast an index to an enum value
+template <typename DimEnum> constexpr DimEnum to_enum(DimType index) {
+  return static_cast<DimEnum>(index);
+}
+
+/// Decode which index in the array corresponds to the passed enum value.
+/// Assuming that they are unique!
+template <typename DimEnum, std::size_t N>
+constexpr int decode_index(const std::array<DimType, N> &dimIndices,
+                           DimEnum dim) {
+  for (auto i = 0u; i < N; ++i) {
+    if (dimIndices[i] == detail::to_index(dim)) {
+      return i;
+    }
+  }
+
+  return -1;
+}
+
+/// Get the value corresponding to the passed enum value from the array
+template <typename DimEnum, typename Scalar, std::size_t N>
+constexpr Scalar get_value(const std::array<Scalar, N> &values, DimEnum dim,
+                           const std::array<DimType, N> &dimIndices) {
+  const auto index = decode_index(dimIndices, dim);
+  if (index < 0) {
+    // TODO: error handling
+  }
+
+  return values[index];
+}
+
+template <typename DimEnum, typename Scalar, std::size_t N>
+constexpr void set_value(Scalar value, std::array<Scalar, N> &values,
+                         DimEnum dim,
+                         const std::array<DimType, N> &dimIndices) {
+  const auto index = decode_index(dimIndices, dim);
+  if (index < 0) {
+    // TODO: error handling
+  }
+
+  values[index] = value;
+}
+
+/// Convert from 2D matrix indices to 1d lower triangle indices
+constexpr int to_lower_tri(int i, int j, size_t N) {
+  if (j < i) {
+    std::swap(i, j);
+  }
+  return i * (2 * N - i - 1) / 2 + j;
+}
+
+/// Get the covariance matrix value corresponding to the passed enum values from
+/// the array
+template <typename DimEnum, typename Scalar, std::size_t N, std::size_t NDims>
+constexpr Scalar get_cov(const std::array<Scalar, N> &cov, DimEnum dimI,
+                         DimEnum dimJ,
+                         const std::array<DimType, NDims> &dimIndices) {
+  auto i = decode_index(dimIndices, dimI);
+  auto j = decode_index(dimIndices, dimJ);
+
+  if (i < 0 || j < 0) {
+    // TODO: error handling
+  }
+
+  return cov[to_lower_tri(i, j, NDims)];
+}
+
+template <typename DimEnum, typename Scalar, std::size_t N, std::size_t NDims>
+constexpr void set_cov(Scalar value, std::array<Scalar, N> &cov, DimEnum dimI,
+                       DimEnum dimJ,
+                       const std::array<DimType, NDims> &dimIndices) {
+  auto i = decode_index(dimIndices, dimI);
+  auto j = decode_index(dimIndices, dimJ);
+
+  if (i < 0 || j < 0) {
+    // TODO: error handling
+  }
+
+  // Covariance is in lower triangle this brings us from 2D indices to 1D
+  cov[to_lower_tri(i, j, NDims)] = value;
+}
+
+} // namespace detail
+
+} // namespace edm4hep
+
+#endif // EDM4HEP_DETAIL_ENUM_ACCESS_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,7 +4,7 @@ ENDIF()
 
 function(set_test_env _testname)
   set_property(TEST ${_testname} APPEND PROPERTY ENVIRONMENT
-      LD_LIBRARY_PATH=$<TARGET_FILE_DIR:edm4hep>:$<TARGET_FILE_DIR:podio::podio>:$ENV{LD_LIBRARY_PATH}
+      LD_LIBRARY_PATH=$<TARGET_FILE_DIR:edm4hep>:$<TARGET_FILE_DIR:podio::podio>:$<TARGET_FILE_DIR:ROOT::Tree>:$ENV{LD_LIBRARY_PATH}
       ROOT_INCLUDE_PATH=${PROJECT_SOURCE_DIR}/edm4hep:$ENV{ROOT_INCLUDE_PATH}
   )
   set_tests_properties(${_testname} PROPERTIES

--- a/test/dimensions.h
+++ b/test/dimensions.h
@@ -1,0 +1,10 @@
+#ifndef EDM4HEP_TEST_DIMENSIONS_H
+#define EDM4HEP_TEST_DIMENSIONS_H
+
+#include "edm4hep/detail/enum_access.h"
+
+enum Cartesian : edm4hep::DimType { X = 0, Y = 1, Z = 2 };
+
+enum class Polar : edm4hep::DimType { R = 0, PHI, THETA };
+
+#endif // EDM4HEP_TEST_DIMENSIONS_H

--- a/test/write_events.h
+++ b/test/write_events.h
@@ -1,11 +1,14 @@
 #ifndef EDM4HEP_TEST_WRITE_EVENTS_H__
 #define EDM4HEP_TEST_WRITE_EVENTS_H__
 
+#include "dimensions.h"
+
 // Data model
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
 #include "edm4hep/CaloHitContributionCollection.h"
 #include "edm4hep/SimCalorimeterHitCollection.h"
+#include "edm4hep/Measurement2DCollection.h"
 
 // STL
 #include <iostream>
@@ -13,6 +16,32 @@
 
 // podio specific includes
 #include "podio/EventStore.h"
+
+void fillCollection(edm4hep::Measurement2DCollection& coll) {
+  auto m1 = coll.create();
+  // Set things via the tacked on interface
+  m1.setDimensions(Cartesian::X, Cartesian::Z);
+  m1.setValue(1.234f, Cartesian::X);
+  m1.setValue(3.14f, Cartesian::Z);
+  m1.setCov(42.0f, Cartesian::X, Cartesian::X);
+  m1.setCov(3.14f, Cartesian::X, Cartesian::Z);
+  m1.setCov(2.34f, Cartesian::Z, Cartesian::Z);
+
+  // Again but with enum class
+  auto m2 = coll.create();
+  m2.setDimensions(Polar::PHI, Polar::THETA);
+  m2.setValue(100.f, Polar::PHI);
+  m2.setValue(200.f, Polar::THETA);
+  m2.setCov(10.f, Polar::PHI, Polar::PHI);
+  m2.setCov(20.f, Polar::THETA, Polar::PHI);
+  m2.setCov(30.f, Polar::THETA, Polar::THETA);
+
+  // We can also go through the "native" interface
+  auto m3 = coll.create();
+  m3.setDims({2, 1});
+  m3.setVals({1.234f, 5.678f});
+  m3.setCovMatrix({1.1f, 2.2f, 3.3f});
+}
 
 template<class WriterT>
 void write(std::string outfilename) {
@@ -34,6 +63,8 @@ void write(std::string outfilename) {
   auto& sccons = store.create<edm4hep::CaloHitContributionCollection>("SimCalorimeterHitContributions");
   writer.registerForWrite("SimCalorimeterHitContributions");
 
+  auto& measurements = store.create<edm4hep::Measurement2DCollection>("measurement2D");
+  writer.registerForWrite("measurement2D");
 
   unsigned nevents = 10 ;
 
@@ -180,6 +211,8 @@ void write(std::string outfilename) {
 
     std::cout << "\n collection:  " << "SimCalorimeterHits" <<  " of type " <<  schs.getValueTypeName() << "\n\n"
         << schs << std::endl ;
+
+    fillCollection(measurements);
 
     //===============================================================================
 


### PR DESCRIPTION
BEGINRELEASENOTES
- TODO

ENDRELEASENOTES

This is a draft implementation for the `MeasurementND` classes mentioned in #161. In its current form it only implements a two dimensional example, but it should easily scale to other numbers of dimensions as well. It probably has some potential for generalizing the `ExtraCode` bits slightly for that.

In the current form it introduces a `Measurement2D` class that has three `std::array`s internally. One for the central values, one for the covariance matrix and one that stores "meta" information on the dimensions. The dimensions in this case are `enum`s (`enum class` also works). The meta information stores which dimension corresponds to which stored value and there is functionality to set/get the order of the dimensions. Using `ExtraCode` we essentially simply layer a second interface that grants access to the stored values via the dimensions directly. Potentially simpler shown than told:

```cpp
enum Cartesian : edm4hep::DimType { X = 0, Y, Z}; // internally we use uint16_t, DimType is just a typedef for that

auto m = MutableMeasurement2D();
// This measurement should describe one in a (Z, X) space
m.setDimensions(Cartesian::Z, Cartesian::X);
// Setting the value for Z
m.setValue(3.14f, Cartesian::Z);
// Setting a value in the covariance matrix (order of dimensions doesn't matter)
m.setCov(1.23f, Cartesian::X, Cartesian::Z);
```
Retrieving the values can be done similarly.

One thing that is not even attempted in the current version is to guard against access with a different dimension enum, e.g. using the above `m` the following works without problems
```cpp
enum class Polar { r, theta, phi };
// this DOES NOT have to be the same dimensions as above
const auto [dim1, dim2] = m.getDimensions<Polar>();
// dim1 == Polar::phi
// dim2 == Polar::r

auto val = m.getValue(Polar::phi);
// val == 3.14f
```

Since this interface is simply added to the one that is generated, the whole class is also usable without any specific enums.

@paulgessinger does this go into a direction that is useful for ACTS?


TODO:
- [ ] Geometry info / CellID field
- [ ] Error handling. What should happen if access with a dimension that is not stored is attempted?
- [ ] Other Ns
- [ ] Better naming of things?
- [ ] Release notes