### PR TITLE
Make sure that the kinematics.h also works for python

### DIFF
--- a/test/utils/CMakeLists.txt
+++ b/test/utils/CMakeLists.txt
@@ -19,3 +19,9 @@ add_executable(unittests
   test_kinematics.cpp)
 target_link_libraries(unittests edm4hep EDM4HEP::utils Catch2::Catch2 Catch2::Catch2WithMain)
 catch_discover_tests(unittests)
+
+add_test(NAME pyunittests COMMAND python -m unittest discover -s ${CMAKE_CURRENT_LIST_DIR})
+set_property(TEST pyunittests
+  PROPERTY ENVIRONMENT
+  LD_LIBRARY_PATH=$<TARGET_FILE_DIR:edm4hep>:$ENV{LD_LIBRARY_PATH}
+  )

--- a/test/utils/test_kinematics.py
+++ b/test/utils/test_kinematics.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import unittest
+
+import ROOT
+import cppyy
+
+if ROOT.gSystem.Load('libedm4hepDict.so') < 0:
+  print('Cannot load edm4hep dictionary for tests')
+  sys.exit(1)
+
+ROOT.gInterpreter.LoadFile(os.path.dirname(__file__) + '/../../utils/include/edm4hep/utils/kinematics.h')
+
+from ROOT import edm4hep
+
+# A few shorthands for slightly easier to read tests below
+p4 = edm4hep.utils.p4
+LVM = edm4hep.LorentzVectorM
+LVE = edm4hep.LorentzVectorE
+SetEnergy = edm4hep.utils.SetEnergy
+SetMass = edm4hep.utils.SetMass
+UseEnergy = edm4hep.utils.UseEnergy
+UseMass = edm4hep.utils.UseMass
+
+
+class TestKinematics(unittest.TestCase):
+  """Tests to ensure that the kinematics header only library also works in
+  python"""
+
+  def test_p4(self):
+    """Test the p4 functionality since that has shown to trip-up cppyy"""
+    # podio doesn't expose the Mutable constructors so we have to use the full
+    # glory of the immutable types here
+    p = edm4hep.MCParticle(11,  # PDG
+                           -1,  # generatorStatus
+                           -1,  # simulatorStatus
+                           1.0,  # charge
+                           0.0,  # time
+                           125.0,  # charge
+                           edm4hep.Vector3d(0, 0, 0),  # vertex
+                           edm4hep.Vector3d(0, 0, 0),  # endpoint
+                           edm4hep.Vector3f(1.0, 2.0, 3.0),  # momentum
+                           edm4hep.Vector3f(0, 0, 0),  # momentumAtEndpoint
+                           edm4hep.Vector3f(0, 0, 0),  # spin
+                           edm4hep.Vector2i(0, 0)  # colorFlow
+                           )
+
+    self.assertEqual(p4(p), LVM(1.0, 2.0, 3.0, 125.0))
+    self.assertEqual(p4(p, SetEnergy(42.0)), LVE(1.0, 2.0, 3.0, 42.0))
+    self.assertEqual(p4(p, SetMass(250.0)), LVM(1.0, 2.0, 3.0, 250.0))
+
+    p = edm4hep.ReconstructedParticle(11,  # type
+                                      250.0,  # energy
+                                      edm4hep.Vector3f(1.0, 2.0, 3.0),  # momentum
+                                      edm4hep.Vector3f(0, 0, 0),  # referencePoint
+                                      1.0,  # charge
+                                      125.0,  # mass
+                                      0.0,  # goodnessOfPID
+                                      cppyy.gbl.std.array('float', 10)()  # covMatrix
+                                      )
+
+    self.assertEqual(p4(p), LVM(1.0, 2.0, 3.0, 125.0))
+    self.assertEqual(p4(p, UseEnergy), LVE(1.0, 2.0, 3.0, 250.0))
+    self.assertEqual(p4(p, UseMass), LVM(1.0, 2.0, 3.0, 125.0))
+    self.assertEqual(p4(p, SetMass()), LVM(1.0, 2.0, 3.0, 0.0))
+    self.assertEqual(p4(p, SetEnergy(42.0)), LVE(1.0, 2.0, 3.0, 42.0))
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/utils/include/edm4hep/utils/kinematics.h
+++ b/utils/include/edm4hep/utils/kinematics.h
@@ -66,9 +66,11 @@ struct UseEnergyTag {
  */
 template<typename T, typename TagT>
 struct TaggedUserValue {
+  TaggedUserValue() = default;
+  TaggedUserValue(T v) : value(v) {}
   using type = typename TagT::type;
   static constexpr bool has_value = true;
-  T value;
+  T value{};
 };
 
 /**
@@ -119,18 +121,28 @@ using SetMass = detail::TaggedUserValue<float, UseMassTag>;
 using SetEnergy = detail::TaggedUserValue<float, UseEnergyTag>;
 
 /**
- * Get the 4 momentum vector from a Particle. By default using the momentum and
- * the mass, but can be switched to using the energy when using the UseEnergy as
- * second argument. Additionally it is possible to take the momentum from the
- * particle but set a specific mass or energy value by using SetMass or
- * SetEnergy as the second argument. The underlying particle will not be changed
- * in this case.
+ * Get the 4 momentum vector from a Particle using the momentum and the mass.
  */
-template<typename ParticleT, typename LorentzVectorTag=UseMassTag>
-inline typename LorentzVectorTag::type p4(ParticleT const& part, LorentzVectorTag tag=UseMass) {
-  return detail::p4(part, &tag);
+template<typename ParticleT>
+inline LorentzVectorM p4(ParticleT const& part) {
+  return detail::p4(part, &UseMass);
 }
 
+/**
+ * Get the 4 momentum vector from a Particle. Use the second argument to choose
+ * something other than the mass. E.g. the UseEnergy as second argument to get
+ * the energy stored within the particle. Additionally it is possible to take
+ * the momentum from the particle but set a specific mass or energy value by
+ * using SetMass or SetEnergy as the second argument. The underlying particle
+ * will not be changed in this case.
+ *
+ * NOTE: split into two overloads, in order to work around a short-coming of
+ * cppyy: See https://github.com/wlav/cppyy/issues/78
+ */
+template<typename ParticleT, typename LorentzVectorTag>
+inline typename LorentzVectorTag::type p4(ParticleT const& part, LorentzVectorTag tag) {
+  return detail::p4(part, &tag);
+}
 
 }} // namespace edm4hep::utils
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix the `kinematics.h` header only utility file such that it also works when used via PyROOT.

ENDRELEASENOTES

For more details see:
- https://root-forum.cern.ch/t/calling-a-tag-dispatched-function-from-pyroot-does-not-work-with-a-default-tag-argument/51156/4
- wlav/cppyy#78
