### PR TITLE
Bump minimum CMake version to 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.16)
 
 project(EDM4HEP LANGUAGES CXX)
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ This project is in a beta stage -- feedback and use of it in production is encou
 
 Required:
 
-* [PODIO](https://github.com/AIDASoft/podio) >= v00-09-02
-* [ROOT](https://github.com/root-project/root) >= v6.18/04
+* [PODIO](https://github.com/AIDASoft/podio) >= v00-15
+* [ROOT](https://github.com/root-project/root) >= v6.22/06
 
 Optional:
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Bump the minimum cmake version to 3.16. Fixes #166 
- Update minimally required versions of podio and ROOT in README

ENDRELEASENOTES

@andresailer @vvolkl or should we rather go for 3.12 (i.e. the same as podio and dd4hep at the moment)?