### PR TITLE
extend for drift chamber and TPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,19 +20,19 @@ A generic event data model for future HEP collider experiments.
 
 | | | |
 |-|-|-|
-| [EventHeader](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L113)         | [MCParticle](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L123)        | [SimTrackerHit](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L191)         |
-| [CaloHitContribution](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L225) | [SimCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L237) | [RawCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L249)     |
-| [CalorimeterHit](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L258)      | [ParticleID](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L270)        | [Cluster](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L283)               |
-| [TrackerHit](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L304)          | [TrackerHitPlane](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L321)   | [TPCHit](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L342)                |
-| [Track](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L354)               | [Vertex](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L373)            | [ReconstructedParticle](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L390) |
+| [EventHeader](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L129)         | [MCParticle](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L139)        | [SimTrackerHit](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L207)         |
+| [CaloHitContribution](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L241) | [SimCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L254) | [RawCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L266)     |
+| [CalorimeterHit](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L274)      | [ParticleID](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L286)        | [Cluster](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L299)               |
+| [TrackerHit](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L320)          | [TrackerHitPlane](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L337)   | [RawTimeSeries](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L358)                |
+| [Track](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L371)               | [Vertex](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L390)            | [ReconstructedParticle](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L407) |
 
 **Associations**
 
 | | | |
 |-|-|-|
-| [MCRecoParticleAssociation](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L421)        | [MCRecoCaloAssociation](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L430)         | [MCRecoTrackerAssociation](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L439)         |
-| [MCRecoTrackerHitPlaneAssociation](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L448) | [MCRecoCaloParticleAssociation](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L457) | [MCRecoClusterParticleAssociation](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L466) |
-| [MCRecoTrackParticleAssociation](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L475)   | [RecoParticleVertexAssociation](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L484) |                                                                                                      |
+| [MCRecoParticleAssociation](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L438)        | [MCRecoCaloAssociation](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L447)         | [MCRecoTrackerAssociation](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L456)         |
+| [MCRecoTrackerHitPlaneAssociation](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L465) | [MCRecoCaloParticleAssociation](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L474) | [MCRecoClusterParticleAssociation](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L483) |
+| [MCRecoTrackParticleAssociation](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L492)   | [RecoParticleVertexAssociation](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L501) |                                                                                                      |
 
 The tests and examples in the `tests` directory show how to read, write, and use these types in your code.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A generic event data model for future HEP collider experiments.
 |-|-|-|
 | [Vector3f ](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L9) | [Vector3d ](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L24)   | [Vector2i](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L40)  |
 | [Vector2f](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L54) | [TrackState ](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L68) | [ObjectID](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L91)  |
+| [Quantity](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L103) | [Hypothesis ](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L111) | [HitLevelData](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L118)  |
 
 
 **Datatypes**
@@ -25,6 +26,8 @@ A generic event data model for future HEP collider experiments.
 | [CalorimeterHit](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L274)      | [ParticleID](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L286)        | [Cluster](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L299)               |
 | [TrackerHit](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L320)          | [TrackerHitPlane](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L337)   | [RawTimeSeries](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L358)                |
 | [Track](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L371)               | [Vertex](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L390)            | [ReconstructedParticle](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L407) |
+| [SimPrimaryIonizationCluster](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L511) | [TrackerPulse](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L529) | [RecIonizationCluster](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L542) |
+| [TimeSeries](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L553) | [RecDqdx](https://github.com/key4hep/EDM4hep/blob/master/edm4hep.yaml#L565) |                                                                                          |
 
 **Associations**
 

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -323,7 +323,7 @@ datatypes :
     Author : "F.Gaede, DESY"
     Members :
       - uint64_t cellID      //ID of the sensor that created this hit
-      - int32_t type                       //type of raw data hit, either one of edm4hep::TPCHIT, edm4hep::SIMTRACKERHIT - see collection parameters "TrackerHitTypeNames" and "TrackerHitTypeValues".
+      - int32_t type                       //type of raw data hit, either one of edm4hep::TrackerRawData, edm4hep::SIMTRACKERHIT - see collection parameters "TrackerHitTypeNames" and "TrackerHitTypeValues".
       - int32_t quality                    //quality bit flag of the hit.
       - float time                     //time of the hit.
       - float eDep                     //energy deposited on the hit [GeV].
@@ -340,7 +340,7 @@ datatypes :
     Author : "Placido Fernandez Declara, CERN"
     Members :
       - uint64_t cellID      //ID of the sensor that created this hit
-      - int32_t type                       //type of raw data hit, either one of edm4hep::TPCHIT, edm4hep::SIMTRACKERHIT - see collection parameters "TrackerHitTypeNames" and "TrackerHitTypeValues".
+      - int32_t type                       //type of raw data hit, either one of edm4hep::TrackerRawData, edm4hep::SIMTRACKERHIT - see collection parameters "TrackerHitTypeNames" and "TrackerHitTypeValues".
       - int32_t quality                    //quality bit flag of the hit.
       - float time                     //time of the hit.
       - float eDep                     //energy deposited on the hit [GeV].
@@ -355,8 +355,8 @@ datatypes :
       - edm4hep::ObjectID  rawHits     //raw data hits. Check getType to get actual data type.
 
 
- #----------  TPCHit
-  edm4hep::TPCHit:
+ #---------- TrackerRawData 
+  edm4hep::TrackerRawData:
     Description: "Time Projection Chamber Hit"
     Author : "F.Gaede, DESY"
     Members:

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -489,3 +489,75 @@ datatypes :
     OneToOneRelations:
      - edm4hep::ReconstructedParticle rec // reference to the reconstructed particle
      - edm4hep::Vertex vertex             // reference to the vertex
+
+
+  edm4hep::SimPrimaryIonizationCluster:
+    Description: "Simulated Primary Ionization"
+    Author : "Wenxing Fang, IHEP"
+    Members:
+      - unsigned long long cellID            //cell id.
+      - float time                           //the primary ionization's time in the lab frame in [ns].
+      - edm4hep::Vector3d position           //the primary ionization's position in [mm].
+      - int   type                           //type.
+    VectorMembers:
+       - unsigned long long electronCellID   //cell id.
+       - float electronTime                  //the time in the lab frame in [ns].
+       - edm4hep::Vector3d electronPosition  //the position in the lab frame [mm].
+       - float pulseTime                     //the pulse's time in the lab frame in [ns].
+       - float pulseAmplitude                //the pulse's amplitude.
+    OneToOneRelations:
+      - edm4hep::MCParticle MCParticle       //the particle that caused the ionizing collisions.
+
+  edm4hep::TrackerPulse:
+    Description: "Reconstructed Tracker Pulse"
+    Author : "Wenxing Fang, IHEP"
+    Members:
+       - unsigned long long cellID       //cell id. 
+       - float time                      //time.
+       - float charge                    //charge.
+       - int quality                     //quality.
+    VectorMembers:
+       - float covMatrix                 //covariance matrix of the charge(c) and time(t) measurements.
+    OneToOneRelations:
+      - edm4hep::TrackerData trackerData  //Optionaly, the TrackerData that has been used to create the pulse can be stored with the pulse.
+
+  edm4hep::RecIonizationCluster:
+    Description: "Reconstructed Ionization Cluster"
+    Author : "Wenxing Fang, IHEP"
+    Members:
+       - unsigned long long cellID  //cell id. 
+       - float significance         //significance.
+       - int type                   //type.
+    OneToManyRelations:
+       - edm4hep::TrackerPulse trackerPulse //the TrackerPulse used to create the ionization cluster.
+
+  edm4hep::TrackerData:
+    Description: "TrackerData"
+    Author : "Wenxing Fang, IHEP"
+    Members:
+       - unsigned long long cellID  //cell id. 
+       - float time                 //begin time.
+       - float interval             //interval of each sampling in [ns].
+    VectorMembers:
+       - float chargeValue          //charge value.
+
+
+  edm4hep::RecDndx:
+    Description : "dN/dx info of Track."
+    Author : "Wenxing Fang, IHEP"
+    Members :
+      - float dNdx                     //the reconstructed dNdx. 
+      - float dNdxError                //error on the dNdx.
+      - int particleType               //particle type, e(0),mu(1),pi(2),K(3),p(4).
+      - int type                       //type.
+    VectorMembers:
+      - unsigned long long  cellID     //cell id.
+      - float  N                       //number of reconstructed ionization cluster.
+      - float  edep                    //energy deposite.
+      - float  pathL                   //path length in [mm].
+      - float  chi                     //chi for e(0), mu(1), pi(2), K(3), p(4).
+      - float  dNdxExpect              //expected dNdx for e(0),mu(1), pi(2), K(3), p(4).
+      - float  dNdxSigma               //expected sigma of the dNdx for e(0),mu(1), pi(2), K(3), p(4).
+    OneToOneRelations:
+      - edm4hep::Track track           //the corresponding track.
+

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -108,17 +108,17 @@ components:
         - float error  // error on the value of the quantity
 
 
-    # Hypothesis for 5 particle types 
+    # Hypothesis for 5 particle types
     edm4hep::Hypothesis:
       Members:
         - float chi2       // chi2
         - float expected   // expected value
         - float sigma      // sigma value
 
-    # hit level data  
+    # hit level data
     edm4hep::HitLevelData:
       Members:
-        - uint64_t cellID  // cell id 
+        - uint64_t cellID  // cell id
         - uint32_t N       // number of reconstructed ionization cluster.
         - float  eDep        // energy deposit.
         - float  pathLength  // track path length in [mm].
@@ -355,7 +355,7 @@ datatypes :
       - edm4hep::ObjectID  rawHits     //raw data hits. Check getType to get actual data type.
 
 
- #---------- TrackerRawData 
+ #---------- TrackerRawData
   edm4hep::TrackerRawData:
     Description: "Time Projection Chamber Hit"
     Author : "F.Gaede, DESY"
@@ -525,12 +525,12 @@ datatypes :
     OneToOneRelations:
       - edm4hep::MCParticle MCParticle       //the particle that caused the ionizing collisions.
 
- #----------  TrackerPulse 
+ #----------  TrackerPulse
   edm4hep::TrackerPulse:
     Description: "Reconstructed Tracker Pulse"
     Author : "Wenxing Fang, IHEP"
     Members:
-       - uint64_t cellID                 //cell id. 
+       - uint64_t cellID                 //cell id.
        - float time                      //time.
        - float charge                    //charge.
        - int16_t quality                 //quality.
@@ -543,18 +543,18 @@ datatypes :
     Description: "Reconstructed Ionization Cluster"
     Author : "Wenxing Fang, IHEP"
     Members:
-       - uint64_t cellID            //cell id. 
+       - uint64_t cellID            //cell id.
        - float significance         //significance.
        - int16_t type               //type.
     OneToManyRelations:
        - edm4hep::TrackerPulse trackerPulse //the TrackerPulse used to create the ionization cluster.
 
- #----------  TrackerData 
+ #----------  TrackerData
   edm4hep::TrackerData:
     Description: "TrackerData"
     Author : "Wenxing Fang, IHEP"
     Members:
-       - uint64_t cellID            //cell id. 
+       - uint64_t cellID            //cell id.
        - float time                 //begin time.
        - float interval             //interval of each sampling in [ns].
     VectorMembers:

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -120,7 +120,7 @@ components:
       Members:
         - uint64_t cellID  // cell id
         - uint32_t N       // number of reconstructed ionization cluster.
-        - float eDep        // energy deposited [GeV].
+        - float eDep        // reconstructed energy deposit [GeV].
         - float pathLength  // track path length [mm].
 
 datatypes :
@@ -323,7 +323,7 @@ datatypes :
     Author : "F.Gaede, DESY"
     Members :
       - uint64_t cellID      //ID of the sensor that created this hit
-      - int32_t type                       //type of raw data hit, either one of edm4hep::TrackerRawData, edm4hep::SIMTRACKERHIT - see collection parameters "TrackerHitTypeNames" and "TrackerHitTypeValues".
+      - int32_t type                       //type of raw data hit, either one of edm4hep::RawTimeSeries, edm4hep::SIMTRACKERHIT - see collection parameters "TrackerHitTypeNames" and "TrackerHitTypeValues".
       - int32_t quality                    //quality bit flag of the hit.
       - float time                     //time of the hit.
       - float eDep                     //energy deposited on the hit [GeV].
@@ -340,7 +340,7 @@ datatypes :
     Author : "Placido Fernandez Declara, CERN"
     Members :
       - uint64_t cellID      //ID of the sensor that created this hit
-      - int32_t type                       //type of raw data hit, either one of edm4hep::TrackerRawData, edm4hep::SIMTRACKERHIT - see collection parameters "TrackerHitTypeNames" and "TrackerHitTypeValues".
+      - int32_t type                       //type of raw data hit, either one of edm4hep::RawTimeSeries, edm4hep::SIMTRACKERHIT - see collection parameters "TrackerHitTypeNames" and "TrackerHitTypeValues".
       - int32_t quality                    //quality bit flag of the hit.
       - float time                     //time of the hit.
       - float eDep                     //energy deposited on the hit [GeV].
@@ -355,17 +355,18 @@ datatypes :
       - edm4hep::ObjectID  rawHits     //raw data hits. Check getType to get actual data type.
 
 
- #---------- TrackerRawData
-  edm4hep::TrackerRawData:
-    Description: "Raw data of a tracker hit"
+ #---------- RawTimeSeries
+  edm4hep::RawTimeSeries:
+    Description: "Raw data of a detector readout"
     Author : "F.Gaede, DESY"
     Members:
        - uint64_t cellID  //detector specific cell id.
        - int32_t quality                //quality flag for the hit.
        - float time                 //time of the hit.
        - float charge               //integrated charge of the hit.
+       - float interval             //interval of each sampling [ns].
     VectorMembers:
-       - int32_t rawDataWords           //raw data (32-bit) word at i.
+       - int32_t adcCounts          //raw data (32-bit) word at i.
 
  #-------- Track
   edm4hep::Track:
@@ -536,7 +537,7 @@ datatypes :
        - int16_t quality                 //quality.
        - std::array<float,3> covMatrix   //lower triangle covariance matrix of the charge(c) and time(t) measurements.
     OneToOneRelations:
-      - edm4hep::TrackerData trackerData  //Optionally, the TrackerData that has been used to create the pulse can be stored with the pulse.
+      - edm4hep::TimeSeries timeSeries   //Optionally, the timeSeries that has been used to create the pulse can be stored with the pulse.
 
  #----------  RecIonizationCluster
   edm4hep::RecIonizationCluster:
@@ -549,16 +550,16 @@ datatypes :
     OneToManyRelations:
        - edm4hep::TrackerPulse trackerPulse //the TrackerPulse used to create the ionization cluster.
 
- #----------  TrackerData
-  edm4hep::TrackerData:
-    Description: "TrackerData"
+ #----------  TimeSeries
+  edm4hep::TimeSeries:
+    Description: "Calibrated Detector Data"
     Author : "Wenxing Fang, IHEP"
     Members:
        - uint64_t cellID            //cell id.
        - float time                 //begin time [ns].
        - float interval             //interval of each sampling [ns].
     VectorMembers:
-       - float chargeValue          //charge value [fC].
+       - float amplitude            //calibrated detector data.
 
 
   #-------------  RecDqdx

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -111,29 +111,17 @@ components:
     # Hypothesis for 5 particle types 
     edm4hep::Hypothesis:
       Members:
-        - float chi_e      // chi for electron
-        - float chi_mu     // chi for muon
-        - float chi_pi     // chi for pion
-        - float chi_k      // chi for kaon
-        - float chi_p      // chi for proton
-        - float expect_e   // expect value for electron
-        - float expect_mu  // expect value for muon
-        - float expect_pi  // expect value for pion
-        - float expect_k   // expect value for kaon
-        - float expect_p   // expect value for proton
-        - float sigma_e    // sigma  value for electron
-        - float sigma_mu   // sigma  value for muon
-        - float sigma_pi   // sigma  value for pion
-        - float sigma_k    // sigma  value for kaon
-        - float sigma_p    // sigma  value for proton
+        - float chi2       // chi2
+        - float expected   // expected value
+        - float sigma      // sigma value
 
     # hit level data  
     edm4hep::HitLevelData:
       Members:
         - uint64_t cellID  // cell id 
         - uint32_t N       // number of reconstructed ionization cluster.
-        - float  edep      // energy deposite.
-        - float  pathL     // track path length in [mm].
+        - float  eDep        // energy deposit.
+        - float  pathLength  // track path length in [mm].
 
 datatypes :
 
@@ -546,8 +534,7 @@ datatypes :
        - float time                      //time.
        - float charge                    //charge.
        - int16_t quality                 //quality.
-    VectorMembers:
-       - float covMatrix                 //covariance matrix of the charge(c) and time(t) measurements.
+       - std::array<float,3> covMatrix   //lower triangle covariance matrix of the charge(c) and time(t) measurements.
     OneToOneRelations:
       - edm4hep::TrackerData trackerData  //Optionaly, the TrackerData that has been used to create the pulse can be stored with the pulse.
 
@@ -583,7 +570,7 @@ datatypes :
       - float dNdxError                //error on the dNdx.
       - int16_t particleType           //particle type, e(0),mu(1),pi(2),K(3),p(4).
       - int16_t type                   //type.
-      - edm4hep::Hypothesis hypothesis  //5 particle hypothesis
+      - std::array<edm4hep::Hypothesis, 5> hypotheses //5 particle hypothesis
     VectorMembers:
       - edm4hep::HitLevelData hitData   //hit level data
     OneToOneRelations:

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -115,13 +115,13 @@ components:
         - float expected   // expected value
         - float sigma      // sigma value
 
-    # hit level data
+    # Reconstructed hit information
     edm4hep::HitLevelData:
       Members:
         - uint64_t cellID  // cell id
         - uint32_t N       // number of reconstructed ionization cluster.
-        - float  eDep        // energy deposit.
-        - float  pathLength  // track path length in [mm].
+        - float eDep        // energy deposited [GeV].
+        - float pathLength  // track path length [mm].
 
 datatypes :
 
@@ -357,7 +357,7 @@ datatypes :
 
  #---------- TrackerRawData
   edm4hep::TrackerRawData:
-    Description: "Time Projection Chamber Hit"
+    Description: "Raw data of a tracker hit"
     Author : "F.Gaede, DESY"
     Members:
        - uint64_t cellID  //detector specific cell id.
@@ -513,15 +513,15 @@ datatypes :
     Author : "Wenxing Fang, IHEP"
     Members:
       - uint64_t cellID                      //cell id.
-      - float time                           //the primary ionization's time in the lab frame in [ns].
-      - edm4hep::Vector3d position           //the primary ionization's position in [mm].
+      - float time                           //the primary ionization's time in the lab frame [ns].
+      - edm4hep::Vector3d position           //the primary ionization's position [mm].
       - int16_t type                         //type.
     VectorMembers:
        - uint64_t electronCellID             //cell id.
-       - float electronTime                  //the time in the lab frame in [ns].
+       - float electronTime                  //the time in the lab frame [ns].
        - edm4hep::Vector3d electronPosition  //the position in the lab frame [mm].
-       - float pulseTime                     //the pulse's time in the lab frame in [ns].
-       - float pulseAmplitude                //the pulse's amplitude.
+       - float pulseTime                     //the pulse's time in the lab frame [ns].
+       - float pulseAmplitude                //the pulse's amplitude [fC].
     OneToOneRelations:
       - edm4hep::MCParticle MCParticle       //the particle that caused the ionizing collisions.
 
@@ -531,12 +531,12 @@ datatypes :
     Author : "Wenxing Fang, IHEP"
     Members:
        - uint64_t cellID                 //cell id.
-       - float time                      //time.
-       - float charge                    //charge.
+       - float time                      //time [ns].
+       - float charge                    //charge [fC].
        - int16_t quality                 //quality.
        - std::array<float,3> covMatrix   //lower triangle covariance matrix of the charge(c) and time(t) measurements.
     OneToOneRelations:
-      - edm4hep::TrackerData trackerData  //Optionaly, the TrackerData that has been used to create the pulse can be stored with the pulse.
+      - edm4hep::TrackerData trackerData  //Optionally, the TrackerData that has been used to create the pulse can be stored with the pulse.
 
  #----------  RecIonizationCluster
   edm4hep::RecIonizationCluster:
@@ -555,15 +555,15 @@ datatypes :
     Author : "Wenxing Fang, IHEP"
     Members:
        - uint64_t cellID            //cell id.
-       - float time                 //begin time.
-       - float interval             //interval of each sampling in [ns].
+       - float time                 //begin time [ns].
+       - float interval             //interval of each sampling [ns].
     VectorMembers:
-       - float chargeValue          //charge value.
+       - float chargeValue          //charge value [fC].
 
 
   #-------------  RecDqdx
   edm4hep::RecDqdx:
-    Description : "dN/dx or dEdx info of Track."
+    Description : "dN/dx or dE/dx info of Track."
     Author : "Wenxing Fang, IHEP"
     Members :
       - edm4hep::Quantity dQdx         //the reconstructed dEdx or dNdx and its error

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -107,6 +107,34 @@ components:
         - float value  // value of the quantity
         - float error  // error on the value of the quantity
 
+
+    # Hypothesis for 5 particle types 
+    edm4hep::Hypothesis:
+      Members:
+        - float chi_e      // chi for electron
+        - float chi_mu     // chi for muon
+        - float chi_pi     // chi for pion
+        - float chi_k      // chi for kaon
+        - float chi_p      // chi for proton
+        - float expect_e   // expect value for electron
+        - float expect_mu  // expect value for muon
+        - float expect_pi  // expect value for pion
+        - float expect_k   // expect value for kaon
+        - float expect_p   // expect value for proton
+        - float sigma_e    // sigma  value for electron
+        - float sigma_mu   // sigma  value for muon
+        - float sigma_pi   // sigma  value for pion
+        - float sigma_k    // sigma  value for kaon
+        - float sigma_p    // sigma  value for proton
+
+    # hit level data  
+    edm4hep::HitLevelData:
+      Members:
+        - uint64_t cellID  // cell id 
+        - uint32_t N       // number of reconstructed ionization cluster.
+        - float  edep      // energy deposite.
+        - float  pathL     // track path length in [mm].
+
 datatypes :
 
 
@@ -491,16 +519,17 @@ datatypes :
      - edm4hep::Vertex vertex             // reference to the vertex
 
 
+  #----------- SimPrimaryIonizationCluster
   edm4hep::SimPrimaryIonizationCluster:
     Description: "Simulated Primary Ionization"
     Author : "Wenxing Fang, IHEP"
     Members:
-      - unsigned long long cellID            //cell id.
+      - uint64_t cellID                      //cell id.
       - float time                           //the primary ionization's time in the lab frame in [ns].
       - edm4hep::Vector3d position           //the primary ionization's position in [mm].
-      - int   type                           //type.
+      - int16_t type                         //type.
     VectorMembers:
-       - unsigned long long electronCellID   //cell id.
+       - uint64_t electronCellID             //cell id.
        - float electronTime                  //the time in the lab frame in [ns].
        - edm4hep::Vector3d electronPosition  //the position in the lab frame [mm].
        - float pulseTime                     //the pulse's time in the lab frame in [ns].
@@ -508,56 +537,54 @@ datatypes :
     OneToOneRelations:
       - edm4hep::MCParticle MCParticle       //the particle that caused the ionizing collisions.
 
+ #----------  TrackerPulse 
   edm4hep::TrackerPulse:
     Description: "Reconstructed Tracker Pulse"
     Author : "Wenxing Fang, IHEP"
     Members:
-       - unsigned long long cellID       //cell id. 
+       - uint64_t cellID                 //cell id. 
        - float time                      //time.
        - float charge                    //charge.
-       - int quality                     //quality.
+       - int16_t quality                 //quality.
     VectorMembers:
        - float covMatrix                 //covariance matrix of the charge(c) and time(t) measurements.
     OneToOneRelations:
       - edm4hep::TrackerData trackerData  //Optionaly, the TrackerData that has been used to create the pulse can be stored with the pulse.
 
+ #----------  RecIonizationCluster
   edm4hep::RecIonizationCluster:
     Description: "Reconstructed Ionization Cluster"
     Author : "Wenxing Fang, IHEP"
     Members:
-       - unsigned long long cellID  //cell id. 
+       - uint64_t cellID            //cell id. 
        - float significance         //significance.
-       - int type                   //type.
+       - int16_t type               //type.
     OneToManyRelations:
        - edm4hep::TrackerPulse trackerPulse //the TrackerPulse used to create the ionization cluster.
 
+ #----------  TrackerData 
   edm4hep::TrackerData:
     Description: "TrackerData"
     Author : "Wenxing Fang, IHEP"
     Members:
-       - unsigned long long cellID  //cell id. 
+       - uint64_t cellID            //cell id. 
        - float time                 //begin time.
        - float interval             //interval of each sampling in [ns].
     VectorMembers:
        - float chargeValue          //charge value.
 
 
+  #-------------  RecDndx
   edm4hep::RecDndx:
     Description : "dN/dx info of Track."
     Author : "Wenxing Fang, IHEP"
     Members :
       - float dNdx                     //the reconstructed dNdx. 
       - float dNdxError                //error on the dNdx.
-      - int particleType               //particle type, e(0),mu(1),pi(2),K(3),p(4).
-      - int type                       //type.
+      - int16_t particleType           //particle type, e(0),mu(1),pi(2),K(3),p(4).
+      - int16_t type                   //type.
+      - edm4hep::Hypothesis hypothesis  //5 particle hypothesis
     VectorMembers:
-      - unsigned long long  cellID     //cell id.
-      - float  N                       //number of reconstructed ionization cluster.
-      - float  edep                    //energy deposite.
-      - float  pathL                   //path length in [mm].
-      - float  chi                     //chi for e(0), mu(1), pi(2), K(3), p(4).
-      - float  dNdxExpect              //expected dNdx for e(0),mu(1), pi(2), K(3), p(4).
-      - float  dNdxSigma               //expected sigma of the dNdx for e(0),mu(1), pi(2), K(3), p(4).
+      - edm4hep::HitLevelData hitData   //hit level data
     OneToOneRelations:
       - edm4hep::Track track           //the corresponding track.
-

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -561,13 +561,12 @@ datatypes :
        - float chargeValue          //charge value.
 
 
-  #-------------  RecDndx
-  edm4hep::RecDndx:
-    Description : "dN/dx info of Track."
+  #-------------  RecDqdx
+  edm4hep::RecDqdx:
+    Description : "dN/dx or dEdx info of Track."
     Author : "Wenxing Fang, IHEP"
     Members :
-      - float dNdx                     //the reconstructed dNdx. 
-      - float dNdxError                //error on the dNdx.
+      - edm4hep::Quantity dQdx         //the reconstructed dEdx or dNdx and its error
       - int16_t particleType           //particle type, e(0),mu(1),pi(2),K(3),p(4).
       - int16_t type                   //type.
       - std::array<edm4hep::Hypothesis, 5> hypotheses //5 particle hypothesis

--- a/test/read_events.h
+++ b/test/read_events.h
@@ -6,7 +6,7 @@
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/SimCalorimeterHitCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
-#include "edm4hep/TPCHitCollection.h"
+#include "edm4hep/TrackerRawDataCollection.h"
 #include "edm4hep/TrackerHitPlaneCollection.h"
 
 // podio specific includes
@@ -23,7 +23,7 @@ void processEvent(const podio::Frame& event, bool verboser, unsigned eventNum) {
   auto& sths = event.get<edm4hep::SimTrackerHitCollection>("SimTrackerHits");
   auto& schs = event.get<edm4hep::SimCalorimeterHitCollection>("SimCalorimeterHits");
   auto& sccons = event.get<edm4hep::CaloHitContributionCollection>("SimCalorimeterHitContributions");
-  auto& tpchs = event.get<edm4hep::TPCHitCollection>("TPCHits");
+  auto& tpchs = event.get<edm4hep::RawTimeSeries>("RawTimeSeries");
   auto& thps = event.get<edm4hep::TrackerHitPlaneCollection>("TrackerHitPlanes");
 
   if (mcps.isValid()) {

--- a/test/read_events.h
+++ b/test/read_events.h
@@ -18,23 +18,13 @@
 #include <iostream>
 #include <vector>
 
-<<<<<<< HEAD
 void processEvent(const podio::Frame& event, bool verboser, unsigned eventNum) {
   auto& mcps = event.get<edm4hep::MCParticleCollection>("MCParticles");
   auto& sths = event.get<edm4hep::SimTrackerHitCollection>("SimTrackerHits");
   auto& schs = event.get<edm4hep::SimCalorimeterHitCollection>("SimCalorimeterHits");
   auto& sccons = event.get<edm4hep::CaloHitContributionCollection>("SimCalorimeterHitContributions");
-  auto& tpchs = event.get<edm4hep::RawTimeSeries>("RawTimeSeries");
+  auto& tpchs = event.get<edm4hep::RawTimeSeriesCollection>("TPCHits");
   auto& thps = event.get<edm4hep::TrackerHitPlaneCollection>("TrackerHitPlanes");
-=======
-void processEvent(podio::EventStore& store, bool verboser, unsigned eventNum) {
-  auto& mcps = store.get<edm4hep::MCParticleCollection>("MCParticles");
-  auto& sths = store.get<edm4hep::SimTrackerHitCollection>("SimTrackerHits");
-  auto& schs = store.get<edm4hep::SimCalorimeterHitCollection>("SimCalorimeterHits");
-  auto& sccons = store.get<edm4hep::CaloHitContributionCollection>("SimCalorimeterHitContributions");
-  auto& tpchs = store.get<edm4hep::TPCHitCollection>("TPCHits");
-  auto& thps = store.get<edm4hep::TrackerHitPlaneCollection>("TrackerHitPlanes");
->>>>>>> d14f948 (update TrackerRawData to RawTimeSeries)
 
   if (mcps.isValid()) {
 

--- a/test/read_events.h
+++ b/test/read_events.h
@@ -4,10 +4,10 @@
 // test data model
 #include "edm4hep/CaloHitContributionCollection.h"
 #include "edm4hep/MCParticleCollection.h"
+#include "edm4hep/RawTimeSeriesCollection.h"
 #include "edm4hep/SimCalorimeterHitCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
 #include "edm4hep/TrackerHitPlaneCollection.h"
-#include "edm4hep/RawTimeSeriesCollection.h"
 
 // podio specific includes
 #include "podio/Frame.h"

--- a/test/read_events.h
+++ b/test/read_events.h
@@ -6,8 +6,8 @@
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/SimCalorimeterHitCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
-#include "edm4hep/TrackerRawDataCollection.h"
 #include "edm4hep/TrackerHitPlaneCollection.h"
+#include "edm4hep/TrackerRawDataCollection.h"
 
 // podio specific includes
 #include "podio/Frame.h"

--- a/test/read_events.h
+++ b/test/read_events.h
@@ -32,7 +32,7 @@ void processEvent(podio::EventStore& store, bool verboser, unsigned eventNum) {
   auto& sths = store.get<edm4hep::SimTrackerHitCollection>("SimTrackerHits");
   auto& schs = store.get<edm4hep::SimCalorimeterHitCollection>("SimCalorimeterHits");
   auto& sccons = store.get<edm4hep::CaloHitContributionCollection>("SimCalorimeterHitContributions");
-  auto& tpchs = store.get<edm4hep::RawTimeSeriesCollection>("TPCHits");
+  auto& tpchs = store.get<edm4hep::TPCHitCollection>("TPCHits");
   auto& thps = store.get<edm4hep::TrackerHitPlaneCollection>("TrackerHitPlanes");
 >>>>>>> d14f948 (update TrackerRawData to RawTimeSeries)
 

--- a/test/read_events.h
+++ b/test/read_events.h
@@ -7,7 +7,7 @@
 #include "edm4hep/SimCalorimeterHitCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
 #include "edm4hep/TrackerHitPlaneCollection.h"
-#include "edm4hep/TrackerRawDataCollection.h"
+#include "edm4hep/RawTimeSeriesCollection.h"
 
 // podio specific includes
 #include "podio/Frame.h"
@@ -18,6 +18,7 @@
 #include <iostream>
 #include <vector>
 
+<<<<<<< HEAD
 void processEvent(const podio::Frame& event, bool verboser, unsigned eventNum) {
   auto& mcps = event.get<edm4hep::MCParticleCollection>("MCParticles");
   auto& sths = event.get<edm4hep::SimTrackerHitCollection>("SimTrackerHits");
@@ -25,6 +26,15 @@ void processEvent(const podio::Frame& event, bool verboser, unsigned eventNum) {
   auto& sccons = event.get<edm4hep::CaloHitContributionCollection>("SimCalorimeterHitContributions");
   auto& tpchs = event.get<edm4hep::RawTimeSeries>("RawTimeSeries");
   auto& thps = event.get<edm4hep::TrackerHitPlaneCollection>("TrackerHitPlanes");
+=======
+void processEvent(podio::EventStore& store, bool verboser, unsigned eventNum) {
+  auto& mcps = store.get<edm4hep::MCParticleCollection>("MCParticles");
+  auto& sths = store.get<edm4hep::SimTrackerHitCollection>("SimTrackerHits");
+  auto& schs = store.get<edm4hep::SimCalorimeterHitCollection>("SimCalorimeterHits");
+  auto& sccons = store.get<edm4hep::CaloHitContributionCollection>("SimCalorimeterHitContributions");
+  auto& tpchs = store.get<edm4hep::RawTimeSeriesCollection>("TPCHits");
+  auto& thps = store.get<edm4hep::TrackerHitPlaneCollection>("TrackerHitPlanes");
+>>>>>>> d14f948 (update TrackerRawData to RawTimeSeries)
 
   if (mcps.isValid()) {
 

--- a/test/write_events.h
+++ b/test/write_events.h
@@ -6,8 +6,8 @@
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/SimCalorimeterHitCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
-#include "edm4hep/TrackerRawDataCollection.h"
 #include "edm4hep/TrackerHitPlaneCollection.h"
+#include "edm4hep/TrackerRawDataCollection.h"
 
 // STL
 #include <iostream>

--- a/test/write_events.h
+++ b/test/write_events.h
@@ -4,10 +4,10 @@
 // Data model
 #include "edm4hep/CaloHitContributionCollection.h"
 #include "edm4hep/MCParticleCollection.h"
+#include "edm4hep/RawTimeSeriesCollection.h"
 #include "edm4hep/SimCalorimeterHitCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
 #include "edm4hep/TrackerHitPlaneCollection.h"
-#include "edm4hep/RawTimeSeriesCollection.h"
 
 // STL
 #include <iostream>

--- a/test/write_events.h
+++ b/test/write_events.h
@@ -6,7 +6,7 @@
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/SimCalorimeterHitCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
-#include "edm4hep/TPCHitCollection.h"
+#include "edm4hep/TrackerRawDataCollection.h"
 #include "edm4hep/TrackerHitPlaneCollection.h"
 
 // STL

--- a/test/write_events.h
+++ b/test/write_events.h
@@ -7,7 +7,7 @@
 #include "edm4hep/SimCalorimeterHitCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
 #include "edm4hep/TrackerHitPlaneCollection.h"
-#include "edm4hep/TrackerRawDataCollection.h"
+#include "edm4hep/RawTimeSeriesCollection.h"
 
 // STL
 #include <iostream>

--- a/test/write_events.h
+++ b/test/write_events.h
@@ -186,8 +186,8 @@ void write(std::string outfilename) {
     event.put(std::move(sccons), "SimCalorimeterHitContributions");
 
     //===============================================================================
-    // write some TPCHits:
-    auto tpchs = edm4hep::TPCHitCollection();
+    // write some RawTimeSeries:
+    auto tpchs = edm4hep::RawTimeSeriesCollection();
     int ntpch = 5;
     for (int j = 0; j < ntpch; ++j) {
       auto tpch1 = tpchs.create();


### PR DESCRIPTION

BEGINRELEASENOTES
- Extend for drift chamber and TPC study
- The extended EDMs are tested within CEPCSW, and it works well
- The extended edm4hep::TrackerPulse and edm4hep::TrackerData are similar to what they are in ILC TPC

ENDRELEASENOTES