### PR TITLE
Make building of json support dependent on nlohmann_json version

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,20 +1,22 @@
 list( APPEND CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" )
 
-add_executable(edm4hep2json src/edm4hep2json.cxx)
-
 find_package(nlohmann_json 3.10)
+if (nlohmann_json_FOUND)
+  add_executable(edm4hep2json src/edm4hep2json.cxx)
 
-set(EDM4HEP_SET_RPATH TRUE)
+  set(EDM4HEP_SET_RPATH TRUE)
 
-target_compile_definitions(edm4hep2json PUBLIC PODIO_JSON_OUTPUT)
-target_include_directories(edm4hep2json
-                           PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+  target_compile_definitions(edm4hep2json PUBLIC PODIO_JSON_OUTPUT)
+  target_include_directories(edm4hep2json
+                             PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-target_link_libraries(edm4hep2json PUBLIC ROOT::Core
-                                          ROOT::Tree
-                                          podio::podio
-                                          podio::podioRootIO
-                                          edm4hep
-                                          nlohmann_json::nlohmann_json)
+  target_link_libraries(edm4hep2json PUBLIC ROOT::Core
+                                            ROOT::Tree
+                                            podio::podio
+                                            podio::podioRootIO
+                                            edm4hep
+                                            nlohmann_json::nlohmann_json)
 
-install(TARGETS edm4hep2json DESTINATION bin)
+  install(TARGETS edm4hep2json DESTINATION bin)
+
+endif()


### PR DESCRIPTION

BEGINRELEASENOTES
- Only build JSON support if a suitable version of nlohmann/json is found. This should fix a few issues in CI.

ENDRELEASENOTES