### PR TITLE
Correct spelling of EDM4hep on doxygen ref page

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -32,7 +32,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "EDM4Hep"
+PROJECT_NAME           = "EDM4hep"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version


### PR DESCRIPTION

BEGINRELEASENOTES
- Use agreed upon spelling of lower case "hep" on doxygen ref page header.

ENDRELEASENOTES