### PR TITLE
Change in edm4hep.yaml for consistent naming

### DIFF
--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -381,7 +381,7 @@ datatypes :
       - float dEdxError                  //error of dEdx.
       - float radiusOfInnermostHit       //radius of the innermost hit that has been used in the track fit
     VectorMembers:
-      - int32_t subDetectorHitNumbers        //number of hits in particular subdetectors.Check/set collection variable TrackSubdetectorNames for decoding the indices
+      - int32_t subdetectorHitNumbers        //number of hits in particular subdetectors.Check/set collection variable TrackSubdetectorNames for decoding the indices
       - edm4hep::TrackState trackStates  //track states
       - edm4hep::Quantity dxQuantities // different measurements of dx quantities
     OneToManyRelations:

--- a/test/utils/CMakeLists.txt
+++ b/test/utils/CMakeLists.txt
@@ -23,5 +23,6 @@ catch_discover_tests(unittests)
 add_test(NAME pyunittests COMMAND python -m unittest discover -s ${CMAKE_CURRENT_LIST_DIR})
 set_property(TEST pyunittests
   PROPERTY ENVIRONMENT
-  LD_LIBRARY_PATH=$<TARGET_FILE_DIR:edm4hep>:$ENV{LD_LIBRARY_PATH}
+  LD_LIBRARY_PATH=$<TARGET_FILE_DIR:edm4hep>:$<TARGET_FILE_DIR:podio::podio>:$<$<TARGET_EXISTS:edm4hepRDF>:$<TARGET_FILE_DIR:edm4hepRDF>:>$<TARGET_FILE_DIR:ROOT::Core>:$ENV{LD_LIBRARY_PATH}
+      ROOT_INCLUDE_PATH=${PROJECT_SOURCE_DIR}/edm4hep:${PROJECT_SOURCE_DIR}/utils/include:$ENV{ROOT_INCLUDE_PATH}
   )


### PR DESCRIPTION
BEGINRELEASENOTES
- Changed the name of one VectorMember of edm4hep::track from subDetectorHitNumbers to subdetectorHitNumbers to be consistent with other spellings of the word subdetector in the yaml file and in LCIO.

ENDRELEASENOTES