### PR TITLE
Require a version of nlohmann_json that actually works

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE
               ${CMAKE_CURRENT_SOURCE_DIR}/NOTICE
               DESTINATION ${CMAKE_INSTALL_DOCDIR})
 
-find_package(nlohmann_json 3.10)
+find_package(nlohmann_json 3.10.5)
 
 add_subdirectory(edm4hep)
 add_subdirectory(utils)


### PR DESCRIPTION

BEGINRELEASENOTES
- Make the minimum nlohmann json version 3.10.5, as other patch releases of the 3.10 series, seem to not compile. Fixes #181 

ENDRELEASENOTES