### PR TITLE
Add a configuration file for the podio visualization tool

### DIFF
--- a/utils/README.md
+++ b/utils/README.md
@@ -11,3 +11,8 @@ The `p4` function can be used to get the 4 momentum vector from a given particle
 Since EDM4hep does not guarantee any internal consistency of the 4 momentum state it is possible to use either the mass or the energy of a particle to get the 4 momentum. Additionally it is also possible pass in user defined values for the mass or the energy.
 
 For some example usages see the [unit tests](/test/utils/test_kinematics.cpp)
+
+## `graph-conf.yaml`
+
+This is a configuration file to be used with the podio visualization tool for
+clustering data types into categories and a better looking graph.

--- a/utils/graph-conf.yaml
+++ b/utils/graph-conf.yaml
@@ -1,0 +1,18 @@
+Reconstruction & Analysis:
+  - edm4hep::Cluster
+  - edm4hep::ParticleID
+  - edm4hep::Track
+  - edm4hep::Vertex
+  - edm4hep::ReconstructedParticle
+Digitization:
+  - edm4hep::CalorimeterHit
+  - edm4hep::TrackerHit
+  - edm4hep::TrackerHitPlane
+Raw Data:
+  - edm4hep::RawCalorimeterHit
+  - edm4hep::TPCHit
+Monte Carlo:
+  - edm4hep::SimCalorimeterHit
+  - edm4hep::CaloHitContribution
+  - edm4hep::MCParticle
+  - edm4hep::SimTrackerHit


### PR DESCRIPTION
BEGINRELEASENOTES
- Add a configuration file for the new podio visualization tool

ENDRELEASENOTES

To reproduce the last diagram shown in https://github.com/AIDASoft/podio/pull/377 (i.e. with clustering the data types into categories) it is necessary to have a configuration file that defines which groups exists. While it can be in either place I believe it should be here so changes in the data types such as renames are more likely to be applied also to this configuration file.

As a reminder, to get the diagram run (once it's merged and installed) `python path_to_podio/tools/podio-vis path_to_EDM4hep/edm4hep.yaml --graph-conf path_to_EDM4hep/utils/graph-conf.yaml`

We can also agree on which Associations to remove to make the plot nicer which can be removed by adding

``` yaml
Filter:
  - datatype
```