### PR TITLE
Add schema_version to YAML definition

### DIFF
--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -3,6 +3,7 @@ options:
   getSyntax: True
   exposePODMembers: False
   includeSubfolder: True
+  schema_version: 1
 
 components:
 

--- a/test/downstream-project-cmake-test/edm4dis.yaml
+++ b/test/downstream-project-cmake-test/edm4dis.yaml
@@ -5,6 +5,7 @@ options :
   # should POD members be exposed with getters/setters in classes that have them as members?
   exposePODMembers: False
   includeSubfolder: True
+  schema_version: 2
 
 datatypes:
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Add `schema_version` to YAML definition now that podio has limited support (see AIDASoft/podio#341)

ENDRELEASENOTES