### PR TITLE
Include sstream header explicitly

### DIFF
--- a/tools/include/edm4hep2json.hxx
+++ b/tools/include/edm4hep2json.hxx
@@ -28,6 +28,7 @@
 #include <exception>
 #include <fstream>
 #include <iostream>
+#include <sstream>
 #include <vector>
 
 nlohmann::json processEvent(const podio::Frame& frame, std::vector<std::string>& collList, bool verboser,


### PR DESCRIPTION
The header file uses it, but it's not included explicitly (and actually
fails to compile locally for me because of this).



BEGINRELEASENOTES
- Added string stream include in `edm4hep2json.hxx`

ENDRELEASENOTES