### PR TITLE
Remove root version check inside CMakeLists.txt

### DIFF
--- a/edm4hep/CMakeLists.txt
+++ b/edm4hep/CMakeLists.txt
@@ -36,8 +36,6 @@ install(FILES
   ../edm4hep.yaml
   DESTINATION "${CMAKE_INSTALL_DATADIR}/edm4hep" COMPONENT dev)
 
-if (${ROOT_VERSION} GREATER 6)
-  install(FILES
-      "${PROJECT_BINARY_DIR}/edm4hep/libedm4hepDict_rdict.pcm"
-      DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT dev)
-endif()
+install(FILES
+  "${PROJECT_BINARY_DIR}/edm4hep/libedm4hepDict_rdict.pcm"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT dev)


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove root version check inside CMakeLists.txt

ENDRELEASENOTES

since we require much newer than 6 to build, also in the spack recipe