### PR TITLE
Add /.cache/ to gitignore (tooling section)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ spack*
 /.clangd/
 /compile_commands.json
 *__pycache__*
+/.cache/


### PR DESCRIPTION

BEGINRELEASENOTES
- Update `.gitignore` to not pick up on newer directories of `clangd`

ENDRELEASENOTES