### PR TITLE
Add a OneToMany relation from TrackerHit to RecIonizationCluster

### DIFF
--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -333,6 +333,8 @@ datatypes:
       - std::array<float,6> covMatrix  //covariance of the position (x,y,z), stored as lower triangle matrix. i.e. cov(x,x) , cov(y,x) , cov(y,y) , cov(z,x) , cov(z,y) , cov(z,z)
     VectorMembers:
       - edm4hep::ObjectID  rawHits     //raw data hits. Check getType to get actual data type.
+    OneToManyRelations:
+      - edm4hep::RecIonizationCluster clusters //ionization clusters that were reconstructed in the cell
 
 
   #-------------  TrackerHitPlane


### PR DESCRIPTION
With the objects added in [PR#179](https://github.com/key4hep/EDM4hep/pull/179) for cluster counting algorithms, the only way to get the number of ionizations associated to a given `TrackerHit` is to do a matching by `cellID` which is quite inefficient. This PR proposes to add a link between `TrackerHit` and `RecIonizationCluster` to simplify the derivation of dN/dx.

BEGINRELEASENOTES
- Add a OneToMany relation from TrackerHit to RecIonizationCluster to allow us deriving the number of clusters associated to a TrackerHit without having to do a matching by cellID

ENDRELEASENOTES