### PR TITLE
Rename `CMAKE_BINARY_DIR` to `PROJECT_BINARY_DIR`

### DIFF
--- a/cmake/EDM4HEPUninstall.cmake
+++ b/cmake/EDM4HEPUninstall.cmake
@@ -33,14 +33,14 @@
 if (NOT TARGET uninstall)
     configure_file(
       "${CMAKE_CURRENT_LIST_DIR}/EDM4HEP_uninstall.cmake.in"
-      "${CMAKE_BINARY_DIR}/EDM4HEP_uninstall.cmake"
+      "${PROJECT_BINARY_DIR}/EDM4HEP_uninstall.cmake"
         IMMEDIATE
         @ONLY
     )
 
     add_custom_target(uninstall
-      COMMAND "${CMAKE_COMMAND}" -P "${CMAKE_BINARY_DIR}/EDM4HEP_uninstall.cmake"
-      WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+      COMMAND "${CMAKE_COMMAND}" -P "${PROJECT_BINARY_DIR}/EDM4HEP_uninstall.cmake"
+      WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
     )
 endif()
 

--- a/cmake/EDM4HEP_uninstall.cmake.in
+++ b/cmake/EDM4HEP_uninstall.cmake.in
@@ -1,8 +1,8 @@
-if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
-    message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
+if(NOT EXISTS "@PROJECT_BINARY_DIR@/install_manifest.txt")
+    message(FATAL_ERROR "Cannot find install manifest: @PROJECT_BINARY_DIR@/install_manifest.txt")
 endif()
 
-file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
+file(READ "@PROJECT_BINARY_DIR@/install_manifest.txt" files)
 string(REGEX REPLACE "\n" ";" files "${files}")
 foreach(file ${files})
     message(STATUS "Uninstalling $ENV{DESTDIR}${file}")

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = @CMAKE_BINARY_DIR@/doxygen
+OUTPUT_DIRECTORY       = @PROJECT_BINARY_DIR@/doxygen
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -144,7 +144,7 @@ FULL_PATH_NAMES        = YES
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        = @PROJECT_SOURCE_DIR@ @CMAKE_BINARY_DIR@
+STRIP_FROM_PATH        = @PROJECT_SOURCE_DIR@ @PROJECT_BINARY_DIR@
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which
@@ -153,7 +153,7 @@ STRIP_FROM_PATH        = @PROJECT_SOURCE_DIR@ @CMAKE_BINARY_DIR@
 # specify the list of include paths that are normally passed to the compiler
 # using the -I flag.
 
-STRIP_FROM_INC_PATH    = @DOXYGEN_INCLUDE_DIRS@ @CMAKE_BINARY_DIR@/include
+STRIP_FROM_INC_PATH    = @DOXYGEN_INCLUDE_DIRS@ @PROJECT_BINARY_DIR@/include
 
 # If the SHORT_NAMES tag is set to YES, doxygen will generate much shorter (but
 # less readable) file names. This can be useful is your file systems doesn't
@@ -731,7 +731,7 @@ WARN_FORMAT            = "$file:$line: $text"
 # messages should be written. If left blank the output is written to standard
 # error (stderr).
 
-WARN_LOGFILE           = @CMAKE_BINARY_DIR@/doxygen-warnings.log
+WARN_LOGFILE           = @PROJECT_BINARY_DIR@/doxygen-warnings.log
 
 #---------------------------------------------------------------------------
 # Configuration options related to the input files
@@ -744,7 +744,7 @@ WARN_LOGFILE           = @CMAKE_BINARY_DIR@/doxygen-warnings.log
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = @PROJECT_SOURCE_DIR@
-INPUT                 += @CMAKE_BINARY_DIR@/include
+INPUT                 += @PROJECT_BINARY_DIR@/include
 INPUT                 += @CMAKE_CURRENT_BINARY_DIR@
 
 # This tag can be used to specify the character encoding of the source files
@@ -801,7 +801,7 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       = */podio/* */TrickTrack/*  */tests/* */dict/* */cmake/* @CMAKE_BINARY_DIR@
+EXCLUDE_PATTERNS       = */podio/* */TrickTrack/*  */tests/* */dict/* */cmake/* @PROJECT_BINARY_DIR@
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the


### PR DESCRIPTION
BEGINRELEASENOTES
- Rename `CMAKE_BINARY_DIR` to `PROJECT_BINARY_DIR`

ENDRELEASENOTES

Continuation of https://github.com/key4hep/EDM4hep/pull/214 but now correctly changing `CMAKE_BINARY_DIR`