### PR TITLE
Make aliases global

### DIFF
--- a/edm4hep/CMakeLists.txt
+++ b/edm4hep/CMakeLists.txt
@@ -4,6 +4,8 @@
 PODIO_GENERATE_DATAMODEL(edm4hep ../edm4hep.yaml headers sources IO_BACKEND_HANDLERS ${PODIO_IO_HANDLERS})
 
 PODIO_ADD_DATAMODEL_CORE_LIB(edm4hep "${headers}" "${sources}")
+add_library(edm4hep::edm4hep ALIAS edm4hep)
+set_target_properties(edm4hep PROPERTIES ALIAS_GLOBAL true)
 
 if (nlohmann_json_FOUND)
   target_compile_definitions(edm4hep PUBLIC PODIO_JSON_OUTPUT)
@@ -12,6 +14,7 @@ endif()
 
 PODIO_ADD_ROOT_IO_DICT(edm4hepDict edm4hep "${headers}" src/selection.xml)
 add_library(edm4hep::edm4hepDict ALIAS edm4hepDict )
+set_target_properties(edm4hep PROPERTIES ALIAS_GLOBAL true)
 
 list(APPEND EDM4HEP_INSTALL_LIBS edm4hep edm4hepDict)
 

--- a/edm4hep/CMakeLists.txt
+++ b/edm4hep/CMakeLists.txt
@@ -4,7 +4,7 @@
 PODIO_GENERATE_DATAMODEL(edm4hep ../edm4hep.yaml headers sources IO_BACKEND_HANDLERS ${PODIO_IO_HANDLERS})
 
 PODIO_ADD_DATAMODEL_CORE_LIB(edm4hep "${headers}" "${sources}")
-add_library(edm4hep::edm4hep ALIAS edm4hep)
+add_library(EDM4HEP::edm4hep ALIAS edm4hep)
 set_target_properties(edm4hep PROPERTIES ALIAS_GLOBAL true)
 
 if (nlohmann_json_FOUND)
@@ -13,7 +13,7 @@ if (nlohmann_json_FOUND)
 endif()
 
 PODIO_ADD_ROOT_IO_DICT(edm4hepDict edm4hep "${headers}" src/selection.xml)
-add_library(edm4hep::edm4hepDict ALIAS edm4hepDict )
+add_library(EDM4HEP::edm4hepDict ALIAS edm4hepDict )
 set_target_properties(edm4hep PROPERTIES ALIAS_GLOBAL true)
 
 list(APPEND EDM4HEP_INSTALL_LIBS edm4hep edm4hepDict)


### PR DESCRIPTION
BEGINRELEASENOTES
-  Make cmake aliases global to allow the aliases to be seen by other subdirectories at configure time
-  Change cmake aliases used within EDM4hep to `EDM4HEP::` instead of `edm4hep::` since the namespace for external use is `EDM4HEP`, for consistency

ENDRELEASENOTES