### PR TITLE
prepare edm4hep for reflex to rootcling migration of PODIO

### DIFF
--- a/edm4hep/CMakeLists.txt
+++ b/edm4hep/CMakeLists.txt
@@ -12,7 +12,7 @@ if (nlohmann_json_FOUND)
   target_link_libraries(edm4hep PUBLIC nlohmann_json::nlohmann_json)
 endif()
 
-PODIO_ADD_ROOT_IO_DICT(edm4hepDict edm4hep "${headers}" src/selection.xml)
+PODIO_ADD_ROOT_IO_DICT(edm4hepDict edm4hep "${headers}" edm4hep/LinkDef.h)
 add_library(EDM4HEP::edm4hepDict ALIAS edm4hepDict )
 set_target_properties(edm4hep PROPERTIES ALIAS_GLOBAL true)
 
@@ -32,7 +32,7 @@ install(TARGETS ${EDM4HEP_INSTALL_LIBS}
   COMPONENT dev)
 
 install(FILES
-  "${PROJECT_BINARY_DIR}/edm4hep/edm4hepDictDict.rootmap"
+  "${PROJECT_BINARY_DIR}/edm4hep/libedm4hep.rootmap"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT dev)
 
 install(FILES
@@ -40,5 +40,5 @@ install(FILES
   DESTINATION "${CMAKE_INSTALL_DATADIR}/edm4hep" COMPONENT dev)
 
 install(FILES
-  "${PROJECT_BINARY_DIR}/edm4hep/libedm4hepDict_rdict.pcm"
+  "${PROJECT_BINARY_DIR}/edm4hep/libedm4hep_rdict.pcm"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT dev)

--- a/python/edm4hep/__init__.py
+++ b/python/edm4hep/__init__.py
@@ -5,7 +5,7 @@ from .__version__ import __version__
 import ROOT
 res = ROOT.gSystem.Load('libedm4hep.so')
 if res < 0:
-    raise RuntimeError('Failed to load libedm4hepDict.so')
+    raise RuntimeError('Failed to load libedm4hep.so')
 
 res = ROOT.gSystem.Load('libedm4hepRDF.so')
 if res < 0:

--- a/python/edm4hep/__init__.py
+++ b/python/edm4hep/__init__.py
@@ -3,7 +3,7 @@ import sys
 
 from .__version__ import __version__
 import ROOT
-res = ROOT.gSystem.Load('libedm4hepDict.so')
+res = ROOT.gSystem.Load('libedm4hep.so')
 if res < 0:
     raise RuntimeError('Failed to load libedm4hepDict.so')
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Move edm4hep to use rootcling instead of reflex for dictionaries (following PODIO)
ENDRELEASENOTES

This change depends on https://github.com/AIDASoft/podio/pull/460