### PR TITLE
CI: use same lcg stacks as podio

### DIFF
--- a/.github/workflows/lcg_linux_with_podio.yml
+++ b/.github/workflows/lcg_linux_with_podio.yml
@@ -8,10 +8,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        LCG: ["LCG_99/x86_64-centos7-gcc10-opt",
-              "dev3/x86_64-centos7-clang12-opt",
-              "dev4/x86_64-centos7-gcc11-opt",
-              "dev4/x86_64-centos7-clang12-opt"]
+        LCG: ["dev3/x86_64-el9-clang16-opt",
+              "dev4/x86_64-el9-clang16-opt"]
+        CXX_STANDARD: [20]
+        include:
+          - LCG: "dev4/x86_64-centos7-gcc11-opt"
+            CXX_STANDARD: 17
+          - LCG: "LCG_102/x86_64-centos7-clang12-opt"
+            CXX_STANDARD: 17
+          - LCG: "LCG_102/x86_64-centos8-gcc11-opt"
+            CXX_STANDARD: 17
     steps:
     - uses: actions/checkout@v3
     - uses: cvmfs-contrib/github-action-cvmfs@v3
@@ -26,7 +32,7 @@ jobs:
           cd podio
           mkdir build install
           cd build
-          cmake .. -DCMAKE_CXX_STANDARD=17 \
+          cmake .. -DCMAKE_CXX_STANDARD=${{ matrix.CXX_STANDARD }} \
             -DENABLE_SIO=ON \
             -DBUILD_TESTING=OFF \
             -DCMAKE_INSTALL_PREFIX=$(pwd)/../install \
@@ -44,7 +50,7 @@ jobs:
           echo "Building edm4hep"
           mkdir build install
           cd build
-          cmake .. -DCMAKE_CXX_STANDARD=17 \
+          cmake .. -DCMAKE_CXX_STANDARD=${{ matrix.CXX_STANDARD }} \
             -DCMAKE_INSTALL_PREFIX=../install \
             -DUSE_EXTERNAL_CATCH2=OFF \
             -G Ninja
@@ -58,7 +64,7 @@ jobs:
           cd test/downstream-project-cmake-test
           mkdir build
           cd build
-          cmake .. -DCMAKE_CXX_STANDARD=17 \
+          cmake .. -DCMAKE_CXX_STANDARD=${{ matrix.CXX_STANDARD }} \
             -DCMAKE_INSTALL_PREFIX=../install \
             -G Ninja
           ninja -k0

--- a/test/utils/CMakeLists.txt
+++ b/test/utils/CMakeLists.txt
@@ -7,7 +7,7 @@ else()
   FetchContent_Declare(
     Catch2
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    GIT_TAG        6f21a3609cea360846a0ca93be55877cca14c86d
+    GIT_TAG        v3.4.0
   )
   FetchContent_MakeAvailable(Catch2)
   set(CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras ${CMAKE_MODULE_PATH})


### PR DESCRIPTION
BEGINRELEASENOTES
- CI: use same lcg stacks as podio
- Test: update to Catch2 3.4.0, same as in podio, and c++20 compatible

ENDRELEASENOTES