### PR TITLE
Skip catch test discovery if environment requires it

### DIFF
--- a/test/utils/CMakeLists.txt
+++ b/test/utils/CMakeLists.txt
@@ -18,7 +18,31 @@ include(Catch)
 add_executable(unittests
   test_kinematics.cpp test_vector_utils.cpp)
 target_link_libraries(unittests edm4hep EDM4HEP::utils Catch2::Catch2 Catch2::Catch2WithMain)
-catch_discover_tests(unittests)
+
+option(SKIP_CATCH_DISCOVERY "Skip the Catch2 test discovery" OFF)
+
+# To work around https://github.com/catchorg/Catch2/issues/2424 we need the
+# DL_PATH argument for catch_discoer_tests which requires CMake 3.22 at least
+# The whole issue can be avoied if we skip the catch test discovery and set the
+# environment on our own
+if (CMAKE_VERSION VERSION_LESS 3.22)
+  set(SKIP_CATCH_DISCOVERY ON)
+endif()
+
+if (SKIP_CATCH_DISCOVERY)
+  # Unfortunately Memory sanitizer seems to be really unhappy with Catch2 and
+  # it fails to succesfully launch the executable and execute any test. Here
+  # we just include them in order to have them show up as failing
+  add_test(NAME unittests COMMAND unittests)
+  set_property(TEST unittests
+    PROPERTY ENVIRONMENT
+    LD_LIBRARY_PATH=$<TARGET_FILE_DIR:edm4hep>:$<TARGET_FILE_DIR:podio::podio>:$<TARGET_FILE_DIR:ROOT::Core>:$ENV{LD_LIBRARY_PATH}
+    PYTHONPATH=${PROJECT_SOURCE_DIR}/python:$ENV{PYTHONPATH}
+    ROOT_INCLUDE_PATH=${PROJECT_SOURCE_DIR}/edm4hep:${PROJECT_SOURCE_DIR}/utils/include:$ENV{ROOT_INCLUDE_PATH}
+  )
+else()
+  catch_discover_tests(unittests)
+endif()
 
 add_test(NAME pyunittests COMMAND python -m unittest discover -s ${CMAKE_CURRENT_LIST_DIR})
 set_property(TEST pyunittests


### PR DESCRIPTION

BEGINRELEASENOTES
- Add `SKIP_CATCH_DISCOVERY` option to turn of `catch_discover_tests` which may not run in the right environment in older cmake versions.

ENDRELEASENOTES

See https://github.com/AIDASoft/podio/pull/425 for similar changes in podio.