### PR TITLE
fix: schema_version is required at top level

### DIFF
--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -1,9 +1,9 @@
 ---
+schema_version: 1
 options:
   getSyntax: True
   exposePODMembers: False
   includeSubfolder: True
-  schema_version: 1
 
 components:
 


### PR DESCRIPTION
The `schema_version` is required in the model dict at top level, not inside the `options` dict. See https://github.com/AIDASoft/podio/blob/48a4bf6702c081288853a642749459ac5e42d6d4/python/podio/podio_config_reader.py#L425-L432

Alternatively, podio can be told to look in `options`... In any case, without this, we get a warning (podio https://github.com/AIDASoft/podio/commit/5d5c99ccd2d7667db2f3a60a47ded246d0d9dfcc, EDM4hep@ https://github.com/key4hep/EDM4hep/commit/cb92d6ca9501ee91f27b07bbc577bcca095047c6)
```
-- Creating 'edm4hep' datamodel
/home/wdconinc/git/podio/install/python/podio_class_generator.py:97: FutureWarning: Please provide a schema_version entry. It will become mandatory. Setting it to 1 as default
```

<details><summary>cmake configuration</summary>
<pre>
$ cmake -Bbuild -S. -Dpodio_ROOT=~/git/podio/install -DCMAKE_CXX_STANDARD:STRING=17 -DBUILD_TESTING:BOOL=OFF -DCMAKE_INSTALL_PREFIX=$PWD/install --fresh
-- The CXX compiler identification is GNU 12.2.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found nlohmann_json: /usr/local/share/cmake/nlohmann_json/nlohmann_jsonConfig.cmake (found suitable version "3.11.2", minimum required is "3.11.2") 
-- Found Python: /usr/local/bin/python3.10 (found version "3.10.10") found components: Interpreter 
-- Found podio: /home/wdconinc/git/podio/install/lib/cmake/podio/podioConfig.cmake  
-- C++ standard: 17
-- Performing Test CXX_FLAG_WORKS__fPIC
-- Performing Test CXX_FLAG_WORKS__fPIC - Success
-- Adding -fPIC to CXX_FLAGS
-- Performing Test CXX_FLAG_WORKS__Wall
-- Performing Test CXX_FLAG_WORKS__Wall - Success
-- Adding -Wall to CXX_FLAGS
-- Performing Test CXX_FLAG_WORKS__Wextra
-- Performing Test CXX_FLAG_WORKS__Wextra - Success
-- Adding -Wextra to CXX_FLAGS
-- Performing Test CXX_FLAG_WORKS__Wpedantic
-- Performing Test CXX_FLAG_WORKS__Wpedantic - Success
-- Adding -Wpedantic to CXX_FLAGS
-- Performing Test CXX_FLAG_WORKS__Wno_unused_variable
-- Performing Test CXX_FLAG_WORKS__Wno_unused_variable - Success
-- Adding -Wno-unused-variable to CXX_FLAGS
-- Performing Test CXX_FLAG_WORKS__Wno_unused_parameter
-- Performing Test CXX_FLAG_WORKS__Wno_unused_parameter - Success
-- Adding -Wno-unused-parameter to CXX_FLAGS
-- Detected GNU compatible linker
-- Found nlohmann_json: /usr/local/share/cmake/nlohmann_json/nlohmann_jsonConfig.cmake (found suitable version "3.11.2", minimum required is "3.10.5") 
-- Found .clang-format file and clang-format executable. Will pass it to podio class generator
-- Creating 'edm4hep' datamodel
/home/wdconinc/git/podio/install/python/podio_class_generator.py:97: FutureWarning: Please provide a schema_version entry. It will become mandatory. Setting it to 1 as default
  self.datamodel = PodioConfigReader.read(yamlfile, package_name, upstream_edm)

  PODIO Data Model
  ================
  Used ../edm4hep.yaml to create 149 classes in /home/wdconinc/git/EDM4hep/edm4hep/
  Read instructions in the README.md to run your first example!

-- Not adding the SIO Blocks library to the targets because the corresponding c++ sources have not been generated
-- Configuring done (11.5s)
-- Generating done (0.0s)
-- Build files have been written to: /home/wdconinc/git/EDM4hep/build
</pre>
</details>

BEGINRELEASENOTES
- Define schema_version at top level in yaml file

ENDRELEASENOTES