### PR TITLE
Use `FILE_SET` to install the headers in `/include` together with the edm4hep library

### DIFF
--- a/.github/workflows/lcg_linux_with_podio.yml
+++ b/.github/workflows/lcg_linux_with_podio.yml
@@ -14,9 +14,7 @@ jobs:
         include:
           - LCG: "dev4/x86_64-centos7-gcc11-opt"
             CXX_STANDARD: 17
-          - LCG: "LCG_102/x86_64-centos7-clang12-opt"
-            CXX_STANDARD: 17
-          - LCG: "LCG_102/x86_64-centos8-gcc11-opt"
+          - LCG: "LCG_104/x86_64-centos8-gcc11-opt"
             CXX_STANDARD: 17
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,7 +10,8 @@ jobs:
     - uses: cvmfs-contrib/github-action-cvmfs@v3
     - uses: aidasoft/run-lcg-view@v4
       with:
-        release-platform: LCG_104/x86_64-el9-clang16-opt
+        container: centos7
+        view-path: /cvmfs/sw-nightlies.hsf.org/key4hep
         run: |
           STARTDIR=$(pwd)
           echo "::group::Build podio"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: cvmfs-contrib/github-action-cvmfs@v3
     - uses: aidasoft/run-lcg-view@v4
       with:
-        container: almalinux9
+        container: ghcr.io/key4hep/key4hep-images/alma9
         view-path: /cvmfs/sw-nightlies.hsf.org/key4hep
         run: |
           STARTDIR=$(pwd)

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: cvmfs-contrib/github-action-cvmfs@v3
     - uses: aidasoft/run-lcg-view@v4
       with:
-        container: ghcr.io/key4hep/key4hep-images/alma9
+        container: centos7
         view-path: /cvmfs/sw-nightlies.hsf.org/key4hep
         run: |
           STARTDIR=$(pwd)

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: cvmfs-contrib/github-action-cvmfs@v3
     - uses: aidasoft/run-lcg-view@v4
       with:
-        release-platform: LCG_103/x86_64-centos7-clang12-opt
+        release-platform: LCG_104/x86_64-centos7-gcc12-opt
         run: |
           STARTDIR=$(pwd)
           echo "::group::Build podio"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: cvmfs-contrib/github-action-cvmfs@v3
     - uses: aidasoft/run-lcg-view@v4
       with:
-        release-platform: LCG_103/x86_64-centos7-clang15-opt
+        release-platform: LCG_104/x86_64-el9-clang16-opt
         run: |
           STARTDIR=$(pwd)
           echo "::group::Build podio"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: cvmfs-contrib/github-action-cvmfs@v3
     - uses: aidasoft/run-lcg-view@v4
       with:
-        container: centos7
+        container: almalinux9
         view-path: /cvmfs/sw-nightlies.hsf.org/key4hep
         run: |
           STARTDIR=$(pwd)

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -47,6 +47,7 @@ jobs:
             -DUSE_EXTERNAL_CATCH2=OFF
           ln -s $(pwd)/compile_commands.json ../
           cd ..
+          pip install pre-commit --user
           pre-commit run --show-diff-on-failure \
             --color=always \
             --all-files

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: cvmfs-contrib/github-action-cvmfs@v3
     - uses: aidasoft/run-lcg-view@v4
       with:
-        release-platform: LCG_104/x86_64-centos7-gcc12-opt
+        release-platform: LCG_103/x86_64-centos7-clang15-opt
         run: |
           STARTDIR=$(pwd)
           echo "::group::Build podio"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,8 +10,7 @@ jobs:
     - uses: cvmfs-contrib/github-action-cvmfs@v3
     - uses: aidasoft/run-lcg-view@v4
       with:
-        container: centos7
-        view-path: /cvmfs/sw-nightlies.hsf.org/key4hep
+        release-platform: LCG_104/x86_64-el9-clang16-opt
         run: |
           STARTDIR=$(pwd)
           echo "::group::Build podio"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: cvmfs-contrib/github-action-cvmfs@v3
     - uses: aidasoft/run-lcg-view@v4
       with:
-        release-platform: LCG_99/x86_64-centos7-clang10-opt
+        release-platform: LCG_104/x86_64-centos7-gcc12-opt
         run: |
           STARTDIR=$(pwd)
           echo "::group::Build podio"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: cvmfs-contrib/github-action-cvmfs@v3
     - uses: aidasoft/run-lcg-view@v4
       with:
-        release-platform: LCG_104/x86_64-centos7-gcc12-opt
+        release-platform: LCG_103/x86_64-centos7-clang12-opt
         run: |
           STARTDIR=$(pwd)
           echo "::group::Build podio"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -37,7 +37,6 @@ jobs:
           export PYTHONPATH=$(python -m site --user-site):$PYTHONPATH
           export PATH=/root/.local/bin:$PATH
           pip install argparse --user
-          pip install pre-commit --user
           mkdir build
           cd build
           cmake .. -DENABLE_SIO=ON \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,14 +9,7 @@ SET( ${PROJECT_NAME}_VERSION_PATCH 1 )
 
 SET( ${PROJECT_NAME}_VERSION  "${${PROJECT_NAME}_VERSION_MAJOR}.${${PROJECT_NAME}_VERSION_MINOR}.${${PROJECT_NAME}_VERSION_PATCH}" )
 
-
-#--- Run the podio class generator and link library -------
-
 find_package(podio REQUIRED HINTS $ENV{PODIO})
-
-#--- Declare ROOT dependency ---------------------------------------------------
-list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})
-set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 find_package(ROOT REQUIRED COMPONENTS RIO Tree Physics)
 
 #--- Define basic build settings -----------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.23)
 
 project(EDM4HEP LANGUAGES CXX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,11 +104,6 @@ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE
               ${CMAKE_CURRENT_SOURCE_DIR}/NOTICE
               DESTINATION ${CMAKE_INSTALL_DOCDIR})
 
-
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/edm4hep/
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/edm4hep
-        FILES_MATCHING PATTERN "*.h")
-
 find_package(nlohmann_json 3.10.5)
 
 add_subdirectory(edm4hep)

--- a/edm4hep/CMakeLists.txt
+++ b/edm4hep/CMakeLists.txt
@@ -9,9 +9,6 @@ set_target_properties(edm4hep PROPERTIES ALIAS_GLOBAL true)
 
 file(GLOB_RECURSE top_headers ${PROJECT_SOURCE_DIR}/include/*.h)
 target_sources(edm4hep PUBLIC FILE_SET headers TYPE HEADERS BASE_DIRS ${PROJECT_SOURCE_DIR}/include FILES ${top_headers})
-target_include_directories(edm4hep PUBLIC
-  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 if (nlohmann_json_FOUND)
   target_compile_definitions(edm4hep PUBLIC PODIO_JSON_OUTPUT)

--- a/edm4hep/CMakeLists.txt
+++ b/edm4hep/CMakeLists.txt
@@ -40,12 +40,9 @@ install(TARGETS ${EDM4HEP_INSTALL_LIBS}
 
 install(FILES
   "${PROJECT_BINARY_DIR}/edm4hep/edm4hepDictDict.rootmap"
+  "${PROJECT_BINARY_DIR}/edm4hep/libedm4hepDict_rdict.pcm"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT dev)
 
 install(FILES
   ../edm4hep.yaml
   DESTINATION "${CMAKE_INSTALL_DATADIR}/edm4hep" COMPONENT dev)
-
-install(FILES
-  "${PROJECT_BINARY_DIR}/edm4hep/libedm4hepDict_rdict.pcm"
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT dev)

--- a/edm4hep/CMakeLists.txt
+++ b/edm4hep/CMakeLists.txt
@@ -7,6 +7,12 @@ PODIO_ADD_DATAMODEL_CORE_LIB(edm4hep "${headers}" "${sources}")
 add_library(EDM4HEP::edm4hep ALIAS edm4hep)
 set_target_properties(edm4hep PROPERTIES ALIAS_GLOBAL true)
 
+file(GLOB_RECURSE top_headers ${PROJECT_SOURCE_DIR}/include/*.h)
+target_sources(edm4hep PUBLIC FILE_SET headers TYPE HEADERS BASE_DIRS ${PROJECT_SOURCE_DIR}/include FILES ${top_headers})
+target_include_directories(edm4hep PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
 if (nlohmann_json_FOUND)
   target_compile_definitions(edm4hep PUBLIC PODIO_JSON_OUTPUT)
   target_link_libraries(edm4hep PUBLIC nlohmann_json::nlohmann_json)
@@ -29,6 +35,7 @@ install(TARGETS ${EDM4HEP_INSTALL_LIBS}
   RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT bin
   LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT shlib
   PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/edm4hep"
+  FILE_SET headers DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
   COMPONENT dev)
 
 install(FILES


### PR DESCRIPTION
BEGINRELEASENOTES
- Use `FILE_SET` to install the headers in the top folder together with the library. This also adds them in the `BUILD_INTERFACE`, something that a simple `INSTALL` doesn't do.
- Bump the CMake version of the LCG stacks
- Simplify finding ROOT, don't do environment variable manipulation in CMake

ENDRELEASENOTES

`FILE_SET` requires CMake 2.23 so the version of the LCG stacks has to be bumped. I discovered that it also has the nice property that it complains if any of the sources that are attached to the library are not installed.