### PR TITLE
Add EventHeader constant

### DIFF
--- a/include/edm4hep/Constants.h
+++ b/include/edm4hep/Constants.h
@@ -21,6 +21,7 @@
 
 namespace edm4hep {
 static constexpr const char* CellIDEncoding = "CellIDEncoding";
-}
+static constexpr const char* EventHeader = "EventHeader";
+} // namespace edm4hep
 
 #endif // EDM4HEP_CONSTANTS_H


### PR DESCRIPTION
To not have this string literal in so many locations

BEGINRELEASENOTES
- Add a constant for the default expected EventHeader name to be used by the converters and PodioInput

ENDRELEASENOTES