### PR TITLE
Change EventHeader to EventHeaderName

### DIFF
--- a/include/edm4hep/Constants.h
+++ b/include/edm4hep/Constants.h
@@ -21,7 +21,7 @@
 
 namespace edm4hep {
 static constexpr const char* CellIDEncoding = "CellIDEncoding";
-static constexpr const char* EventHeader = "EventHeader";
+static constexpr const char* EventHeaderName = "EventHeader";
 } // namespace edm4hep
 
 #endif // EDM4HEP_CONSTANTS_H


### PR DESCRIPTION
BEGINRELEASENOTES
- Change EventHeader to EventHeaderName; we already have an EventHeaderCollection and its elements are called EventHeader (`edm4hep::EventHeader` more precisely)

ENDRELEASENOTES

Building can work because there is `edm4hep::EventHeader` and the constant is not namespaced but it's going to break at some point, at the very least you can't do things like `using edm4hep::EventHeader`.