### PR TITLE
Make sure that tests also work in Ubuntu environments

### DIFF
--- a/.github/workflows/lcg_linux_with_podio.yml
+++ b/.github/workflows/lcg_linux_with_podio.yml
@@ -16,6 +16,8 @@ jobs:
             CXX_STANDARD: 17
           - LCG: "LCG_104/x86_64-centos8-gcc11-opt"
             CXX_STANDARD: 17
+          - LCG: "dev4/x86_64-ubuntu2004-gcc9-opt"
+            CXX_STANDARD: 17
     steps:
     - uses: actions/checkout@v3
     - uses: cvmfs-contrib/github-action-cvmfs@v3

--- a/test/utils/CMakeLists.txt
+++ b/test/utils/CMakeLists.txt
@@ -41,7 +41,10 @@ if (SKIP_CATCH_DISCOVERY)
     ROOT_INCLUDE_PATH=${PROJECT_SOURCE_DIR}/edm4hep:${PROJECT_SOURCE_DIR}/utils/include:$ENV{ROOT_INCLUDE_PATH}
   )
 else()
-  catch_discover_tests(unittests_edm4hep)
+  catch_discover_tests(unittests_edm4hep
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    DL_PATHS $<TARGET_FILE_DIR:edm4hep>:$<TARGET_FILE_DIR:podio::podio>:$<TARGET_FILE_DIR:ROOT::Core>:$ENV{LD_LIBRARY_PATH}
+  )
 endif()
 
 add_test(NAME pyunittests COMMAND python -m unittest discover -s ${CMAKE_CURRENT_LIST_DIR})


### PR DESCRIPTION

BEGINRELEASENOTES
- Make sure that tests also work in Ubuntu 20.04 environments by running catch test discovery in correct environment.

ENDRELEASENOTES