### PR TITLE
Fixed doxygen excluded files and path stripping

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -145,6 +145,7 @@ FULL_PATH_NAMES        = YES
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
 STRIP_FROM_PATH        = @PROJECT_SOURCE_DIR@ @PROJECT_BINARY_DIR@
+STRIP_FROM_PATH       += @PROJECT_SOURCE_DIR@/edm4hep
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which
@@ -154,6 +155,7 @@ STRIP_FROM_PATH        = @PROJECT_SOURCE_DIR@ @PROJECT_BINARY_DIR@
 # using the -I flag.
 
 STRIP_FROM_INC_PATH    = @DOXYGEN_INCLUDE_DIRS@ @PROJECT_BINARY_DIR@/include
+STRIP_FROM_INC_PATH   += @PROJECT_SOURCE_DIR@/edm4hep
 
 # If the SHORT_NAMES tag is set to YES, doxygen will generate much shorter (but
 # less readable) file names. This can be useful is your file systems doesn't

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -785,7 +785,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                =
+EXCLUDE                = @PROJECT_BINARY_DIR@ @CMAKE_INSTALL_PREFIX@
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
@@ -801,7 +801,8 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       = */podio/* */TrickTrack/*  */tests/* */dict/* */cmake/* @PROJECT_BINARY_DIR@
+EXCLUDE_PATTERNS       = */podio/* */test/* */tests/*
+EXCLUDE_PATTERNS      += */dict/* */cmake/* */scripts/*
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the


### PR DESCRIPTION

BEGINRELEASENOTES
- Fixed doxygen excluded files and path stripping

ENDRELEASENOTES

The documentation generated with doxygen included tests and scripts which aren't part of exposed API

Broken file striping illustration with `edm4hep::Vector3f` [docs](https://edm4hep.web.cern.ch/classedm4hep_1_1_vector3f.html):
Was:

```
edm4hep::Vector3f Class Reference

#include </builds/key4hep/edm4hep/edm4hep/edm4hep/Vector3f.h>
.
.
.
The documentation for this class was generated from the following file:

   - edm4hep/edm4hep/Vector3f.h

```
fixed:
```
edm4hep::Vector3f Class Reference

#include <edm4hep/Vector3f.h>
.
.
.
The documentation for this class was generated from the following file:

   - edm4hep/Vector3f.h
```
