### PR TITLE
Use interface types for TrackerHit

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,10 @@ A generic event data model for future HEP collider experiments.
 
 **Datatypes**
 
-| | | |
-|-|-|-|
 | [EventHeader](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L136)         | [MCParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L148)        | [SimTrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L216)         |
 | [CaloHitContribution](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L258) | [SimCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L270) | [RawCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L282)     |
 | [CalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L291)      | [ParticleID](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L303)        | [Cluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L316)               |
-| [TrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L337)          | [TrackerHitPlane](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L352)   | [RawTimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L371)                |
+| [TrackerHit3D](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L337)          | [TrackerHitPlane](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L352)   | [RawTimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L371)                |
 | [Track](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L384)               | [Vertex](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L403)            | [ReconstructedParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L420) |
 | [SimPrimaryIonizationCluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L528) | [TrackerPulse](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L562) | [RecIonizationCluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L575) |
 | [TimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L586) | [RecDqdx](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L598) |                                                                                          |
@@ -36,6 +34,13 @@ A generic event data model for future HEP collider experiments.
 | [MCRecoParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L454)        | [MCRecoCaloAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L463)         | [MCRecoTrackerAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L472)         |
 | [MCRecoTrackerHitPlaneAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L481) | [MCRecoCaloParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L490) | [MCRecoClusterParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L499) |
 | [MCRecoTrackParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L508)   | [RecoParticleVertexAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L517) |                                                                                                      |
+
+**Interfaces**
+
+| | | |
+|-|-|-|
+| [TrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#625) | | |
+
 
 The tests and examples in the `tests` directory show how to read, write, and use these types in your code.
 

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -396,7 +396,7 @@ datatypes:
       - edm4hep::TrackState trackStates  // track states
       - edm4hep::Quantity dxQuantities // different measurements of dx quantities
     OneToManyRelations:
-      - edm4hep::TrackerHit3D trackerHits  // hits that have been used to create this track
+      - edm4hep::TrackerHit trackerHits  // hits that have been used to create this track
       - edm4hep::Track tracks            // tracks (segments) that have been combined to create this track
 
  #---------- Vertex
@@ -475,7 +475,7 @@ datatypes:
     Members:
       - float weight              // weight of this association
     OneToOneRelations:
-     - edm4hep::TrackerHit3D rec    // reference to the reconstructed hit
+     - edm4hep::TrackerHit rec    // reference to the reconstructed hit
      - edm4hep::SimTrackerHit sim // reference to the simulated hit
 
   edm4hep::MCRecoTrackerHitPlaneAssociation:
@@ -607,3 +607,20 @@ datatypes:
       - edm4hep::HitLevelData hitData   // hit level data
     OneToOneRelations:
       - edm4hep::Track track           // the corresponding track
+
+interfaces:
+  edm4hep::TrackerHit:
+    Description: "Tracker hit interface class"
+    Author: "Thomas Madlener, DESY"
+    Members:
+      - uint64_t cellID // ID of the sensor that created this hit
+      - int32_t type // type of the raw data hit
+      - int32_t quality // quality bit flag of the hit
+      - float time [ns] // time of the hit
+      - float eDep [GeV] // energy deposited on the hit
+      - float eDepError [GeV] // error measured on eDep
+      - edm4hep::Vector3d position [mm] // hit position
+      - std::array<float, 6> covMatrix // covariance of the position (x,y,z) stored as lower triangle matrix, i.e. cov(x,x), cov(y, x), cov(y, y), cov(z, x), cov(z, y), cov(z, z)
+    Types:
+      - edm4hep::TrackerHit3D
+      - edm4hep::TrackerHitPlane

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -620,7 +620,6 @@ interfaces:
       - float eDep [GeV] // energy deposited on the hit
       - float eDepError [GeV] // error measured on eDep
       - edm4hep::Vector3d position [mm] // hit position
-      - std::array<float, 6> covMatrix // covariance of the position (x,y,z) stored as lower triangle matrix, i.e. cov(x,x), cov(y, x), cov(y, y), cov(z, x), cov(z, y), cov(z, z)
     Types:
       - edm4hep::TrackerHit3D
       - edm4hep::TrackerHitPlane

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -334,7 +334,7 @@ datatypes:
       - edm4hep::ParticleID     particleIDs  // particle IDs (sorted by their likelihood)
 
   #-------------  TrackerHit
-  edm4hep::TrackerHit:
+  edm4hep::TrackerHit3D:
     Description: "Tracker hit"
     Author: "EDM4hep authors"
     Members:
@@ -396,7 +396,7 @@ datatypes:
       - edm4hep::TrackState trackStates  // track states
       - edm4hep::Quantity dxQuantities // different measurements of dx quantities
     OneToManyRelations:
-      - edm4hep::TrackerHit trackerHits  // hits that have been used to create this track
+      - edm4hep::TrackerHit3D trackerHits  // hits that have been used to create this track
       - edm4hep::Track tracks            // tracks (segments) that have been combined to create this track
 
  #---------- Vertex
@@ -475,7 +475,7 @@ datatypes:
     Members:
       - float weight              // weight of this association
     OneToOneRelations:
-     - edm4hep::TrackerHit rec    // reference to the reconstructed hit
+     - edm4hep::TrackerHit3D rec    // reference to the reconstructed hit
      - edm4hep::SimTrackerHit sim // reference to the simulated hit
 
   edm4hep::MCRecoTrackerHitPlaneAssociation:

--- a/tools/include/edm4hep2json.hxx
+++ b/tools/include/edm4hep2json.hxx
@@ -18,7 +18,7 @@
 #include "edm4hep/SimTrackerHitCollection.h"
 #include "edm4hep/TimeSeriesCollection.h"
 #include "edm4hep/TrackCollection.h"
-#include "edm4hep/TrackerHitCollection.h"
+#include "edm4hep/TrackerHit3DCollection.h"
 #include "edm4hep/TrackerHitPlaneCollection.h"
 #include "edm4hep/TrackerPulseCollection.h"
 #include "edm4hep/VertexCollection.h"
@@ -92,8 +92,8 @@ nlohmann::json processEvent(const podio::Frame& frame, std::vector<std::string>&
       insertIntoJson<edm4hep::ParticleIDCollection>(jsonDict, coll, collList[i]);
     } else if (coll->getTypeName() == "edm4hep::ClusterCollection") {
       insertIntoJson<edm4hep::ClusterCollection>(jsonDict, coll, collList[i]);
-    } else if (coll->getTypeName() == "edm4hep::TrackerHitCollection") {
-      insertIntoJson<edm4hep::TrackerHitCollection>(jsonDict, coll, collList[i]);
+    } else if (coll->getTypeName() == "edm4hep::TrackerHit3DCollection") {
+      insertIntoJson<edm4hep::TrackerHit3DCollection>(jsonDict, coll, collList[i]);
     } else if (coll->getTypeName() == "edm4hep::TrackerHitPlaneCollection") {
       insertIntoJson<edm4hep::TrackerHitPlaneCollection>(jsonDict, coll, collList[i]);
     } else if (coll->getTypeName() == "edm4hep::RawTimeSeriesCollection") {

--- a/utils/src/dataframe.cc
+++ b/utils/src/dataframe.cc
@@ -6,7 +6,7 @@
 #include "edm4hep/ReconstructedParticleData.h"
 #include "edm4hep/SimCalorimeterHitData.h"
 #include "edm4hep/SimTrackerHitData.h"
-#include "edm4hep/TrackerHitData.h"
+#include "edm4hep/TrackerHit3DData.h"
 #include "edm4hep/TrackerHitPlaneData.h"
 #include "edm4hep/VertexData.h"
 
@@ -77,7 +77,7 @@ INST_MOMENTUM_FUNCS(edm4hep::ReconstructedParticleData);
 INST_MOMENTUM_FUNCS(edm4hep::SimTrackerHitData);
 
 INST_POSITION_FUNCS(edm4hep::SimTrackerHitData);
-INST_POSITION_FUNCS(edm4hep::TrackerHitData);
+INST_POSITION_FUNCS(edm4hep::TrackerHit3DData);
 INST_POSITION_FUNCS(edm4hep::TrackerHitPlaneData);
 INST_POSITION_FUNCS(edm4hep::SimCalorimeterHitData);
 INST_POSITION_FUNCS(edm4hep::CalorimeterHitData);


### PR DESCRIPTION
BEGINRELEASENOTES
- Make the `edm4hep::TrackerHit` an `interface` type and use that in the `edm4hep::Track`.
- Rename the current `edm4hep::TrackerHit` to `edm4hep::TrackerHit3D`
- **This is a breaking change. However, we currently do not plan to implement schema evolution for this**

ENDRELEASENOTES

- [x] Needs AIDASoft/podio#516
Breaking changes downstream:
- [x] https://github.com/key4hep/k4EDM4hep2LcioConv/pull/45
- [x] https://github.com/key4hep/k4FWCore/pull/174
- [x] https://github.com/AIDASoft/DD4hep/pull/1219 (DDDigi also uses the TrackerHit and needs to be updated accordingly.)
- [x] https://github.com/key4hep/k4MarlinWrapper/pull/168
- [x] https://github.com/key4hep/k4SimDelphes/pull/113
- [x] https://github.com/HEP-FCC/k4SimGeant4/pull/62
- [x] https://github.com/HEP-FCC/FCCAnalyses/pull/345
- [x] CEPCSW breaks (https://github.com/cepc/CEPCSW/issues/263)
- [x] Update documentation (add an `interfaces` section?)

This is one of a few rather breaking changes that we plan to do in the near future towards an EDM4hep version 1.0.

Fixes #218 