### PR TITLE
Rename MCParticle relations to particle to avoid clashes with type names

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,20 +23,20 @@ A generic event data model for future HEP collider experiments.
 | | | |
 |-|-|-|
 | [EventHeader](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L145)         | [MCParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L155)        | [SimTrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L224)         |
-| [CaloHitContribution](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L258) | [SimCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L270) | [RawCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L282)     |
-| [CalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L291)      | [ParticleID](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L303)        | [Cluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L316)               |
-| [TrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L337)          | [TrackerHitPlane](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L354)   | [RawTimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L375)                |
-| [Track](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L388)               | [Vertex](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L407)            | [ReconstructedParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L424) |
-| [SimPrimaryIonizationCluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L528) | [TrackerPulse](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L546) | [RecIonizationCluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L559) |
-| [TimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L570) | [RecDqdx](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L582) |                                                                                          |
+| [CaloHitContribution](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L266) | [SimCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L278) | [RawCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L290)     |
+| [CalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L299)      | [ParticleID](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L311)        | [Cluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L324)               |
+| [TrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L345)          | [TrackerHitPlane](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L362)   | [RawTimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L383)                |
+| [Track](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L396)               | [Vertex](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L415)            | [ReconstructedParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L432) |
+| [SimPrimaryIonizationCluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L536) | [TrackerPulse](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L570) | [RecIonizationCluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L583) |
+| [TimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L594) | [RecDqdx](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L606) |                                                                                          |
 
 **Associations**
 
 | | | |
 |-|-|-|
-| [MCRecoParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L454)        | [MCRecoCaloAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L463)         | [MCRecoTrackerAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L472)         |
-| [MCRecoTrackerHitPlaneAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L481) | [MCRecoCaloParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L490) | [MCRecoClusterParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L499) |
-| [MCRecoTrackParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L508)   | [RecoParticleVertexAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L517) |                                                                                                      |
+| [MCRecoParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L462)        | [MCRecoCaloAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L471)         | [MCRecoTrackerAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L480)         |
+| [MCRecoTrackerHitPlaneAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L489) | [MCRecoCaloParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L498) | [MCRecoClusterParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L507) |
+| [MCRecoTrackParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L516)   | [RecoParticleVertexAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L525) |                                                                                                      |
 
 The tests and examples in the `tests` directory show how to read, write, and use these types in your code.
 

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -243,6 +243,7 @@ datatypes:
       int32_t  set_bit(int32_t val, int num, bool bitval){ return (val & ~(1<<num)) | (bitval << num); }\n
       void setOverlay(bool val) { setQuality( set_bit( getQuality() , BITOverlay , val ) ) ;   }\n
       void setProducedBySecondary(bool val) { setQuality( set_bit( getQuality() , BITProducedBySecondary , val ) ) ;   }\n
+      [[deprecated("use setParticle instead")]]
       void setMCParticle(edm4hep::MCParticle particle) { setParticle(std::move(particle)); }\n
       "
     ExtraCode:
@@ -256,6 +257,7 @@ datatypes:
       double y() const {return getPosition()[1];}\n
       double z() const {return getPosition()[2];}\n
       double rho() const {return sqrt(x()*x() + y()*y());}\n
+      [[deprecated("use getParticle instead")]]
       edm4hep::MCParticle getMCParticle() const { return getParticle(); }\n
       "
 
@@ -552,11 +554,17 @@ datatypes:
       #include <cmath>\n
       #include <edm4hep/MCParticle.h>\n
       "
-      declaration: "void setMCParticle(edm4hep::MCParticle particle) { setParticle(std::move(particle)); }\n"
+      declaration: "
+      [[deprecated("use setParticle instead")]]
+      void setMCParticle(edm4hep::MCParticle particle) { setParticle(std::move(particle)); }\n
+      "
 
     ExtraCode:
       includes: "#include <edm4hep/MCParticle.h>\n"
-      declaration: "edm4hep::MCParticle getMCParticle() const { return getParticle(); }\n"
+      declaration: "
+      [[deprecated("use getParticle instead")]]
+      edm4hep::MCParticle getMCParticle() const { return getParticle(); }\n
+      "
 
  #----------  TrackerPulse
   edm4hep::TrackerPulse:

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -243,7 +243,7 @@ datatypes:
       int32_t  set_bit(int32_t val, int num, bool bitval){ return (val & ~(1<<num)) | (bitval << num); }\n
       void setOverlay(bool val) { setQuality( set_bit( getQuality() , BITOverlay , val ) ) ;   }\n
       void setProducedBySecondary(bool val) { setQuality( set_bit( getQuality() , BITProducedBySecondary , val ) ) ;   }\n
-      [[deprecated("use setParticle instead")]]
+      [[deprecated(\"use setParticle instead\")]]
       void setMCParticle(edm4hep::MCParticle particle) { setParticle(std::move(particle)); }\n
       "
     ExtraCode:
@@ -257,7 +257,7 @@ datatypes:
       double y() const {return getPosition()[1];}\n
       double z() const {return getPosition()[2];}\n
       double rho() const {return sqrt(x()*x() + y()*y());}\n
-      [[deprecated("use getParticle instead")]]
+      [[deprecated(\"use getParticle instead\")]]
       edm4hep::MCParticle getMCParticle() const { return getParticle(); }\n
       "
 
@@ -555,14 +555,14 @@ datatypes:
       #include <edm4hep/MCParticle.h>\n
       "
       declaration: "
-      [[deprecated("use setParticle instead")]]
+      [[deprecated(\"use setParticle instead\")]]\n
       void setMCParticle(edm4hep::MCParticle particle) { setParticle(std::move(particle)); }\n
       "
 
     ExtraCode:
       includes: "#include <edm4hep/MCParticle.h>\n"
       declaration: "
-      [[deprecated("use getParticle instead")]]
+      [[deprecated(\"use getParticle instead\")]]
       edm4hep::MCParticle getMCParticle() const { return getParticle(); }\n
       "
 

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -233,15 +233,20 @@ datatypes:
       - edm4hep::Vector3d position     //the hit position in [mm].
       - edm4hep::Vector3f momentum     //the 3-momentum of the particle at the hits position in [GeV]
     OneToOneRelations:
-      - edm4hep::MCParticle MCParticle //MCParticle that caused the hit.
+      - edm4hep::MCParticle particle //MCParticle that caused the hit.
     MutableExtraCode:
-      includes: "#include <cmath>"
+      includes: "
+      #include <cmath>\n
+      #include <edm4hep/MCParticle.h>\n
+      "
       declaration: "
       int32_t  set_bit(int32_t val, int num, bool bitval){ return (val & ~(1<<num)) | (bitval << num); }\n
       void setOverlay(bool val) { setQuality( set_bit( getQuality() , BITOverlay , val ) ) ;   }\n
       void setProducedBySecondary(bool val) { setQuality( set_bit( getQuality() , BITProducedBySecondary , val ) ) ;   }\n
+      void setMCParticle(edm4hep::MCParticle particle) { setParticle(std::move(particle)); }\n
       "
     ExtraCode:
+      includes: "#include <edm4hep/MCParticle.h>\n"
       declaration: "
       static const int  BITOverlay = 31;\n
       static const int  BITProducedBySecondary = 30;\n
@@ -251,6 +256,7 @@ datatypes:
       double y() const {return getPosition()[1];}\n
       double z() const {return getPosition()[2];}\n
       double rho() const {return sqrt(x()*x() + y()*y());}\n
+      edm4hep::MCParticle getMCParticle() const { return getParticle(); }\n
       "
 
 
@@ -540,7 +546,17 @@ datatypes:
        - float pulseTime                     //the pulse's time in the lab frame [ns].
        - float pulseAmplitude                //the pulse's amplitude [fC].
     OneToOneRelations:
-      - edm4hep::MCParticle MCParticle       //the particle that caused the ionizing collisions.
+      - edm4hep::MCParticle particle       //the particle that caused the ionizing collisions.
+    MutableExtraCode:
+      includes: "
+      #include <cmath>\n
+      #include <edm4hep/MCParticle.h>\n
+      "
+      declaration: "void setMCParticle(edm4hep::MCParticle particle) { setParticle(std::move(particle)); }\n"
+
+    ExtraCode:
+      includes: "#include <edm4hep/MCParticle.h>\n"
+      declaration: "edm4hep::MCParticle getMCParticle() const { return getParticle(); }\n"
 
  #----------  TrackerPulse
   edm4hep::TrackerPulse:


### PR DESCRIPTION
BEGINRELEASENOTES
- Rename `MCParticle` relations to `particle` in `SimTrackerHit` and `SimPrimaryIonizationCluster` to avoid clashes with the `MCParticle` typename.
  - Add `getMCParticle` and `setMCParticle` via `ExtraCode` to keep everything working.
  - **This will break the reading of existing files via podio utilities**

ENDRELEASENOTES

- [x] Check if everything still builds with the ExtraCode

Fixes #247 