### PR TITLE
Add Python formatting CMake targets (black, flake8)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+# Minimal flake8 tweak to be compatible with black's line length of 88 characters
+# https://black.readthedocs.io/en/stable/the_black_code_style.html#line-length
+
+[flake8]
+max-line-length = 88
+extend-ignore = E203

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,3 +102,6 @@ add_subdirectory(python)
 
 #--- create uninstall target ---------------------------------------------------
 include(cmake/EDM4HEPUninstall.cmake)
+
+#--- code format targets -------------------------------------------------------
+include(cmake/pythonFormat.cmake)

--- a/cmake/pythonFormat.cmake
+++ b/cmake/pythonFormat.cmake
@@ -4,7 +4,8 @@
 
 
 # Get all our Python files
-file(GLOB_RECURSE ALL_PYTHON_FILES ${PROJECT_SOURCE_DIR}/*.py)
+file(GLOB_RECURSE ALL_PYTHON_FILES ${PROJECT_SOURCE_DIR}/python/*.py 
+  ${PROJECT_SOURCE_DIR}/scripts/*.py ${PROJECT_SOURCE_DIR}/test/*.py)
 
 # Black is rather simple because there are no options...
 find_program(BLACK_EXECUTABLE black)
@@ -24,7 +25,7 @@ if(FLAKE8_EXECUTABLE)
     add_custom_target(
         flake8
         COMMAND ${FLAKE8_EXECUTABLE}
-        --config=${CMAKE_CURRENT_SOURCE_DIR}/.flake8
+        --config=${PROJECT_SOURCE_DIR}/.flake8
         ${ALL_PYTHON_FILES}
     )
     set_target_properties(flake8 PROPERTIES EXCLUDE_FROM_ALL TRUE)

--- a/cmake/pythonFormat.cmake
+++ b/cmake/pythonFormat.cmake
@@ -11,7 +11,7 @@ find_program(BLACK_EXECUTABLE black)
 if(BLACK_EXECUTABLE)
     add_custom_target(
             black
-            COMMAND black
+            COMMAND ${BLACK_EXECUTABLE}
             ${ALL_PYTHON_FILES}
     )
     set_target_properties(black PROPERTIES EXCLUDE_FROM_ALL TRUE)
@@ -23,7 +23,7 @@ find_program(FLAKE8_EXECUTABLE flake8)
 if(FLAKE8_EXECUTABLE)
     add_custom_target(
         flake8
-        COMMAND flake8
+        COMMAND ${FLAKE8_EXECUTABLE}
         --config=${CMAKE_CURRENT_SOURCE_DIR}/.flake8
         ${ALL_PYTHON_FILES}
     )

--- a/cmake/pythonFormat.cmake
+++ b/cmake/pythonFormat.cmake
@@ -1,0 +1,34 @@
+# Additional target to run python linters and formatters on python scripts
+#
+# Requires black/flake8 to be available in the environment
+
+
+# Get all our Python files
+file(GLOB_RECURSE ALL_PYTHON_FILES ${PROJECT_SOURCE_DIR}/*.py)
+
+# Black is rather simple because there are no options...
+find_program(BLACK_EXECUTABLE black)
+if(BLACK_EXECUTABLE)
+    add_custom_target(
+            black
+            COMMAND black
+            ${ALL_PYTHON_FILES}
+    )
+    set_target_properties(black PROPERTIES EXCLUDE_FROM_ALL TRUE)
+else()
+    message(STATUS "Failed to find black executable - no target to run black can be set")
+endif()
+
+find_program(FLAKE8_EXECUTABLE flake8)
+if(FLAKE8_EXECUTABLE)
+    add_custom_target(
+        flake8
+        COMMAND flake8
+        --config=${CMAKE_CURRENT_SOURCE_DIR}/.flake8
+        ${ALL_PYTHON_FILES}
+    )
+    set_target_properties(flake8 PROPERTIES EXCLUDE_FROM_ALL TRUE)
+else()
+    message(STATUS "Failed to find flake8 executable - no target to run flake8 can be set")
+endif()
+


### PR DESCRIPTION
Add CMake targets for running black and flake8 on Python source files
CMake will look to find the relevant binaries and setup the targets if they are there, if they are not found a STATUS message is printed
Targets are excluded from "all" to avoid running them by accident

BEGINRELEASENOTES
Add CMake targets for running black and flake8 on Python source files
ENDRELEASENOTES

This is basically the same PR as https://github.com/AIDASoft/podio/pull/544
