### PR TITLE
Change ROOTFrame{Writer,Reader} to ROOT{Writer,Reader}

### DIFF
--- a/test/hepmc/edm4hep_testhepmc.cc
+++ b/test/hepmc/edm4hep_testhepmc.cc
@@ -17,7 +17,11 @@
 #include "HepPDT/ParticleID.hh"
 
 #include "podio/Frame.h"
+#if PODIO_VERSION_MAJOR > 0 || (PODIO_VERSION_MAJOR == 0 && PODIO_VERSION_MINOR >= 99)
+#include "podio/ROOTWriter.h"
+#else
 #include "podio/ROOTFrameWriter.h"
+#endif
 
 #include "edm4hep/MCParticleCollection.h"
 
@@ -154,7 +158,11 @@ int main() {
   auto event = podio::Frame();
   event.put(std::move(edm_particle_collection), "TestParticles2");
 
+#if PODIO_VERSION_MAJOR > 0 || (PODIO_VERSION_MAJOR == 0 && PODIO_VERSION_MINOR >= 99)
+  auto writer = podio::ROOTWriter("edm4hep_testhepmc.root");
+#else
   auto writer = podio::ROOTFrameWriter("edm4hep_testhepmc.root");
+#endif
   writer.writeFrame(event, "events");
 
   // after all events

--- a/test/read_events.cc
+++ b/test/read_events.cc
@@ -1,8 +1,16 @@
 #include "read_events.h"
+#if PODIO_VERSION_MAJOR > 0 || (PODIO_VERSION_MAJOR == 0 && PODIO_VERSION_MINOR >= 99)
+#include "podio/ROOTReader.h"
+#else
 #include "podio/ROOTFrameReader.h"
+#endif
 
 int main() {
+#if PODIO_VERSION_MAJOR > 0 || (PODIO_VERSION_MAJOR == 0 && PODIO_VERSION_MINOR >= 99)
+  read_events<podio::ROOTReader>("edm4hep_events.root");
+#else
   read_events<podio::ROOTFrameReader>("edm4hep_events.root");
+#endif
 
   return 0;
 }

--- a/test/write_events.cc
+++ b/test/write_events.cc
@@ -1,7 +1,15 @@
 #include "write_events.h"
+#if PODIO_VERSION_MAJOR > 0 || (PODIO_VERSION_MAJOR == 0 && PODIO_VERSION_MINOR >= 99)
+#include "podio/ROOTWriter.h"
+#else
 #include "podio/ROOTFrameWriter.h"
+#endif
 
 int main(int, char*[]) {
 
+#if PODIO_VERSION_MAJOR > 0 || (PODIO_VERSION_MAJOR == 0 && PODIO_VERSION_MINOR >= 99)
+  write<podio::ROOTWriter>("edm4hep_events.root");
+#else
   write<podio::ROOTFrameWriter>("edm4hep_events.root");
+#endif
 }

--- a/tools/src/edm4hep2json.cxx
+++ b/tools/src/edm4hep2json.cxx
@@ -136,8 +136,8 @@ int main(int argc, char** argv) {
                                                 frameName, nEventsMax, verboser);
   } else {
 #if PODIO_VERSION_MAJOR > 0 || (PODIO_VERSION_MAJOR == 0 && PODIO_VERSION_MINOR >= 99)
-    return read_frames<podio::ROOTReader>(inFilePath, outFilePath, requestedCollections, requestedEvents,
-                                               frameName, nEventsMax, verboser);
+    return read_frames<podio::ROOTReader>(inFilePath, outFilePath, requestedCollections, requestedEvents, frameName,
+                                          nEventsMax, verboser);
 #else
     return read_frames<podio::ROOTFrameReader>(inFilePath, outFilePath, requestedCollections, requestedEvents,
                                                frameName, nEventsMax, verboser);

--- a/tools/src/edm4hep2json.cxx
+++ b/tools/src/edm4hep2json.cxx
@@ -5,7 +5,11 @@
 #include "TFile.h"
 
 // podio
+#if PODIO_VERSION_MAJOR > 0 || (PODIO_VERSION_MAJOR == 0 && PODIO_VERSION_MINOR >= 99)
+#include "podio/ROOTReader.h"
+#else
 #include "podio/ROOTFrameReader.h"
+#endif
 #include "podio/ROOTLegacyReader.h"
 
 // std
@@ -131,8 +135,13 @@ int main(int argc, char** argv) {
     return read_frames<podio::ROOTLegacyReader>(inFilePath, outFilePath, requestedCollections, requestedEvents,
                                                 frameName, nEventsMax, verboser);
   } else {
+#if PODIO_VERSION_MAJOR > 0 || (PODIO_VERSION_MAJOR == 0 && PODIO_VERSION_MINOR >= 99)
+    return read_frames<podio::ROOTReader>(inFilePath, outFilePath, requestedCollections, requestedEvents,
+                                               frameName, nEventsMax, verboser);
+#else
     return read_frames<podio::ROOTFrameReader>(inFilePath, outFilePath, requestedCollections, requestedEvents,
                                                frameName, nEventsMax, verboser);
+#endif
   }
 
   return EXIT_SUCCESS;


### PR DESCRIPTION
BEGINRELEASENOTES
- Change ROOTFrame{Writer,Reader} to ROOT{Writer,Reader} following https://github.com/AIDASoft/podio/pull/549

ENDRELEASENOTES

When the #ifs are removed we should specify a requirement of podio 0.99 or greater