### PR TITLE
Revert "Make MCParticle momenta use doubles instead of floats"

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,30 +13,30 @@ A generic event data model for future HEP collider experiments.
 | | | |
 |-|-|-|
 | [Vector4f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L9)       | [Vector3f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L26)  | [Vector3d](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L41)    |
-| [Vector2i](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L60)      | [Vector2f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L74)  | [TrackState](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L88)  |
-| [ObjectID](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L111)     | [Quantity](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L123) | [Hypothesis](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L131) |
-| [HitLevelData](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L138) | | |
+| [Vector2i](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L57)      | [Vector2f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L71)  | [TrackState](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L85)  |
+| [ObjectID](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L108)     | [Quantity](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L120) | [Hypothesis](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L128) |
+| [HitLevelData](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L135) | | |
 
 
 **Datatypes**
 
 | | | |
 |-|-|-|
-| [EventHeader](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L148)         | [MCParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L158)        | [SimTrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L227)         |
-| [CaloHitContribution](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L261) | [SimCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L273) | [RawCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L285)     |
-| [CalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L294)      | [ParticleID](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L306)        | [Cluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L319)               |
-| [TrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L340)          | [TrackerHitPlane](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L357)   | [RawTimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L378)                |
-| [Track](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L391)               | [Vertex](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L410)            | [ReconstructedParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L427) |
-| [SimPrimaryIonizationCluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L531) | [TrackerPulse](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L549) | [RecIonizationCluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L562) |
-| [TimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L573) | [RecDqdx](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L585) |                                                                                          |
+| [EventHeader](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L145)         | [MCParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L155)        | [SimTrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L224)         |
+| [CaloHitContribution](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L258) | [SimCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L270) | [RawCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L282)     |
+| [CalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L291)      | [ParticleID](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L303)        | [Cluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L316)               |
+| [TrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L337)          | [TrackerHitPlane](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L354)   | [RawTimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L375)                |
+| [Track](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L388)               | [Vertex](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L407)            | [ReconstructedParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L424) |
+| [SimPrimaryIonizationCluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L528) | [TrackerPulse](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L546) | [RecIonizationCluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L559) |
+| [TimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L570) | [RecDqdx](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L582) |                                                                                          |
 
 **Associations**
 
 | | | |
 |-|-|-|
-| [MCRecoParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L457)        | [MCRecoCaloAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L466)         | [MCRecoTrackerAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L475)         |
-| [MCRecoTrackerHitPlaneAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L484) | [MCRecoCaloParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L493) | [MCRecoClusterParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L502) |
-| [MCRecoTrackParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L511)   | [RecoParticleVertexAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L520) |                                                                                                      |
+| [MCRecoParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L454)        | [MCRecoCaloAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L463)         | [MCRecoTrackerAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L472)         |
+| [MCRecoTrackerHitPlaneAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L481) | [MCRecoCaloParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L490) | [MCRecoClusterParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L499) |
+| [MCRecoTrackParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L508)   | [RecoParticleVertexAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L517) |                                                                                                      |
 
 The tests and examples in the `tests` directory show how to read, write, and use these types in your code.
 

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -44,14 +44,11 @@ components:
         - double y
         - double z
       ExtraCode:
-        includes: "#include <edm4hep/Vector3f.h>"
         declaration: "
         constexpr Vector3d() : x(0),y(0),z(0) {}\n
         constexpr Vector3d(double xx, double yy, double zz) : x(xx),y(yy),z(zz) {}\n
         constexpr Vector3d(const double* v) : x(v[0]),y(v[1]),z(v[2]) {}\n
         constexpr Vector3d(const float* v) : x(v[0]),y(v[1]),z(v[2]) {}\n
-        [[ deprecated(\"This constructor will be removed again it is mainly here for an easier transition\") ]]\n
-        constexpr Vector3d(const Vector3f& v) : x(v.x), y(v.y), z(v.z) {}\n
         constexpr bool operator==(const Vector3d& v) const { return (x==v.x&&y==v.y&&z==v.z) ; }\n
         constexpr double operator[](unsigned i) const { return *( &x + i ) ; }\n
         "
@@ -167,8 +164,8 @@ datatypes:
       - double mass                     //mass of the particle in [GeV]
       - edm4hep::Vector3d vertex              //production vertex of the particle in [mm].
       - edm4hep::Vector3d endpoint            //endpoint of the particle in [mm]
-      - edm4hep::Vector3d momentum             //particle 3-momentum at the production vertex in [GeV]
-      - edm4hep::Vector3d momentumAtEndpoint   //particle 3-momentum at the endpoint in [GeV]
+      - edm4hep::Vector3f momentum             //particle 3-momentum at the production vertex in [GeV]
+      - edm4hep::Vector3f momentumAtEndpoint   //particle 3-momentum at the endpoint in [GeV]
       - edm4hep::Vector3f spin                 //spin (helicity) vector of the particle.
       - edm4hep::Vector2i colorFlow                //color flow as defined by the generator
     OneToManyRelations:

--- a/test/utils/test_kinematics.py
+++ b/test/utils/test_kinematics.py
@@ -31,8 +31,8 @@ class TestKinematics(unittest.TestCase):
                            125.0,  # charge
                            edm4hep.Vector3d(0, 0, 0),  # vertex
                            edm4hep.Vector3d(0, 0, 0),  # endpoint
-                           edm4hep.Vector3d(1.0, 2.0, 3.0),  # momentum
-                           edm4hep.Vector3d(0, 0, 0),  # momentumAtEndpoint
+                           edm4hep.Vector3f(1.0, 2.0, 3.0),  # momentum
+                           edm4hep.Vector3f(0, 0, 0),  # momentumAtEndpoint
                            edm4hep.Vector3f(0, 0, 0),  # spin
                            edm4hep.Vector2i(0, 0)  # colorFlow
                            )


### PR DESCRIPTION
Reverts key4hep/EDM4hep#237

BEGINRELEASENOTES

- Revert making MCParticle momenta double precision, since this breaks without schema evolution. (Reverts key4hep/EDM4hep#237)
  - All particle momenta are effectively zeroed out at the moment.

ENDRELEASENOTES

@wdconinc in case you have picked up `edm4hep@0.10.4` already via spack you will most likely run into issues with that.

**We will bring these changes back in the breaking set of things for v1.0.**

Fixes https://github.com/key4hep/k4MarlinWrapper/issues/170