### PR TITLE
Put the schema_version to the correct level

### DIFF
--- a/test/downstream-project-cmake-test/edm4dis.yaml
+++ b/test/downstream-project-cmake-test/edm4dis.yaml
@@ -1,11 +1,12 @@
 ---
+schema_version: 2
+
 options :
   # should getters / setters be prefixed with get / set?
   getSyntax: True
   # should POD members be exposed with getters/setters in classes that have them as members?
   exposePODMembers: False
   includeSubfolder: True
-  schema_version: 2
 
 datatypes:
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Put the `schema_version` to the correct level for the downstream usage tests to keep it working after [podio#556)(https://github.com/AIDASoft/podio/pull/556)

ENDRELEASENOTES