### PR TITLE
Rename EDep to eDep in SimTrackerHit

### DIFF
--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -231,7 +231,7 @@ datatypes:
     Author: "F.Gaede, DESY"
     Members:
       - uint64_t cellID      //ID of the sensor that created this hit
-      - float EDep                     //energy deposited in the hit [GeV].
+      - float eDep                     //energy deposited in the hit [GeV].
       - float time                     //proper time of the hit in the lab frame in [ns].
       - float pathLength               //path length of the particle in the sensitive material that resulted in this hit.
       - int32_t   quality                  //quality bit flag.


### PR DESCRIPTION
BEGINRELEASENOTES
- Rename EDep to eDep in SimTrackerHit for consistency with other uses of "eDep"

ENDRELEASENOTES

Fixes https://github.com/key4hep/EDM4hep/issues/180
I think EDep to eDep fits better the variable usage that we have instead of eDep to EDep