### PR TITLE
Homogenize authors and cleanup docstrings

### DIFF
--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -339,7 +339,7 @@ datatypes:
       - edm4hep::Vector3f    directionError  // covariance matrix of the direction (3 Parameters) [mm^2].
     VectorMembers:
       - float   shapeParameters      // shape parameters. This should be accompanied by a descriptive list of names in the shapeParameterNames collection level metadata, as a vector of strings with the same ordering.
-      - float   subdetectorEnergies  // energy observed in a particular subdetector. Check/set collection parameter ClusterSubdetectorNames for decoding the indices of the array.
+      - float   subdetectorEnergies  // energy observed in a particular subdetector.
     OneToManyRelations:
       - edm4hep::Cluster        clusters     // clusters that have been combined to this cluster.
       - edm4hep::CalorimeterHit hits         // hits that have been combined to this cluster.
@@ -351,7 +351,7 @@ datatypes:
     Author: "EDM4hep authors"
     Members:
       - uint64_t cellID      // ID of the sensor that created this hit.
-      - int32_t type                       // type of raw data hit, either one of edm4hep::RawTimeSeries, edm4hep::SIMTRACKERHIT.
+      - int32_t type                       // type of raw data hit
       - int32_t quality                    // quality bit flag of the hit.
       - float time                     // time of the hit [ns].
       - float eDep                     // energy deposited on the hit [GeV].
@@ -368,7 +368,7 @@ datatypes:
     Author: "EDM4hep authors"
     Members:
       - uint64_t cellID      // ID of the sensor that created this hit.
-      - int32_t type                       // type of raw data hit, either one of edm4hep::RawTimeSeries, edm4hep::SIMTRACKERHIT.
+      - int32_t type                       // type of raw data hit
       - int32_t quality                    // quality bit flag of the hit.
       - float time                     // time of the hit [ns].
       - float eDep                     // energy deposited on the hit [GeV].
@@ -408,7 +408,7 @@ datatypes:
       - float dEdxError                  // error of dEdx.
       - float radiusOfInnermostHit       // radius of the innermost hit that has been used in the track fit.
     VectorMembers:
-      - int32_t subdetectorHitNumbers        // number of hits in particular subdetectors.Check/set collection variable TrackSubdetectorNames for decoding the indices.
+      - int32_t subdetectorHitNumbers        // number of hits in particular subdetectors.
       - edm4hep::TrackState trackStates  // track states.
       - edm4hep::Quantity dxQuantities // different measurements of dx quantities.
     OneToManyRelations:

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -87,14 +87,14 @@ components:
       # Parametrized description of a particle track
     edm4hep::TrackState:
       Members:
-        - int32_t location // for use with At{Other|IP|FirstHit|LastHit|Calorimeter|Vertex}|LastLocation
-        - float D0 // transverse impact parameter
-        - float phi // azimuthal angle
+        - int32_t location // for use with At{Other|IP|FirstHit|LastHit|Calorimeter|Vertex}|LastLocation.
+        - float D0 // transverse impact parameter.
+        - float phi // azimuthal angle.
         - float omega // is the signed curvature of the track in [1/mm].
-        - float Z0 // longitudinal impact parameter
-        - float tanLambda // lambda is the dip angle of the track in r-z
-        - float time // time of the track at this trackstate
-        - edm4hep::Vector3f referencePoint // Reference point of the track parameters, e.g. the origin at the IP, or the position  of the first/last hits or the entry point into the calorimeter. [mm]
+        - float Z0 // longitudinal impact parameter.
+        - float tanLambda // lambda is the dip angle of the track in r-z.
+        - float time // time of the track at this trackstate.
+        - edm4hep::Vector3f referencePoint // Reference point of the track parameters, e.g. the origin at the IP, or the position  of the first/last hits or the entry point into the calorimeter [mm].
         - std::array<float, 21> covMatrix // lower triangular covariance matrix of the track parameters.  the order of parameters is  d0, phi, omega, z0, tan(lambda), time. the array is a row-major flattening of the matrix.
       ExtraCode:
         declaration: "
@@ -122,22 +122,22 @@ components:
     # quantity with an identifier, a value and an error
     edm4hep::Quantity:
       Members:
-        - int16_t type // flag identifying how to interpret the quantity
-        - float value  // value of the quantity
-        - float error  // error on the value of the quantity
+        - int16_t type // flag identifying how to interpret the quantity.
+        - float value  // value of the quantity.
+        - float error  // error on the value of the quantity.
 
 
     # Hypothesis for 5 particle types
     edm4hep::Hypothesis:
       Members:
-        - float chi2       // chi2
-        - float expected   // expected value
-        - float sigma      // sigma value
+        - float chi2       // chi2.
+        - float expected   // expected value.
+        - float sigma      // sigma value.
 
     # Reconstructed hit information
     edm4hep::HitLevelData:
       Members:
-        - uint64_t cellID  // cell id
+        - uint64_t cellID  // cell id.
         - uint32_t N       // number of reconstructed ionization cluster.
         - float eDep        // reconstructed energy deposit [GeV].
         - float pathLength  // track path length [mm].
@@ -149,10 +149,10 @@ datatypes:
     Description: "Event Header. Additional parameters are assumed to go into the metadata tree."
     Author: "EDM4hep authors"
     Members:
-      - int32_t eventNumber    // event number
-      - int32_t runNumber      // run number
-      - uint64_t timeStamp     // time stamp
-      - double weight       // event weight
+      - int32_t eventNumber    // event number.
+      - int32_t runNumber      // run number.
+      - uint64_t timeStamp     // time stamp.
+      - double weight       // event weight.
     VectorMembers:
       - double weights       // event weights in case there are multiple. **NOTE that weights[0] might not be the same as weight!** Event weight names should be stored using the edm4hep::EventWeights name in the file level metadata.
 
@@ -161,18 +161,18 @@ datatypes:
     Description: "The Monte Carlo particle - based on the lcio::MCParticle."
     Author: "EDM4hep authors"
     Members:
-      - int32_t PDG                         // PDG code of the particle
-      - int32_t generatorStatus             // status of the particle as defined by the generator
-      - int32_t simulatorStatus             // status of the particle from the simulation program - use BIT constants below
-      - float charge                    // particle charge
+      - int32_t PDG                         // PDG code of the particle.
+      - int32_t generatorStatus             // status of the particle as defined by the generator.
+      - int32_t simulatorStatus             // status of the particle from the simulation program - use BIT constants below.
+      - float charge                    // particle charge.
       - float time                      // creation time of the particle in [ns] wrt. the event, e.g. for preassigned decays or decays in flight from the simulator.
-      - double mass                     // mass of the particle in [GeV]
+      - double mass                     // mass of the particle in [GeV].
       - edm4hep::Vector3d vertex              // production vertex of the particle in [mm].
-      - edm4hep::Vector3d endpoint            // endpoint of the particle in [mm]
-      - edm4hep::Vector3d momentum             // particle 3-momentum at the production vertex in [GeV]
-      - edm4hep::Vector3d momentumAtEndpoint   // particle 3-momentum at the endpoint in [GeV]
+      - edm4hep::Vector3d endpoint            // endpoint of the particle in [mm].
+      - edm4hep::Vector3d momentum             // particle 3-momentum at the production vertex in [GeV].
+      - edm4hep::Vector3d momentumAtEndpoint   // particle 3-momentum at the endpoint in [GeV].
       - edm4hep::Vector3f spin                 // spin (helicity) vector of the particle.
-      - edm4hep::Vector2i colorFlow                // color flow as defined by the generator
+      - edm4hep::Vector2i colorFlow                // color flow as defined by the generator.
     OneToManyRelations:
       - edm4hep::MCParticle parents // The parents of this particle.
       - edm4hep::MCParticle daughters // The daughters this particle.
@@ -272,8 +272,8 @@ datatypes:
     Author: "EDM4hep authors"
     Members:
       - int32_t   PDG                        // PDG code of the shower particle that caused this contribution.
-      - float energy                     // energy in [GeV] of the this contribution
-      - float time                       // time in [ns] of this contribution
+      - float energy                     // energy in [GeV] of the this contribution.
+      - float time                       // time in [ns] of this contribution.
       - edm4hep::Vector3f stepPosition   // position of this energy deposition (step) [mm]
     OneToOneRelations:
       - edm4hep::MCParticle particle     // primary MCParticle that caused the shower responsible for this contribution to the hit.
@@ -283,11 +283,11 @@ datatypes:
     Description: "Simulated calorimeter hit"
     Author: "EDM4hep authors"
     Members:
-      - uint64_t cellID       // ID of the sensor that created this hit
+      - uint64_t cellID       // ID of the sensor that created this hit.
       - float energy                    // energy of the hit in [GeV].
       - edm4hep::Vector3f position      // position of the hit in world coordinates in [mm].
     OneToManyRelations:
-      - edm4hep::CaloHitContribution contributions  // Monte Carlo step contribution - parallel to particle
+      - edm4hep::CaloHitContribution contributions  // Monte Carlo step contribution - parallel to particle.
 
 
   #-------------  RawCalorimeterHit
@@ -316,9 +316,9 @@ datatypes:
     Description:  "ParticleID"
     Author: "EDM4hep authors"
     Members:
-      - int32_t   type           // userdefined type
+      - int32_t   type           // userdefined type.
       - int32_t   PDG            // PDG code of this id - ( 999999 ) if unknown.
-      - int32_t   algorithmType  // type of the algorithm/module that created this hypothesis
+      - int32_t   algorithmType  // type of the algorithm/module that created this hypothesis.
       - float likelihood     // likelihood of this hypothesis - in a user defined normalization.
     VectorMembers:
       - float parameters     // parameters associated with this hypothesis.
@@ -330,13 +330,13 @@ datatypes:
     Author: "EDM4hep authors"
     Members:
       - int32_t                  type            // flagword that defines the type of cluster. Bits 16-31 are used internally.
-      - float                energy          // energy of the cluster [GeV]
-      - float                energyError     // error on the energy
-      - edm4hep::Vector3f    position        // position of the cluster [mm]
+      - float                energy          // energy of the cluster [GeV].
+      - float                energyError     // error on the energy.
+      - edm4hep::Vector3f    position        // position of the cluster [mm].
       - std::array<float,6>  positionError   // covariance matrix of the position (6 Parameters)
       - float                iTheta          // intrinsic direction of cluster at position  Theta. Not to be confused with direction cluster is seen from IP.
       - float                phi             // intrinsic direction of cluster at position - Phi. Not to be confused with direction cluster is seen from IP.
-      - edm4hep::Vector3f    directionError  // covariance matrix of the direction (3 Parameters) [mm^2]
+      - edm4hep::Vector3f    directionError  // covariance matrix of the direction (3 Parameters) [mm^2].
     VectorMembers:
       - float   shapeParameters      // shape parameters. This should be accompanied by a descriptive list of names in the shapeParameterNames collection level metadata, as a vector of strings with the same ordering.
       - float   subdetectorEnergies  // energy observed in a particular subdetector. Check/set collection parameter ClusterSubdetectorNames for decoding the indices of the array.
@@ -350,7 +350,7 @@ datatypes:
     Description: "Tracker hit"
     Author: "EDM4hep authors"
     Members:
-      - uint64_t cellID      // ID of the sensor that created this hit
+      - uint64_t cellID      // ID of the sensor that created this hit.
       - int32_t type                       // type of raw data hit, either one of edm4hep::RawTimeSeries, edm4hep::SIMTRACKERHIT.
       - int32_t quality                    // quality bit flag of the hit.
       - float time                     // time of the hit [ns].
@@ -367,16 +367,16 @@ datatypes:
     Description: "Tracker hit plane"
     Author: "EDM4hep authors"
     Members:
-      - uint64_t cellID      // ID of the sensor that created this hit
+      - uint64_t cellID      // ID of the sensor that created this hit.
       - int32_t type                       // type of raw data hit, either one of edm4hep::RawTimeSeries, edm4hep::SIMTRACKERHIT.
       - int32_t quality                    // quality bit flag of the hit.
       - float time                     // time of the hit [ns].
       - float eDep                     // energy deposited on the hit [GeV].
       - float eDepError                // error measured on EDep [GeV].
-      - edm4hep::Vector2f u            // measurement direction vector, u lies in the x-y plane
-      - edm4hep::Vector2f v            // measurement direction vector, v is along z
-      - float du                       // measurement error along the direction
-      - float dv                       // measurement error along the direction
+      - edm4hep::Vector2f u            // measurement direction vector, u lies in the x-y plane.
+      - edm4hep::Vector2f v            // measurement direction vector, v is along z.
+      - float du                       // measurement error along the direction.
+      - float dv                       // measurement error along the direction.
       - edm4hep::Vector3d position     // hit position in [mm].
       - std::array<float,6> covMatrix  // covariance of the position (x,y,z), stored as lower triangle matrix. i.e. cov(x,x) , cov(y,x) , cov(y,y) , cov(z,x) , cov(z,y) , cov(z,z)
     VectorMembers:
@@ -401,28 +401,28 @@ datatypes:
     Description: "Reconstructed track"
     Author: "EDM4hep authors"
     Members:
-      - int32_t type                         // flagword that defines the type of track.Bits 16-31 are used internally
-      - float chi2                       // Chi^2 of the track fit
-      - int32_t ndf                          // number of degrees of freedom of the track fit
+      - int32_t type                         // flagword that defines the type of track.Bits 16-31 are used internally.
+      - float chi2                       // Chi^2 of the track fit.
+      - int32_t ndf                          // number of degrees of freedom of the track fit.
       - float dEdx                       // dEdx of the track.
       - float dEdxError                  // error of dEdx.
-      - float radiusOfInnermostHit       // radius of the innermost hit that has been used in the track fit
+      - float radiusOfInnermostHit       // radius of the innermost hit that has been used in the track fit.
     VectorMembers:
-      - int32_t subdetectorHitNumbers        // number of hits in particular subdetectors.Check/set collection variable TrackSubdetectorNames for decoding the indices
-      - edm4hep::TrackState trackStates  // track states
-      - edm4hep::Quantity dxQuantities // different measurements of dx quantities
+      - int32_t subdetectorHitNumbers        // number of hits in particular subdetectors.Check/set collection variable TrackSubdetectorNames for decoding the indices.
+      - edm4hep::TrackState trackStates  // track states.
+      - edm4hep::Quantity dxQuantities // different measurements of dx quantities.
     OneToManyRelations:
-      - edm4hep::TrackerHit trackerHits  // hits that have been used to create this track
-      - edm4hep::Track tracks            // tracks (segments) that have been combined to create this track
+      - edm4hep::TrackerHit trackerHits  // hits that have been used to create this track.
+      - edm4hep::Track tracks            // tracks (segments) that have been combined to create this track.
 
  #---------- Vertex
   edm4hep::Vertex:
     Description: "Vertex"
     Author: "EDM4hep authors"
     Members:
-      - int32_t                 primary       // boolean flag, if vertex is the primary vertex of the event
-      - float               chi2          // chi-squared of the vertex fit
-      - float               probability   // probability of the vertex fit
+      - int32_t                 primary       // boolean flag, if vertex is the primary vertex of the event.
+      - float               chi2          // chi-squared of the vertex fit.
+      - float               probability   // probability of the vertex fit.
       - edm4hep::Vector3f   position      // [mm] position of the vertex.
       - std::array<float,6> covMatrix     // covariance matrix of the position (stored as lower triangle matrix, i.e. cov(xx),cov(y,x),cov(z,x),cov(y,y),... )
       - int32_t                 algorithmType // type code for the algorithm that has been used to create the vertex.
@@ -440,14 +440,14 @@ datatypes:
       - int32_t                PDG            // PDG of the reconstructed particle.
       - float                  energy         // [GeV] energy of the reconstructed particle. Four momentum state is not kept consistent internally.
       - edm4hep::Vector3f      momentum       // [GeV] particle momentum. Four momentum state is not kept consistent internally.
-      - edm4hep::Vector3f      referencePoint // [mm] reference, i.e. where the particle has been measured
+      - edm4hep::Vector3f      referencePoint // [mm] reference, i.e. where the particle has been measured.
       - float                  charge         // charge of the reconstructed particle.
       - float                  mass           // [GeV] mass of the reconstructed particle, set independently from four vector. Four momentum state is not kept consistent internally.
-      - float                  goodnessOfPID  // overall goodness of the PID on a scale of [0;1]
+      - float                  goodnessOfPID  // overall goodness of the PID on a scale of [0;1].
       - std::array<float,10>   covMatrix      // cvariance matrix of the reconstructed particle 4vector (10 parameters). Stored as lower triangle matrix of the four momentum (px,py,pz,E), i.e. cov(px,px), cov(py,##
     OneToOneRelations:
-      - edm4hep::Vertex          startVertex    // start vertex associated to this particle
-      - edm4hep::ParticleID      particleIDUsed // particle Id used for the kinematics of this particle
+      - edm4hep::Vertex          startVertex    // start vertex associated to this particle.
+      - edm4hep::ParticleID      particleIDUsed // particle Id used for the kinematics of this particle.
     OneToManyRelations:
       - edm4hep::Cluster               clusters     // clusters that have been used for this particle.
       - edm4hep::Track                 tracks       // tracks that have been used for this particle.
@@ -471,73 +471,73 @@ datatypes:
     Description: "Used to keep track of the correspondence between MC and reconstructed particles"
     Author: "EDM4hep authors"
     Members:
-      - float weight                        // weight of this association
+      - float weight                        // weight of this association.
     OneToOneRelations:
-     - edm4hep::ReconstructedParticle  rec  // reference to the reconstructed particle
-     - edm4hep::MCParticle sim              // reference to the Monte-Carlo particle
+     - edm4hep::ReconstructedParticle  rec  // reference to the reconstructed particle.
+     - edm4hep::MCParticle sim              // reference to the Monte-Carlo particle.
 
   edm4hep::MCRecoCaloAssociation:
     Description: "Association between a CaloHit and the corresponding simulated CaloHit"
     Author: "EDM4hep authors"
     Members:
-      - float weight                    // weight of this association
+      - float weight                    // weight of this association.
     OneToOneRelations:
-     - edm4hep::CalorimeterHit rec     // reference to the reconstructed hit
-     - edm4hep::SimCalorimeterHit sim  // reference to the simulated hit
+     - edm4hep::CalorimeterHit rec     // reference to the reconstructed hit.
+     - edm4hep::SimCalorimeterHit sim  // reference to the simulated hit.
 
   edm4hep::MCRecoTrackerAssociation:
     Description: "Association between a TrackerHit and the corresponding simulated TrackerHit"
     Author: "EDM4hep authors"
     Members:
-      - float weight              // weight of this association
+      - float weight              // weight of this association.
     OneToOneRelations:
-     - edm4hep::TrackerHit rec    // reference to the reconstructed hit
-     - edm4hep::SimTrackerHit sim // reference to the simulated hit
+     - edm4hep::TrackerHit rec    // reference to the reconstructed hit.
+     - edm4hep::SimTrackerHit sim // reference to the simulated hit.
 
   edm4hep::MCRecoTrackerHitPlaneAssociation:
     Description: "Association between a TrackerHitPlane and the corresponding simulated TrackerHit"
     Author: "EDM4hep authors"
     Members:
-      - float weight                // weight of this association
+      - float weight                // weight of this association.
     OneToOneRelations:
-     - edm4hep::TrackerHitPlane rec // reference to the reconstructed hit
-     - edm4hep::SimTrackerHit sim   // reference to the simulated hit
+     - edm4hep::TrackerHitPlane rec // reference to the reconstructed hit.
+     - edm4hep::SimTrackerHit sim   // reference to the simulated hit.
 
   edm4hep::MCRecoCaloParticleAssociation:
     Description: "Association between a CalorimeterHit and a MCParticle"
     Author: "EDM4hep authors"
     Members:
-      - float weight                // weight of this association
+      - float weight                // weight of this association.
     OneToOneRelations:
-     - edm4hep::CalorimeterHit rec  // reference to the reconstructed hit
-     - edm4hep::MCParticle sim      // reference to the Monte-Carlo particle
+     - edm4hep::CalorimeterHit rec  // reference to the reconstructed hit.
+     - edm4hep::MCParticle sim      // reference to the Monte-Carlo particle.
 
   edm4hep::MCRecoClusterParticleAssociation:
     Description: "Association between a Cluster and a MCParticle"
     Author: "EDM4hep authors"
     Members:
-      - float weight                // weight of this association
+      - float weight                // weight of this association.
     OneToOneRelations:
-     - edm4hep::Cluster rec         // reference to the cluster
-     - edm4hep::MCParticle sim      // reference to the Monte-Carlo particle
+     - edm4hep::Cluster rec         // reference to the cluster.
+     - edm4hep::MCParticle sim      // reference to the Monte-Carlo particle.
 
   edm4hep::MCRecoTrackParticleAssociation:
     Description: "Association between a Track and a MCParticle"
     Author: "EDM4hep authors"
     Members:
-      - float weight                // weight of this association
+      - float weight                // weight of this association.
     OneToOneRelations:
-     - edm4hep::Track   rec         // reference to the track
-     - edm4hep::MCParticle sim      // reference to the Monte-Carlo particle
+     - edm4hep::Track   rec         // reference to the track.
+     - edm4hep::MCParticle sim      // reference to the Monte-Carlo particle.
 
   edm4hep::RecoParticleVertexAssociation:
     Description: "Association between a Reconstructed Particle and a Vertex"
     Author: "EDM4hep authors"
     Members:
-      - float weight                      // weight of this association
+      - float weight                      // weight of this association.
     OneToOneRelations:
-     - edm4hep::ReconstructedParticle rec // reference to the reconstructed particle
-     - edm4hep::Vertex vertex             // reference to the vertex
+     - edm4hep::ReconstructedParticle rec // reference to the reconstructed particle.
+     - edm4hep::Vertex vertex             // reference to the vertex.
 
 
   #----------- SimPrimaryIonizationCluster
@@ -615,11 +615,11 @@ datatypes:
     Description: "dN/dx or dE/dx info of Track."
     Author: "EDM4hep authors"
     Members:
-      - edm4hep::Quantity dQdx         // the reconstructed dEdx or dNdx and its error
+      - edm4hep::Quantity dQdx         // the reconstructed dEdx or dNdx and its error.
       - int16_t particleType           // particle type, e(0),mu(1),pi(2),K(3),p(4).
       - int16_t type                   // type.
-      - std::array<edm4hep::Hypothesis, 5> hypotheses //5 particle hypothesis
+      - std::array<edm4hep::Hypothesis, 5> hypotheses // 5 particle hypothesis.
     VectorMembers:
-      - edm4hep::HitLevelData hitData   // hit level data
+      - edm4hep::HitLevelData hitData   // hit level data.
     OneToOneRelations:
       - edm4hep::Track track           // the corresponding track.

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -309,7 +309,7 @@ datatypes:
       - float energyError          //error of the hit energy in [GeV].
       - float time                 //time of the hit in [ns].
       - edm4hep::Vector3f position //position of the hit in world coordinates in [mm].
-      - int32_t type                   //type of hit. Mapping of integer types to names via collection parameters "CalorimeterHitTypeNames" and "CalorimeterHitTypeValues".
+      - int32_t type                   //type of hit.
 
  #---------- ParticleID
   edm4hep::ParticleID:
@@ -321,7 +321,7 @@ datatypes:
       - int32_t   algorithmType  //type of the algorithm/module that created this hypothesis
       - float likelihood     //likelihood of this hypothesis - in a user defined normalization.
     VectorMembers:
-      - float parameters     //parameters associated with this hypothesis. Check/set collection parameters ParameterNames_PIDAlgorithmTypeName for decoding the indices.
+      - float parameters     //parameters associated with this hypothesis.
 
 
  #------ Cluster
@@ -338,7 +338,7 @@ datatypes:
       - float                phi             //intrinsic direction of cluster at position - Phi. Not to be confused with direction cluster is seen from IP.
       - edm4hep::Vector3f    directionError  //covariance matrix of the direction (3 Parameters) [mm^2]
     VectorMembers:
-      - float   shapeParameters      //shape parameters - check/set collection parameter ClusterShapeParameters for size and names of parameters.
+      - float   shapeParameters      //shape parameters. This should be accompanied by a descriptive list of names in the shapeParameterNames collection level metadata, as a vector of strings with the same ordering.
       - float   subdetectorEnergies  //energy observed in a particular subdetector. Check/set collection parameter ClusterSubdetectorNames for decoding the indices of the array.
     OneToManyRelations:
       - edm4hep::Cluster        clusters     //clusters that have been combined to this cluster.
@@ -351,7 +351,7 @@ datatypes:
     Author: "EDM4hep authors"
     Members:
       - uint64_t cellID      //ID of the sensor that created this hit
-      - int32_t type                       //type of raw data hit, either one of edm4hep::RawTimeSeries, edm4hep::SIMTRACKERHIT - see collection parameters "TrackerHitTypeNames" and "TrackerHitTypeValues".
+      - int32_t type                       //type of raw data hit, either one of edm4hep::RawTimeSeries, edm4hep::SIMTRACKERHIT.
       - int32_t quality                    //quality bit flag of the hit.
       - float time                     //time of the hit [ns].
       - float eDep                     //energy deposited on the hit [GeV].
@@ -368,7 +368,7 @@ datatypes:
     Author: "EDM4hep authors"
     Members:
       - uint64_t cellID      //ID of the sensor that created this hit
-      - int32_t type                       //type of raw data hit, either one of edm4hep::RawTimeSeries, edm4hep::SIMTRACKERHIT - see collection parameters "TrackerHitTypeNames" and "TrackerHitTypeValues".
+      - int32_t type                       //type of raw data hit, either one of edm4hep::RawTimeSeries, edm4hep::SIMTRACKERHIT.
       - int32_t quality                    //quality bit flag of the hit.
       - float time                     //time of the hit [ns].
       - float eDep                     //energy deposited on the hit [GeV].
@@ -425,9 +425,9 @@ datatypes:
       - float               probability   //probability of the vertex fit
       - edm4hep::Vector3f   position      // [mm] position of the vertex.
       - std::array<float,6> covMatrix     //covariance matrix of the position (stored as lower triangle matrix, i.e. cov(xx),cov(y,x),cov(z,x),cov(y,y),... )
-      - int32_t                 algorithmType //type code for the algorithm that has been used to create the vertex - check/set the collection parameters AlgorithmName and AlgorithmType.
+      - int32_t                 algorithmType //type code for the algorithm that has been used to create the vertex.
     VectorMembers:
-      - float               parameters    //additional parameters related to this vertex - check/set the collection parameter "VertexParameterNames" for the parameters meaning.
+      - float               parameters    //additional parameters related to this vertex.
     OneToOneRelations:
       - edm4hep::ReconstructedParticle associatedParticle //reconstructed particle associated to this vertex.
 

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -149,9 +149,9 @@ datatypes:
     Description: "Event Header. Additional parameters are assumed to go into the metadata tree."
     Author: "EDM4hep authors"
     Members:
-      - int32_t eventNumber    //event number
-      - int32_t runNumber      //run number
-      - uint64_t timeStamp     //time stamp
+      - int32_t eventNumber    // event number
+      - int32_t runNumber      // run number
+      - uint64_t timeStamp     // time stamp
       - double weight       // event weight
     VectorMembers:
       - double weights       // event weights in case there are multiple. **NOTE that weights[0] might not be the same as weight!** Event weight names should be stored using the edm4hep::EventWeights name in the file level metadata.
@@ -161,18 +161,18 @@ datatypes:
     Description: "The Monte Carlo particle - based on the lcio::MCParticle."
     Author: "EDM4hep authors"
     Members:
-      - int32_t PDG                         //PDG code of the particle
-      - int32_t generatorStatus             //status of the particle as defined by the generator
-      - int32_t simulatorStatus             //status of the particle from the simulation program - use BIT constants below
-      - float charge                    //particle charge
-      - float time                      //creation time of the particle in [ns] wrt. the event, e.g. for preassigned decays or decays in flight from the simulator.
-      - double mass                     //mass of the particle in [GeV]
-      - edm4hep::Vector3d vertex              //production vertex of the particle in [mm].
-      - edm4hep::Vector3d endpoint            //endpoint of the particle in [mm]
-      - edm4hep::Vector3d momentum             //particle 3-momentum at the production vertex in [GeV]
-      - edm4hep::Vector3d momentumAtEndpoint   //particle 3-momentum at the endpoint in [GeV]
-      - edm4hep::Vector3f spin                 //spin (helicity) vector of the particle.
-      - edm4hep::Vector2i colorFlow                //color flow as defined by the generator
+      - int32_t PDG                         // PDG code of the particle
+      - int32_t generatorStatus             // status of the particle as defined by the generator
+      - int32_t simulatorStatus             // status of the particle from the simulation program - use BIT constants below
+      - float charge                    // particle charge
+      - float time                      // creation time of the particle in [ns] wrt. the event, e.g. for preassigned decays or decays in flight from the simulator.
+      - double mass                     // mass of the particle in [GeV]
+      - edm4hep::Vector3d vertex              // production vertex of the particle in [mm].
+      - edm4hep::Vector3d endpoint            // endpoint of the particle in [mm]
+      - edm4hep::Vector3d momentum             // particle 3-momentum at the production vertex in [GeV]
+      - edm4hep::Vector3d momentumAtEndpoint   // particle 3-momentum at the endpoint in [GeV]
+      - edm4hep::Vector3f spin                 // spin (helicity) vector of the particle.
+      - edm4hep::Vector2i colorFlow                // color flow as defined by the generator
     OneToManyRelations:
       - edm4hep::MCParticle parents // The parents of this particle.
       - edm4hep::MCParticle daughters // The daughters this particle.
@@ -229,15 +229,15 @@ datatypes:
     Description: "Simulated tracker hit"
     Author: "EDM4hep authors"
     Members:
-      - uint64_t cellID      //ID of the sensor that created this hit
-      - float eDep                     //energy deposited in the hit [GeV].
-      - float time                     //proper time of the hit in the lab frame in [ns].
-      - float pathLength               //path length of the particle in the sensitive material that resulted in this hit.
-      - int32_t   quality                  //quality bit flag.
-      - edm4hep::Vector3d position     //the hit position in [mm].
-      - edm4hep::Vector3f momentum     //the 3-momentum of the particle at the hits position in [GeV]
+      - uint64_t cellID      // ID of the sensor that created this hit.
+      - float eDep                     // energy deposited in the hit [GeV].
+      - float time                     // proper time of the hit in the lab frame in [ns].
+      - float pathLength               // path length of the particle in the sensitive material that resulted in this hit.
+      - int32_t   quality                  // quality bit flag.
+      - edm4hep::Vector3d position     // the hit position in [mm].
+      - edm4hep::Vector3f momentum     // the 3-momentum of the particle at the hits position in [GeV].
     OneToOneRelations:
-      - edm4hep::MCParticle particle //MCParticle that caused the hit.
+      - edm4hep::MCParticle particle // MCParticle that caused the hit.
     MutableExtraCode:
       includes: "
       #include <cmath>\n
@@ -271,23 +271,23 @@ datatypes:
     Description: "Monte Carlo contribution to SimCalorimeterHit"
     Author: "EDM4hep authors"
     Members:
-      - int32_t   PDG                        //PDG code of the shower particle that caused this contribution.
-      - float energy                     //energy in [GeV] of the this contribution
-      - float time                       //time in [ns] of this contribution
-      - edm4hep::Vector3f stepPosition   //position of this energy deposition (step) [mm]
+      - int32_t   PDG                        // PDG code of the shower particle that caused this contribution.
+      - float energy                     // energy in [GeV] of the this contribution
+      - float time                       // time in [ns] of this contribution
+      - edm4hep::Vector3f stepPosition   // position of this energy deposition (step) [mm]
     OneToOneRelations:
-      - edm4hep::MCParticle particle     //primary MCParticle that caused the shower responsible for this contribution to the hit.
+      - edm4hep::MCParticle particle     // primary MCParticle that caused the shower responsible for this contribution to the hit.
 
   #------------- SimCalorimeterHit
   edm4hep::SimCalorimeterHit:
     Description: "Simulated calorimeter hit"
     Author: "EDM4hep authors"
     Members:
-      - uint64_t cellID       //ID of the sensor that created this hit
-      - float energy                    //energy of the hit in [GeV].
-      - edm4hep::Vector3f position      //position of the hit in world coordinates in [mm].
+      - uint64_t cellID       // ID of the sensor that created this hit
+      - float energy                    // energy of the hit in [GeV].
+      - edm4hep::Vector3f position      // position of the hit in world coordinates in [mm].
     OneToManyRelations:
-      - edm4hep::CaloHitContribution contributions  //Monte Carlo step contribution - parallel to particle
+      - edm4hep::CaloHitContribution contributions  // Monte Carlo step contribution - parallel to particle
 
 
   #-------------  RawCalorimeterHit
@@ -295,33 +295,33 @@ datatypes:
     Description: "Raw calorimeter hit"
     Author: "EDM4hep authors"
     Members:
-      - uint64_t cellID   //detector specific (geometrical) cell id.
-      - int32_t amplitude               //amplitude of the hit in ADC counts.
-      - int32_t timeStamp               //time stamp for the hit.
+      - uint64_t cellID   // detector specific (geometrical) cell id.
+      - int32_t amplitude               // amplitude of the hit in ADC counts.
+      - int32_t timeStamp               // time stamp for the hit.
 
   #-------------  CalorimeterHit
   edm4hep::CalorimeterHit:
     Description: "Calorimeter hit"
     Author: "EDM4hep authors"
     Members:
-      - uint64_t cellID  //detector specific (geometrical) cell id.
-      - float energy               //energy of the hit in [GeV].
-      - float energyError          //error of the hit energy in [GeV].
-      - float time                 //time of the hit in [ns].
-      - edm4hep::Vector3f position //position of the hit in world coordinates in [mm].
-      - int32_t type                   //type of hit.
+      - uint64_t cellID  // detector specific (geometrical) cell id.
+      - float energy               // energy of the hit in [GeV].
+      - float energyError          // error of the hit energy in [GeV].
+      - float time                 // time of the hit in [ns].
+      - edm4hep::Vector3f position // position of the hit in world coordinates in [mm].
+      - int32_t type                   // type of hit.
 
  #---------- ParticleID
   edm4hep::ParticleID:
     Description:  "ParticleID"
     Author: "EDM4hep authors"
     Members:
-      - int32_t   type           //userdefined type
-      - int32_t   PDG            //PDG code of this id - ( 999999 ) if unknown.
-      - int32_t   algorithmType  //type of the algorithm/module that created this hypothesis
-      - float likelihood     //likelihood of this hypothesis - in a user defined normalization.
+      - int32_t   type           // userdefined type
+      - int32_t   PDG            // PDG code of this id - ( 999999 ) if unknown.
+      - int32_t   algorithmType  // type of the algorithm/module that created this hypothesis
+      - float likelihood     // likelihood of this hypothesis - in a user defined normalization.
     VectorMembers:
-      - float parameters     //parameters associated with this hypothesis.
+      - float parameters     // parameters associated with this hypothesis.
 
 
  #------ Cluster
@@ -329,37 +329,37 @@ datatypes:
     Description: "Calorimeter Hit Cluster"
     Author: "EDM4hep authors"
     Members:
-      - int32_t                  type            //flagword that defines the type of cluster. Bits 16-31 are used internally.
-      - float                energy          //energy of the cluster [GeV]
-      - float                energyError     //error on the energy
-      - edm4hep::Vector3f    position        //position of the cluster [mm]
-      - std::array<float,6>  positionError   //covariance matrix of the position (6 Parameters)
-      - float                iTheta          //intrinsic direction of cluster at position  Theta. Not to be confused with direction cluster is seen from IP.
-      - float                phi             //intrinsic direction of cluster at position - Phi. Not to be confused with direction cluster is seen from IP.
-      - edm4hep::Vector3f    directionError  //covariance matrix of the direction (3 Parameters) [mm^2]
+      - int32_t                  type            // flagword that defines the type of cluster. Bits 16-31 are used internally.
+      - float                energy          // energy of the cluster [GeV]
+      - float                energyError     // error on the energy
+      - edm4hep::Vector3f    position        // position of the cluster [mm]
+      - std::array<float,6>  positionError   // covariance matrix of the position (6 Parameters)
+      - float                iTheta          // intrinsic direction of cluster at position  Theta. Not to be confused with direction cluster is seen from IP.
+      - float                phi             // intrinsic direction of cluster at position - Phi. Not to be confused with direction cluster is seen from IP.
+      - edm4hep::Vector3f    directionError  // covariance matrix of the direction (3 Parameters) [mm^2]
     VectorMembers:
-      - float   shapeParameters      //shape parameters. This should be accompanied by a descriptive list of names in the shapeParameterNames collection level metadata, as a vector of strings with the same ordering.
-      - float   subdetectorEnergies  //energy observed in a particular subdetector. Check/set collection parameter ClusterSubdetectorNames for decoding the indices of the array.
+      - float   shapeParameters      // shape parameters. This should be accompanied by a descriptive list of names in the shapeParameterNames collection level metadata, as a vector of strings with the same ordering.
+      - float   subdetectorEnergies  // energy observed in a particular subdetector. Check/set collection parameter ClusterSubdetectorNames for decoding the indices of the array.
     OneToManyRelations:
-      - edm4hep::Cluster        clusters     //clusters that have been combined to this cluster.
-      - edm4hep::CalorimeterHit hits         //hits that have been combined to this cluster.
-      - edm4hep::ParticleID     particleIDs  //particle IDs (sorted by their likelihood)
+      - edm4hep::Cluster        clusters     // clusters that have been combined to this cluster.
+      - edm4hep::CalorimeterHit hits         // hits that have been combined to this cluster.
+      - edm4hep::ParticleID     particleIDs  // particle IDs (sorted by their likelihood)
 
   #-------------  TrackerHit
   edm4hep::TrackerHit:
     Description: "Tracker hit"
     Author: "EDM4hep authors"
     Members:
-      - uint64_t cellID      //ID of the sensor that created this hit
-      - int32_t type                       //type of raw data hit, either one of edm4hep::RawTimeSeries, edm4hep::SIMTRACKERHIT.
-      - int32_t quality                    //quality bit flag of the hit.
-      - float time                     //time of the hit [ns].
-      - float eDep                     //energy deposited on the hit [GeV].
-      - float eDepError                //error measured on EDep [GeV].
-      - edm4hep::Vector3d position     //hit position in [mm].
-      - std::array<float,6> covMatrix  //covariance of the position (x,y,z), stored as lower triangle matrix. i.e. cov(x,x) , cov(y,x) , cov(y,y) , cov(z,x) , cov(z,y) , cov(z,z)
+      - uint64_t cellID      // ID of the sensor that created this hit
+      - int32_t type                       // type of raw data hit, either one of edm4hep::RawTimeSeries, edm4hep::SIMTRACKERHIT.
+      - int32_t quality                    // quality bit flag of the hit.
+      - float time                     // time of the hit [ns].
+      - float eDep                     // energy deposited on the hit [GeV].
+      - float eDepError                // error measured on EDep [GeV].
+      - edm4hep::Vector3d position     // hit position in [mm].
+      - std::array<float,6> covMatrix  // covariance of the position (x,y,z), stored as lower triangle matrix. i.e. cov(x,x) , cov(y,x) , cov(y,y) , cov(z,x) , cov(z,y) , cov(z,z)
     VectorMembers:
-      - edm4hep::ObjectID  rawHits     //raw data hits. Check getType to get actual data type.
+      - edm4hep::ObjectID  rawHits     // raw data hits. Check getType to get actual data type.
 
 
   #-------------  TrackerHitPlane
@@ -367,20 +367,20 @@ datatypes:
     Description: "Tracker hit plane"
     Author: "EDM4hep authors"
     Members:
-      - uint64_t cellID      //ID of the sensor that created this hit
-      - int32_t type                       //type of raw data hit, either one of edm4hep::RawTimeSeries, edm4hep::SIMTRACKERHIT.
-      - int32_t quality                    //quality bit flag of the hit.
-      - float time                     //time of the hit [ns].
-      - float eDep                     //energy deposited on the hit [GeV].
-      - float eDepError                //error measured on EDep [GeV].
-      - edm4hep::Vector2f u            //measurement direction vector, u lies in the x-y plane
-      - edm4hep::Vector2f v            //measurement direction vector, v is along z
-      - float du                       //measurement error along the direction
-      - float dv                       //measurement error along the direction
-      - edm4hep::Vector3d position     //hit position in [mm].
-      - std::array<float,6> covMatrix  //covariance of the position (x,y,z), stored as lower triangle matrix. i.e. cov(x,x) , cov(y,x) , cov(y,y) , cov(z,x) , cov(z,y) , cov(z,z)
+      - uint64_t cellID      // ID of the sensor that created this hit
+      - int32_t type                       // type of raw data hit, either one of edm4hep::RawTimeSeries, edm4hep::SIMTRACKERHIT.
+      - int32_t quality                    // quality bit flag of the hit.
+      - float time                     // time of the hit [ns].
+      - float eDep                     // energy deposited on the hit [GeV].
+      - float eDepError                // error measured on EDep [GeV].
+      - edm4hep::Vector2f u            // measurement direction vector, u lies in the x-y plane
+      - edm4hep::Vector2f v            // measurement direction vector, v is along z
+      - float du                       // measurement error along the direction
+      - float dv                       // measurement error along the direction
+      - edm4hep::Vector3d position     // hit position in [mm].
+      - std::array<float,6> covMatrix  // covariance of the position (x,y,z), stored as lower triangle matrix. i.e. cov(x,x) , cov(y,x) , cov(y,y) , cov(z,x) , cov(z,y) , cov(z,z)
     VectorMembers:
-      - edm4hep::ObjectID  rawHits     //raw data hits. Check getType to get actual data type.
+      - edm4hep::ObjectID  rawHits     // raw data hits. Check getType to get actual data type.
 
 
  #---------- RawTimeSeries
@@ -388,48 +388,48 @@ datatypes:
     Description: "Raw data of a detector readout"
     Author: "EDM4hep authors"
     Members:
-       - uint64_t cellID  //detector specific cell id.
-       - int32_t quality                //quality flag for the hit.
-       - float time                 //time of the hit [ns].
-       - float charge               //integrated charge of the hit [fC].
-       - float interval             //interval of each sampling [ns].
+       - uint64_t cellID  // detector specific cell id.
+       - int32_t quality                // quality flag for the hit.
+       - float time                 // time of the hit [ns].
+       - float charge               // integrated charge of the hit [fC].
+       - float interval             // interval of each sampling [ns].
     VectorMembers:
-       - int32_t adcCounts          //raw data (32-bit) word at i.
+       - int32_t adcCounts          // raw data (32-bit) word at i.
 
  #-------- Track
   edm4hep::Track:
     Description: "Reconstructed track"
     Author: "EDM4hep authors"
     Members:
-      - int32_t type                         //flagword that defines the type of track.Bits 16-31 are used internally
-      - float chi2                       //Chi^2 of the track fit
-      - int32_t ndf                          //number of degrees of freedom of the track fit
-      - float dEdx                       //dEdx of the track.
-      - float dEdxError                  //error of dEdx.
-      - float radiusOfInnermostHit       //radius of the innermost hit that has been used in the track fit
+      - int32_t type                         // flagword that defines the type of track.Bits 16-31 are used internally
+      - float chi2                       // Chi^2 of the track fit
+      - int32_t ndf                          // number of degrees of freedom of the track fit
+      - float dEdx                       // dEdx of the track.
+      - float dEdxError                  // error of dEdx.
+      - float radiusOfInnermostHit       // radius of the innermost hit that has been used in the track fit
     VectorMembers:
-      - int32_t subdetectorHitNumbers        //number of hits in particular subdetectors.Check/set collection variable TrackSubdetectorNames for decoding the indices
-      - edm4hep::TrackState trackStates  //track states
+      - int32_t subdetectorHitNumbers        // number of hits in particular subdetectors.Check/set collection variable TrackSubdetectorNames for decoding the indices
+      - edm4hep::TrackState trackStates  // track states
       - edm4hep::Quantity dxQuantities // different measurements of dx quantities
     OneToManyRelations:
-      - edm4hep::TrackerHit trackerHits  //hits that have been used to create this track
-      - edm4hep::Track tracks            //tracks (segments) that have been combined to create this track
+      - edm4hep::TrackerHit trackerHits  // hits that have been used to create this track
+      - edm4hep::Track tracks            // tracks (segments) that have been combined to create this track
 
  #---------- Vertex
   edm4hep::Vertex:
     Description: "Vertex"
     Author: "EDM4hep authors"
     Members:
-      - int32_t                 primary       //boolean flag, if vertex is the primary vertex of the event
-      - float               chi2          //chi-squared of the vertex fit
-      - float               probability   //probability of the vertex fit
+      - int32_t                 primary       // boolean flag, if vertex is the primary vertex of the event
+      - float               chi2          // chi-squared of the vertex fit
+      - float               probability   // probability of the vertex fit
       - edm4hep::Vector3f   position      // [mm] position of the vertex.
-      - std::array<float,6> covMatrix     //covariance matrix of the position (stored as lower triangle matrix, i.e. cov(xx),cov(y,x),cov(z,x),cov(y,y),... )
-      - int32_t                 algorithmType //type code for the algorithm that has been used to create the vertex.
+      - std::array<float,6> covMatrix     // covariance matrix of the position (stored as lower triangle matrix, i.e. cov(xx),cov(y,x),cov(z,x),cov(y,y),... )
+      - int32_t                 algorithmType // type code for the algorithm that has been used to create the vertex.
     VectorMembers:
-      - float               parameters    //additional parameters related to this vertex.
+      - float               parameters    // additional parameters related to this vertex.
     OneToOneRelations:
-      - edm4hep::ReconstructedParticle associatedParticle //reconstructed particle associated to this vertex.
+      - edm4hep::ReconstructedParticle associatedParticle // reconstructed particle associated to this vertex.
 
 
   #------- ReconstructedParticle
@@ -441,18 +441,18 @@ datatypes:
       - float                  energy         // [GeV] energy of the reconstructed particle. Four momentum state is not kept consistent internally.
       - edm4hep::Vector3f      momentum       // [GeV] particle momentum. Four momentum state is not kept consistent internally.
       - edm4hep::Vector3f      referencePoint // [mm] reference, i.e. where the particle has been measured
-      - float                  charge         //charge of the reconstructed particle.
+      - float                  charge         // charge of the reconstructed particle.
       - float                  mass           // [GeV] mass of the reconstructed particle, set independently from four vector. Four momentum state is not kept consistent internally.
-      - float                  goodnessOfPID  //overall goodness of the PID on a scale of [0;1]
-      - std::array<float,10>   covMatrix      //cvariance matrix of the reconstructed particle 4vector (10 parameters). Stored as lower triangle matrix of the four momentum (px,py,pz,E), i.e. cov(px,px), cov(py,##
+      - float                  goodnessOfPID  // overall goodness of the PID on a scale of [0;1]
+      - std::array<float,10>   covMatrix      // cvariance matrix of the reconstructed particle 4vector (10 parameters). Stored as lower triangle matrix of the four momentum (px,py,pz,E), i.e. cov(px,px), cov(py,##
     OneToOneRelations:
-      - edm4hep::Vertex          startVertex    //start vertex associated to this particle
-      - edm4hep::ParticleID      particleIDUsed //particle Id used for the kinematics of this particle
+      - edm4hep::Vertex          startVertex    // start vertex associated to this particle
+      - edm4hep::ParticleID      particleIDUsed // particle Id used for the kinematics of this particle
     OneToManyRelations:
-      - edm4hep::Cluster               clusters     //clusters that have been used for this particle.
-      - edm4hep::Track                 tracks       //tracks that have been used for this particle.
-      - edm4hep::ReconstructedParticle particles    //reconstructed particles that have been combined to this particle.
-      - edm4hep::ParticleID            particleIDs  //particle Ids (not sorted by their likelihood)
+      - edm4hep::Cluster               clusters     // clusters that have been used for this particle.
+      - edm4hep::Track                 tracks       // tracks that have been used for this particle.
+      - edm4hep::ReconstructedParticle particles    // reconstructed particles that have been combined to this particle.
+      - edm4hep::ParticleID            particleIDs  // particle Ids (not sorted by their likelihood)
     ExtraCode:
       declaration: "
       bool isCompound() const { return particles_size() > 0 ;}\n
@@ -461,7 +461,7 @@ datatypes:
       "
     MutableExtraCode:
       declaration: "
-      //vertex where the particle decays This method actually returns the start vertex from the first daughter particle found.\n
+      //vertex where the particle decays. This method actually returns the start vertex from the first daughter particle found.\n
       //TODO: edm4hep::Vertex  getEndVertex() { return  edm4hep::Vertex(  (getParticles(0).isAvailable() ? getParticles(0).getStartVertex() :  edm4hep::Vertex(0,0) ) ) ; }\n
       [[deprecated(\"use setPDG instead\")]]\n
       void setType(int32_t pdg) { setPDG(pdg); }\n
@@ -545,18 +545,18 @@ datatypes:
     Description: "Simulated Primary Ionization"
     Author: "EDM4hep authors"
     Members:
-      - uint64_t cellID                      //cell id.
-      - float time                           //the primary ionization's time in the lab frame [ns].
-      - edm4hep::Vector3d position           //the primary ionization's position [mm].
-      - int16_t type                         //type.
+      - uint64_t cellID                      // cell id.
+      - float time                           // the primary ionization's time in the lab frame [ns].
+      - edm4hep::Vector3d position           // the primary ionization's position [mm].
+      - int16_t type                         // type.
     VectorMembers:
-       - uint64_t electronCellID             //cell id.
-       - float electronTime                  //the time in the lab frame [ns].
-       - edm4hep::Vector3d electronPosition  //the position in the lab frame [mm].
-       - float pulseTime                     //the pulse's time in the lab frame [ns].
-       - float pulseAmplitude                //the pulse's amplitude [fC].
+       - uint64_t electronCellID             // cell id.
+       - float electronTime                  // the time in the lab frame [ns].
+       - edm4hep::Vector3d electronPosition  // the position in the lab frame [mm].
+       - float pulseTime                     // the pulse's time in the lab frame [ns].
+       - float pulseAmplitude                // the pulse's amplitude [fC].
     OneToOneRelations:
-      - edm4hep::MCParticle particle       //the particle that caused the ionizing collisions.
+      - edm4hep::MCParticle particle       // the particle that caused the ionizing collisions.
     MutableExtraCode:
       includes: "
       #include <cmath>\n
@@ -579,35 +579,35 @@ datatypes:
     Description: "Reconstructed Tracker Pulse"
     Author: "EDM4hep authors"
     Members:
-       - uint64_t cellID                 //cell id.
-       - float time                      //time [ns].
-       - float charge                    //charge [fC].
-       - int16_t quality                 //quality.
-       - std::array<float,3> covMatrix   //lower triangle covariance matrix of the charge(c) and time(t) measurements.
+       - uint64_t cellID                 // cell id.
+       - float time                      // time [ns].
+       - float charge                    // charge [fC].
+       - int16_t quality                 // quality.
+       - std::array<float,3> covMatrix   // lower triangle covariance matrix of the charge(c) and time(t) measurements.
     OneToOneRelations:
-      - edm4hep::TimeSeries timeSeries   //Optionally, the timeSeries that has been used to create the pulse can be stored with the pulse.
+      - edm4hep::TimeSeries timeSeries   // Optionally, the timeSeries that has been used to create the pulse can be stored with the pulse.
 
  #----------  RecIonizationCluster
   edm4hep::RecIonizationCluster:
     Description: "Reconstructed Ionization Cluster"
     Author: "EDM4hep authors"
     Members:
-       - uint64_t cellID            //cell id.
-       - float significance         //significance.
-       - int16_t type               //type.
+       - uint64_t cellID            // cell id.
+       - float significance         // significance.
+       - int16_t type               // type.
     OneToManyRelations:
-       - edm4hep::TrackerPulse trackerPulse //the TrackerPulse used to create the ionization cluster.
+       - edm4hep::TrackerPulse trackerPulse // the TrackerPulse used to create the ionization cluster.
 
  #----------  TimeSeries
   edm4hep::TimeSeries:
     Description: "Calibrated Detector Data"
     Author: "EDM4hep authors"
     Members:
-       - uint64_t cellID            //cell id.
-       - float time                 //begin time [ns].
-       - float interval             //interval of each sampling [ns].
+       - uint64_t cellID            // cell id.
+       - float time                 // begin time [ns].
+       - float interval             // interval of each sampling [ns].
     VectorMembers:
-       - float amplitude            //calibrated detector data.
+       - float amplitude            // calibrated detector data.
 
 
   #-------------  RecDqdx
@@ -615,11 +615,11 @@ datatypes:
     Description: "dN/dx or dE/dx info of Track."
     Author: "EDM4hep authors"
     Members:
-      - edm4hep::Quantity dQdx         //the reconstructed dEdx or dNdx and its error
-      - int16_t particleType           //particle type, e(0),mu(1),pi(2),K(3),p(4).
-      - int16_t type                   //type.
+      - edm4hep::Quantity dQdx         // the reconstructed dEdx or dNdx and its error
+      - int16_t particleType           // particle type, e(0),mu(1),pi(2),K(3),p(4).
+      - int16_t type                   // type.
       - std::array<edm4hep::Hypothesis, 5> hypotheses //5 particle hypothesis
     VectorMembers:
-      - edm4hep::HitLevelData hitData   //hit level data
+      - edm4hep::HitLevelData hitData   // hit level data
     OneToOneRelations:
-      - edm4hep::Track track           //the corresponding track.
+      - edm4hep::Track track           // the corresponding track.

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -147,7 +147,7 @@ datatypes:
 
   edm4hep::EventHeader:
     Description: "Event Header. Additional parameters are assumed to go into the metadata tree."
-    Author: "F.Gaede"
+    Author: "EDM4hep authors"
     Members:
       - int32_t eventNumber    //event number
       - int32_t runNumber      //run number
@@ -159,7 +159,7 @@ datatypes:
 
   edm4hep::MCParticle:
     Description: "The Monte Carlo particle - based on the lcio::MCParticle."
-    Author: "F.Gaede, DESY"
+    Author: "EDM4hep authors"
     Members:
       - int32_t PDG                         //PDG code of the particle
       - int32_t generatorStatus             //status of the particle as defined by the generator
@@ -227,7 +227,7 @@ datatypes:
   #----------- SimTrackerHit
   edm4hep::SimTrackerHit:
     Description: "Simulated tracker hit"
-    Author: "F.Gaede, DESY"
+    Author: "EDM4hep authors"
     Members:
       - uint64_t cellID      //ID of the sensor that created this hit
       - float eDep                     //energy deposited in the hit [GeV].
@@ -269,7 +269,7 @@ datatypes:
   #------------- CaloHitContribution
   edm4hep::CaloHitContribution:
     Description: "Monte Carlo contribution to SimCalorimeterHit"
-    Author: "F.Gaede, DESY"
+    Author: "EDM4hep authors"
     Members:
       - int32_t   PDG                        //PDG code of the shower particle that caused this contribution.
       - float energy                     //energy in [GeV] of the this contribution
@@ -281,7 +281,7 @@ datatypes:
   #------------- SimCalorimeterHit
   edm4hep::SimCalorimeterHit:
     Description: "Simulated calorimeter hit"
-    Author: "F.Gaede, DESY"
+    Author: "EDM4hep authors"
     Members:
       - uint64_t cellID       //ID of the sensor that created this hit
       - float energy                    //energy of the hit in [GeV].
@@ -293,7 +293,7 @@ datatypes:
   #-------------  RawCalorimeterHit
   edm4hep::RawCalorimeterHit:
     Description: "Raw calorimeter hit"
-    Author: "F.Gaede, DESY"
+    Author: "EDM4hep authors"
     Members:
       - uint64_t cellID   //detector specific (geometrical) cell id.
       - int32_t amplitude               //amplitude of the hit in ADC counts.
@@ -302,7 +302,7 @@ datatypes:
   #-------------  CalorimeterHit
   edm4hep::CalorimeterHit:
     Description: "Calorimeter hit"
-    Author: "F.Gaede, DESY"
+    Author: "EDM4hep authors"
     Members:
       - uint64_t cellID  //detector specific (geometrical) cell id.
       - float energy               //energy of the hit in [GeV].
@@ -314,7 +314,7 @@ datatypes:
  #---------- ParticleID
   edm4hep::ParticleID:
     Description:  "ParticleID"
-    Author: "F.Gaede, DESY"
+    Author: "EDM4hep authors"
     Members:
       - int32_t   type           //userdefined type
       - int32_t   PDG            //PDG code of this id - ( 999999 ) if unknown.
@@ -327,7 +327,7 @@ datatypes:
  #------ Cluster
   edm4hep::Cluster:
     Description: "Calorimeter Hit Cluster"
-    Author: "F.Gaede, DESY"
+    Author: "EDM4hep authors"
     Members:
       - int32_t                  type            //flagword that defines the type of cluster. Bits 16-31 are used internally.
       - float                energy          //energy of the cluster [GeV]
@@ -348,7 +348,7 @@ datatypes:
   #-------------  TrackerHit
   edm4hep::TrackerHit:
     Description: "Tracker hit"
-    Author: "F.Gaede, DESY"
+    Author: "EDM4hep authors"
     Members:
       - uint64_t cellID      //ID of the sensor that created this hit
       - int32_t type                       //type of raw data hit, either one of edm4hep::RawTimeSeries, edm4hep::SIMTRACKERHIT - see collection parameters "TrackerHitTypeNames" and "TrackerHitTypeValues".
@@ -365,7 +365,7 @@ datatypes:
   #-------------  TrackerHitPlane
   edm4hep::TrackerHitPlane:
     Description: "Tracker hit plane"
-    Author: "Placido Fernandez Declara, CERN"
+    Author: "EDM4hep authors"
     Members:
       - uint64_t cellID      //ID of the sensor that created this hit
       - int32_t type                       //type of raw data hit, either one of edm4hep::RawTimeSeries, edm4hep::SIMTRACKERHIT - see collection parameters "TrackerHitTypeNames" and "TrackerHitTypeValues".
@@ -386,7 +386,7 @@ datatypes:
  #---------- RawTimeSeries
   edm4hep::RawTimeSeries:
     Description: "Raw data of a detector readout"
-    Author: "F.Gaede, DESY"
+    Author: "EDM4hep authors"
     Members:
        - uint64_t cellID  //detector specific cell id.
        - int32_t quality                //quality flag for the hit.
@@ -399,7 +399,7 @@ datatypes:
  #-------- Track
   edm4hep::Track:
     Description: "Reconstructed track"
-    Author: "F.Gaede, DESY"
+    Author: "EDM4hep authors"
     Members:
       - int32_t type                         //flagword that defines the type of track.Bits 16-31 are used internally
       - float chi2                       //Chi^2 of the track fit
@@ -418,7 +418,7 @@ datatypes:
  #---------- Vertex
   edm4hep::Vertex:
     Description: "Vertex"
-    Author: "F.Gaede, DESY"
+    Author: "EDM4hep authors"
     Members:
       - int32_t                 primary       //boolean flag, if vertex is the primary vertex of the event
       - float               chi2          //chi-squared of the vertex fit
@@ -435,7 +435,7 @@ datatypes:
   #------- ReconstructedParticle
   edm4hep::ReconstructedParticle:
     Description: "Reconstructed Particle"
-    Author: "F.Gaede, DESY"
+    Author: "EDM4hep authors"
     Members:
       - int32_t                PDG            // PDG of the reconstructed particle.
       - float                  energy         // [GeV] energy of the reconstructed particle. Four momentum state is not kept consistent internally.
@@ -469,7 +469,7 @@ datatypes:
 
   edm4hep::MCRecoParticleAssociation:
     Description: "Used to keep track of the correspondence between MC and reconstructed particles"
-    Author: "C. Bernet, B. Hegner"
+    Author: "EDM4hep authors"
     Members:
       - float weight                        // weight of this association
     OneToOneRelations:
@@ -478,7 +478,7 @@ datatypes:
 
   edm4hep::MCRecoCaloAssociation:
     Description: "Association between a CaloHit and the corresponding simulated CaloHit"
-    Author: "C. Bernet, B. Hegner"
+    Author: "EDM4hep authors"
     Members:
       - float weight                    // weight of this association
     OneToOneRelations:
@@ -487,7 +487,7 @@ datatypes:
 
   edm4hep::MCRecoTrackerAssociation:
     Description: "Association between a TrackerHit and the corresponding simulated TrackerHit"
-    Author: "C. Bernet, B. Hegner"
+    Author: "EDM4hep authors"
     Members:
       - float weight              // weight of this association
     OneToOneRelations:
@@ -496,7 +496,7 @@ datatypes:
 
   edm4hep::MCRecoTrackerHitPlaneAssociation:
     Description: "Association between a TrackerHitPlane and the corresponding simulated TrackerHit"
-    Author: "Placido Fernandez Declara"
+    Author: "EDM4hep authors"
     Members:
       - float weight                // weight of this association
     OneToOneRelations:
@@ -505,7 +505,7 @@ datatypes:
 
   edm4hep::MCRecoCaloParticleAssociation:
     Description: "Association between a CalorimeterHit and a MCParticle"
-    Author: "Placido Fernandez Declara"
+    Author: "EDM4hep authors"
     Members:
       - float weight                // weight of this association
     OneToOneRelations:
@@ -514,7 +514,7 @@ datatypes:
 
   edm4hep::MCRecoClusterParticleAssociation:
     Description: "Association between a Cluster and a MCParticle"
-    Author: "Placido Fernandez Declara"
+    Author: "EDM4hep authors"
     Members:
       - float weight                // weight of this association
     OneToOneRelations:
@@ -523,7 +523,7 @@ datatypes:
 
   edm4hep::MCRecoTrackParticleAssociation:
     Description: "Association between a Track and a MCParticle"
-    Author: "Placido Fernandez Declara"
+    Author: "EDM4hep authors"
     Members:
       - float weight                // weight of this association
     OneToOneRelations:
@@ -532,7 +532,7 @@ datatypes:
 
   edm4hep::RecoParticleVertexAssociation:
     Description: "Association between a Reconstructed Particle and a Vertex"
-    Author: "Placido Fernandez Declara"
+    Author: "EDM4hep authors"
     Members:
       - float weight                      // weight of this association
     OneToOneRelations:
@@ -543,7 +543,7 @@ datatypes:
   #----------- SimPrimaryIonizationCluster
   edm4hep::SimPrimaryIonizationCluster:
     Description: "Simulated Primary Ionization"
-    Author: "Wenxing Fang, IHEP"
+    Author: "EDM4hep authors"
     Members:
       - uint64_t cellID                      //cell id.
       - float time                           //the primary ionization's time in the lab frame [ns].
@@ -577,7 +577,7 @@ datatypes:
  #----------  TrackerPulse
   edm4hep::TrackerPulse:
     Description: "Reconstructed Tracker Pulse"
-    Author: "Wenxing Fang, IHEP"
+    Author: "EDM4hep authors"
     Members:
        - uint64_t cellID                 //cell id.
        - float time                      //time [ns].
@@ -590,7 +590,7 @@ datatypes:
  #----------  RecIonizationCluster
   edm4hep::RecIonizationCluster:
     Description: "Reconstructed Ionization Cluster"
-    Author: "Wenxing Fang, IHEP"
+    Author: "EDM4hep authors"
     Members:
        - uint64_t cellID            //cell id.
        - float significance         //significance.
@@ -601,7 +601,7 @@ datatypes:
  #----------  TimeSeries
   edm4hep::TimeSeries:
     Description: "Calibrated Detector Data"
-    Author: "Wenxing Fang, IHEP"
+    Author: "EDM4hep authors"
     Members:
        - uint64_t cellID            //cell id.
        - float time                 //begin time [ns].
@@ -613,7 +613,7 @@ datatypes:
   #-------------  RecDqdx
   edm4hep::RecDqdx:
     Description: "dN/dx or dE/dx info of Track."
-    Author: "Wenxing Fang, IHEP"
+    Author: "EDM4hep authors"
     Members:
       - edm4hep::Quantity dQdx         //the reconstructed dEdx or dNdx and its error
       - int16_t particleType           //particle type, e(0),mu(1),pi(2),K(3),p(4).

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -87,15 +87,15 @@ components:
       # Parametrized description of a particle track
     edm4hep::TrackState:
       Members:
-        - int32_t location // for use with At{Other|IP|FirstHit|LastHit|Calorimeter|Vertex}|LastLocation.
-        - float D0 // transverse impact parameter.
-        - float phi // azimuthal angle.
-        - float omega // is the signed curvature of the track in [1/mm].
-        - float Z0 // longitudinal impact parameter.
-        - float tanLambda // lambda is the dip angle of the track in r-z.
-        - float time // time of the track at this trackstate.
-        - edm4hep::Vector3f referencePoint // Reference point of the track parameters, e.g. the origin at the IP, or the position  of the first/last hits or the entry point into the calorimeter [mm].
-        - std::array<float, 21> covMatrix // lower triangular covariance matrix of the track parameters.  the order of parameters is  d0, phi, omega, z0, tan(lambda), time. the array is a row-major flattening of the matrix.
+        - int32_t location // for use with At{Other|IP|FirstHit|LastHit|Calorimeter|Vertex}|LastLocation
+        - float D0 // transverse impact parameter
+        - float phi // azimuthal angle
+        - float omega // is the signed curvature of the track in [1/mm]
+        - float Z0 // longitudinal impact parameter
+        - float tanLambda // lambda is the dip angle of the track in r-z
+        - float time // time of the track at this trackstate
+        - edm4hep::Vector3f referencePoint // Reference point of the track parameters, e.g. the origin at the IP, or the position  of the first/last hits or the entry point into the calorimeter [mm]
+        - std::array<float, 21> covMatrix // lower triangular covariance matrix of the track parameters.  the order of parameters is  d0, phi, omega, z0, tan(lambda), time. the array is a row-major flattening of the matrix
       ExtraCode:
         declaration: "
         static const int AtOther = 0 ; // any location other than the ones defined below\n
@@ -122,25 +122,25 @@ components:
     # quantity with an identifier, a value and an error
     edm4hep::Quantity:
       Members:
-        - int16_t type // flag identifying how to interpret the quantity.
-        - float value  // value of the quantity.
-        - float error  // error on the value of the quantity.
+        - int16_t type // flag identifying how to interpret the quantity
+        - float value  // value of the quantity
+        - float error  // error on the value of the quantity
 
 
     # Hypothesis for 5 particle types
     edm4hep::Hypothesis:
       Members:
-        - float chi2       // chi2.
-        - float expected   // expected value.
-        - float sigma      // sigma value.
+        - float chi2       // chi2
+        - float expected   // expected value
+        - float sigma      // sigma value
 
     # Reconstructed hit information
     edm4hep::HitLevelData:
       Members:
-        - uint64_t cellID  // cell id.
-        - uint32_t N       // number of reconstructed ionization cluster.
-        - float eDep        // reconstructed energy deposit [GeV].
-        - float pathLength  // track path length [mm].
+        - uint64_t cellID  // cell id
+        - uint32_t N       // number of reconstructed ionization cluster
+        - float eDep        // reconstructed energy deposit [GeV]
+        - float pathLength  // track path length [mm]
 
 datatypes:
 
@@ -149,33 +149,33 @@ datatypes:
     Description: "Event Header. Additional parameters are assumed to go into the metadata tree."
     Author: "EDM4hep authors"
     Members:
-      - int32_t eventNumber    // event number.
-      - int32_t runNumber      // run number.
-      - uint64_t timeStamp     // time stamp.
-      - double weight       // event weight.
+      - int32_t eventNumber    // event number
+      - int32_t runNumber      // run number
+      - uint64_t timeStamp     // time stamp
+      - double weight       // event weight
     VectorMembers:
-      - double weights       // event weights in case there are multiple. **NOTE that weights[0] might not be the same as weight!** Event weight names should be stored using the edm4hep::EventWeights name in the file level metadata.
+      - double weights       // event weights in case there are multiple. **NOTE that weights[0] might not be the same as weight!** Event weight names should be stored using the edm4hep::EventWeights name in the file level metadata
 
 
   edm4hep::MCParticle:
     Description: "The Monte Carlo particle - based on the lcio::MCParticle."
     Author: "EDM4hep authors"
     Members:
-      - int32_t PDG                         // PDG code of the particle.
-      - int32_t generatorStatus             // status of the particle as defined by the generator.
-      - int32_t simulatorStatus             // status of the particle from the simulation program - use BIT constants below.
-      - float charge                    // particle charge.
-      - float time                      // creation time of the particle in [ns] wrt. the event, e.g. for preassigned decays or decays in flight from the simulator.
-      - double mass                     // mass of the particle in [GeV].
-      - edm4hep::Vector3d vertex              // production vertex of the particle in [mm].
-      - edm4hep::Vector3d endpoint            // endpoint of the particle in [mm].
-      - edm4hep::Vector3d momentum             // particle 3-momentum at the production vertex in [GeV].
-      - edm4hep::Vector3d momentumAtEndpoint   // particle 3-momentum at the endpoint in [GeV].
-      - edm4hep::Vector3f spin                 // spin (helicity) vector of the particle.
-      - edm4hep::Vector2i colorFlow                // color flow as defined by the generator.
+      - int32_t PDG                         // PDG code of the particle
+      - int32_t generatorStatus             // status of the particle as defined by the generator
+      - int32_t simulatorStatus             // status of the particle from the simulation program - use BIT constants below
+      - float charge                    // particle charge
+      - float time                      // creation time of the particle in [ns] wrt. the event, e.g. for preassigned decays or decays in flight from the simulator
+      - double mass                     // mass of the particle in [GeV]
+      - edm4hep::Vector3d vertex              // production vertex of the particle in [mm]
+      - edm4hep::Vector3d endpoint            // endpoint of the particle in [mm]
+      - edm4hep::Vector3d momentum             // particle 3-momentum at the production vertex in [GeV]
+      - edm4hep::Vector3d momentumAtEndpoint   // particle 3-momentum at the endpoint in [GeV]
+      - edm4hep::Vector3f spin                 // spin (helicity) vector of the particle
+      - edm4hep::Vector2i colorFlow                // color flow as defined by the generator
     OneToManyRelations:
-      - edm4hep::MCParticle parents // The parents of this particle.
-      - edm4hep::MCParticle daughters // The daughters this particle.
+      - edm4hep::MCParticle parents // The parents of this particle
+      - edm4hep::MCParticle daughters // The daughters this particle
     MutableExtraCode:
       includes: "#include <cmath>"
       declaration: "
@@ -229,15 +229,15 @@ datatypes:
     Description: "Simulated tracker hit"
     Author: "EDM4hep authors"
     Members:
-      - uint64_t cellID      // ID of the sensor that created this hit.
-      - float eDep                     // energy deposited in the hit [GeV].
-      - float time                     // proper time of the hit in the lab frame in [ns].
-      - float pathLength               // path length of the particle in the sensitive material that resulted in this hit.
-      - int32_t   quality                  // quality bit flag.
-      - edm4hep::Vector3d position     // the hit position in [mm].
-      - edm4hep::Vector3f momentum     // the 3-momentum of the particle at the hits position in [GeV].
+      - uint64_t cellID      // ID of the sensor that created this hit
+      - float eDep                     // energy deposited in the hit [GeV]
+      - float time                     // proper time of the hit in the lab frame in [ns]
+      - float pathLength               // path length of the particle in the sensitive material that resulted in this hit
+      - int32_t   quality                  // quality bit flag
+      - edm4hep::Vector3d position     // the hit position in [mm]
+      - edm4hep::Vector3f momentum     // the 3-momentum of the particle at the hits position in [GeV]
     OneToOneRelations:
-      - edm4hep::MCParticle particle // MCParticle that caused the hit.
+      - edm4hep::MCParticle particle // MCParticle that caused the hit
     MutableExtraCode:
       includes: "
       #include <cmath>\n
@@ -271,23 +271,23 @@ datatypes:
     Description: "Monte Carlo contribution to SimCalorimeterHit"
     Author: "EDM4hep authors"
     Members:
-      - int32_t   PDG                        // PDG code of the shower particle that caused this contribution.
-      - float energy                     // energy in [GeV] of the this contribution.
-      - float time                       // time in [ns] of this contribution.
+      - int32_t   PDG                        // PDG code of the shower particle that caused this contribution
+      - float energy                     // energy in [GeV] of the this contribution
+      - float time                       // time in [ns] of this contribution
       - edm4hep::Vector3f stepPosition   // position of this energy deposition (step) [mm]
     OneToOneRelations:
-      - edm4hep::MCParticle particle     // primary MCParticle that caused the shower responsible for this contribution to the hit.
+      - edm4hep::MCParticle particle     // primary MCParticle that caused the shower responsible for this contribution to the hit
 
   #------------- SimCalorimeterHit
   edm4hep::SimCalorimeterHit:
     Description: "Simulated calorimeter hit"
     Author: "EDM4hep authors"
     Members:
-      - uint64_t cellID       // ID of the sensor that created this hit.
-      - float energy                    // energy of the hit in [GeV].
-      - edm4hep::Vector3f position      // position of the hit in world coordinates in [mm].
+      - uint64_t cellID       // ID of the sensor that created this hit
+      - float energy                    // energy of the hit in [GeV]
+      - edm4hep::Vector3f position      // position of the hit in world coordinates in [mm]
     OneToManyRelations:
-      - edm4hep::CaloHitContribution contributions  // Monte Carlo step contribution - parallel to particle.
+      - edm4hep::CaloHitContribution contributions  // Monte Carlo step contribution - parallel to particle
 
 
   #-------------  RawCalorimeterHit
@@ -295,33 +295,33 @@ datatypes:
     Description: "Raw calorimeter hit"
     Author: "EDM4hep authors"
     Members:
-      - uint64_t cellID   // detector specific (geometrical) cell id.
-      - int32_t amplitude               // amplitude of the hit in ADC counts.
-      - int32_t timeStamp               // time stamp for the hit.
+      - uint64_t cellID   // detector specific (geometrical) cell id
+      - int32_t amplitude               // amplitude of the hit in ADC counts
+      - int32_t timeStamp               // time stamp for the hit
 
   #-------------  CalorimeterHit
   edm4hep::CalorimeterHit:
     Description: "Calorimeter hit"
     Author: "EDM4hep authors"
     Members:
-      - uint64_t cellID  // detector specific (geometrical) cell id.
-      - float energy               // energy of the hit in [GeV].
-      - float energyError          // error of the hit energy in [GeV].
-      - float time                 // time of the hit in [ns].
-      - edm4hep::Vector3f position // position of the hit in world coordinates in [mm].
-      - int32_t type                   // type of hit.
+      - uint64_t cellID  // detector specific (geometrical) cell id
+      - float energy               // energy of the hit in [GeV]
+      - float energyError          // error of the hit energy in [GeV]
+      - float time                 // time of the hit in [ns]
+      - edm4hep::Vector3f position // position of the hit in world coordinates in [mm]
+      - int32_t type                   // type of hit
 
  #---------- ParticleID
   edm4hep::ParticleID:
     Description:  "ParticleID"
     Author: "EDM4hep authors"
     Members:
-      - int32_t   type           // userdefined type.
-      - int32_t   PDG            // PDG code of this id - ( 999999 ) if unknown.
-      - int32_t   algorithmType  // type of the algorithm/module that created this hypothesis.
-      - float likelihood     // likelihood of this hypothesis - in a user defined normalization.
+      - int32_t   type           // userdefined type
+      - int32_t   PDG            // PDG code of this id - ( 999999 ) if unknown
+      - int32_t   algorithmType  // type of the algorithm/module that created this hypothesis
+      - float likelihood     // likelihood of this hypothesis - in a user defined normalization
     VectorMembers:
-      - float parameters     // parameters associated with this hypothesis.
+      - float parameters     // parameters associated with this hypothesis
 
 
  #------ Cluster
@@ -329,20 +329,20 @@ datatypes:
     Description: "Calorimeter Hit Cluster"
     Author: "EDM4hep authors"
     Members:
-      - int32_t                  type            // flagword that defines the type of cluster. Bits 16-31 are used internally.
-      - float                energy          // energy of the cluster [GeV].
-      - float                energyError     // error on the energy.
-      - edm4hep::Vector3f    position        // position of the cluster [mm].
+      - int32_t                  type            // flagword that defines the type of cluster. Bits 16-31 are used internally
+      - float                energy          // energy of the cluster [GeV]
+      - float                energyError     // error on the energy
+      - edm4hep::Vector3f    position        // position of the cluster [mm]
       - std::array<float,6>  positionError   // covariance matrix of the position (6 Parameters)
-      - float                iTheta          // intrinsic direction of cluster at position  Theta. Not to be confused with direction cluster is seen from IP.
-      - float                phi             // intrinsic direction of cluster at position - Phi. Not to be confused with direction cluster is seen from IP.
-      - edm4hep::Vector3f    directionError  // covariance matrix of the direction (3 Parameters) [mm^2].
+      - float                iTheta          // intrinsic direction of cluster at position  Theta. Not to be confused with direction cluster is seen from IP
+      - float                phi             // intrinsic direction of cluster at position - Phi. Not to be confused with direction cluster is seen from IP
+      - edm4hep::Vector3f    directionError  // covariance matrix of the direction (3 Parameters) [mm^2]
     VectorMembers:
-      - float   shapeParameters      // shape parameters. This should be accompanied by a descriptive list of names in the shapeParameterNames collection level metadata, as a vector of strings with the same ordering.
-      - float   subdetectorEnergies  // energy observed in a particular subdetector.
+      - float   shapeParameters      // shape parameters. This should be accompanied by a descriptive list of names in the shapeParameterNames collection level metadata, as a vector of strings with the same ordering
+      - float   subdetectorEnergies  // energy observed in a particular subdetector
     OneToManyRelations:
-      - edm4hep::Cluster        clusters     // clusters that have been combined to this cluster.
-      - edm4hep::CalorimeterHit hits         // hits that have been combined to this cluster.
+      - edm4hep::Cluster        clusters     // clusters that have been combined to this cluster
+      - edm4hep::CalorimeterHit hits         // hits that have been combined to this cluster
       - edm4hep::ParticleID     particleIDs  // particle IDs (sorted by their likelihood)
 
   #-------------  TrackerHit
@@ -350,16 +350,16 @@ datatypes:
     Description: "Tracker hit"
     Author: "EDM4hep authors"
     Members:
-      - uint64_t cellID      // ID of the sensor that created this hit.
+      - uint64_t cellID      // ID of the sensor that created this hit
       - int32_t type                       // type of raw data hit
-      - int32_t quality                    // quality bit flag of the hit.
-      - float time                     // time of the hit [ns].
-      - float eDep                     // energy deposited on the hit [GeV].
-      - float eDepError                // error measured on EDep [GeV].
-      - edm4hep::Vector3d position     // hit position in [mm].
+      - int32_t quality                    // quality bit flag of the hit
+      - float time                     // time of the hit [ns]
+      - float eDep                     // energy deposited on the hit [GeV]
+      - float eDepError                // error measured on EDep [GeV]
+      - edm4hep::Vector3d position     // hit position in [mm]
       - std::array<float,6> covMatrix  // covariance of the position (x,y,z), stored as lower triangle matrix. i.e. cov(x,x) , cov(y,x) , cov(y,y) , cov(z,x) , cov(z,y) , cov(z,z)
     VectorMembers:
-      - edm4hep::ObjectID  rawHits     // raw data hits. Check getType to get actual data type.
+      - edm4hep::ObjectID  rawHits     // raw data hits. Check getType to get actual data type
 
 
   #-------------  TrackerHitPlane
@@ -367,20 +367,20 @@ datatypes:
     Description: "Tracker hit plane"
     Author: "EDM4hep authors"
     Members:
-      - uint64_t cellID      // ID of the sensor that created this hit.
+      - uint64_t cellID      // ID of the sensor that created this hit
       - int32_t type                       // type of raw data hit
-      - int32_t quality                    // quality bit flag of the hit.
-      - float time                     // time of the hit [ns].
-      - float eDep                     // energy deposited on the hit [GeV].
-      - float eDepError                // error measured on EDep [GeV].
-      - edm4hep::Vector2f u            // measurement direction vector, u lies in the x-y plane.
-      - edm4hep::Vector2f v            // measurement direction vector, v is along z.
-      - float du                       // measurement error along the direction.
-      - float dv                       // measurement error along the direction.
-      - edm4hep::Vector3d position     // hit position in [mm].
+      - int32_t quality                    // quality bit flag of the hit
+      - float time                     // time of the hit [ns]
+      - float eDep                     // energy deposited on the hit [GeV]
+      - float eDepError                // error measured on EDep [GeV]
+      - edm4hep::Vector2f u            // measurement direction vector, u lies in the x-y plane
+      - edm4hep::Vector2f v            // measurement direction vector, v is along z
+      - float du                       // measurement error along the direction
+      - float dv                       // measurement error along the direction
+      - edm4hep::Vector3d position     // hit position in [mm]
       - std::array<float,6> covMatrix  // covariance of the position (x,y,z), stored as lower triangle matrix. i.e. cov(x,x) , cov(y,x) , cov(y,y) , cov(z,x) , cov(z,y) , cov(z,z)
     VectorMembers:
-      - edm4hep::ObjectID  rawHits     // raw data hits. Check getType to get actual data type.
+      - edm4hep::ObjectID  rawHits     // raw data hits. Check getType to get actual data type
 
 
  #---------- RawTimeSeries
@@ -388,48 +388,48 @@ datatypes:
     Description: "Raw data of a detector readout"
     Author: "EDM4hep authors"
     Members:
-       - uint64_t cellID  // detector specific cell id.
-       - int32_t quality                // quality flag for the hit.
-       - float time                 // time of the hit [ns].
-       - float charge               // integrated charge of the hit [fC].
-       - float interval             // interval of each sampling [ns].
+       - uint64_t cellID  // detector specific cell id
+       - int32_t quality                // quality flag for the hit
+       - float time                 // time of the hit [ns]
+       - float charge               // integrated charge of the hit [fC]
+       - float interval             // interval of each sampling [ns]
     VectorMembers:
-       - int32_t adcCounts          // raw data (32-bit) word at i.
+       - int32_t adcCounts          // raw data (32-bit) word at i
 
  #-------- Track
   edm4hep::Track:
     Description: "Reconstructed track"
     Author: "EDM4hep authors"
     Members:
-      - int32_t type                         // flagword that defines the type of track.Bits 16-31 are used internally.
-      - float chi2                       // Chi^2 of the track fit.
-      - int32_t ndf                          // number of degrees of freedom of the track fit.
-      - float dEdx                       // dEdx of the track.
-      - float dEdxError                  // error of dEdx.
-      - float radiusOfInnermostHit       // radius of the innermost hit that has been used in the track fit.
+      - int32_t type                         // flagword that defines the type of track.Bits 16-31 are used internally
+      - float chi2                       // Chi^2 of the track fit
+      - int32_t ndf                          // number of degrees of freedom of the track fit
+      - float dEdx                       // dEdx of the track
+      - float dEdxError                  // error of dEdx
+      - float radiusOfInnermostHit       // radius of the innermost hit that has been used in the track fit
     VectorMembers:
-      - int32_t subdetectorHitNumbers        // number of hits in particular subdetectors.
-      - edm4hep::TrackState trackStates  // track states.
-      - edm4hep::Quantity dxQuantities // different measurements of dx quantities.
+      - int32_t subdetectorHitNumbers        // number of hits in particular subdetectors
+      - edm4hep::TrackState trackStates  // track states
+      - edm4hep::Quantity dxQuantities // different measurements of dx quantities
     OneToManyRelations:
-      - edm4hep::TrackerHit trackerHits  // hits that have been used to create this track.
-      - edm4hep::Track tracks            // tracks (segments) that have been combined to create this track.
+      - edm4hep::TrackerHit trackerHits  // hits that have been used to create this track
+      - edm4hep::Track tracks            // tracks (segments) that have been combined to create this track
 
  #---------- Vertex
   edm4hep::Vertex:
     Description: "Vertex"
     Author: "EDM4hep authors"
     Members:
-      - int32_t                 primary       // boolean flag, if vertex is the primary vertex of the event.
-      - float               chi2          // chi-squared of the vertex fit.
-      - float               probability   // probability of the vertex fit.
-      - edm4hep::Vector3f   position      // [mm] position of the vertex.
+      - int32_t                 primary       // boolean flag, if vertex is the primary vertex of the event
+      - float               chi2          // chi-squared of the vertex fit
+      - float               probability   // probability of the vertex fit
+      - edm4hep::Vector3f   position      // [mm] position of the vertex
       - std::array<float,6> covMatrix     // covariance matrix of the position (stored as lower triangle matrix, i.e. cov(xx),cov(y,x),cov(z,x),cov(y,y),... )
-      - int32_t                 algorithmType // type code for the algorithm that has been used to create the vertex.
+      - int32_t                 algorithmType // type code for the algorithm that has been used to create the vertex
     VectorMembers:
-      - float               parameters    // additional parameters related to this vertex.
+      - float               parameters    // additional parameters related to this vertex
     OneToOneRelations:
-      - edm4hep::ReconstructedParticle associatedParticle // reconstructed particle associated to this vertex.
+      - edm4hep::ReconstructedParticle associatedParticle // reconstructed particle associated to this vertex
 
 
   #------- ReconstructedParticle
@@ -438,20 +438,20 @@ datatypes:
     Author: "EDM4hep authors"
     Members:
       - int32_t                PDG            // PDG of the reconstructed particle.
-      - float                  energy         // [GeV] energy of the reconstructed particle. Four momentum state is not kept consistent internally.
-      - edm4hep::Vector3f      momentum       // [GeV] particle momentum. Four momentum state is not kept consistent internally.
-      - edm4hep::Vector3f      referencePoint // [mm] reference, i.e. where the particle has been measured.
-      - float                  charge         // charge of the reconstructed particle.
-      - float                  mass           // [GeV] mass of the reconstructed particle, set independently from four vector. Four momentum state is not kept consistent internally.
-      - float                  goodnessOfPID  // overall goodness of the PID on a scale of [0;1].
+      - float                  energy         // [GeV] energy of the reconstructed particle. Four momentum state is not kept consistent internally
+      - edm4hep::Vector3f      momentum       // [GeV] particle momentum. Four momentum state is not kept consistent internally
+      - edm4hep::Vector3f      referencePoint // [mm] reference, i.e. where the particle has been measured
+      - float                  charge         // charge of the reconstructed particle
+      - float                  mass           // [GeV] mass of the reconstructed particle, set independently from four vector. Four momentum state is not kept consistent internally
+      - float                  goodnessOfPID  // overall goodness of the PID on a scale of [0;1]
       - std::array<float,10>   covMatrix      // cvariance matrix of the reconstructed particle 4vector (10 parameters). Stored as lower triangle matrix of the four momentum (px,py,pz,E), i.e. cov(px,px), cov(py,##
     OneToOneRelations:
-      - edm4hep::Vertex          startVertex    // start vertex associated to this particle.
-      - edm4hep::ParticleID      particleIDUsed // particle Id used for the kinematics of this particle.
+      - edm4hep::Vertex          startVertex    // start vertex associated to this particle
+      - edm4hep::ParticleID      particleIDUsed // particle Id used for the kinematics of this particle
     OneToManyRelations:
-      - edm4hep::Cluster               clusters     // clusters that have been used for this particle.
-      - edm4hep::Track                 tracks       // tracks that have been used for this particle.
-      - edm4hep::ReconstructedParticle particles    // reconstructed particles that have been combined to this particle.
+      - edm4hep::Cluster               clusters     // clusters that have been used for this particle
+      - edm4hep::Track                 tracks       // tracks that have been used for this particle
+      - edm4hep::ReconstructedParticle particles    // reconstructed particles that have been combined to this particle
       - edm4hep::ParticleID            particleIDs  // particle Ids (not sorted by their likelihood)
     ExtraCode:
       declaration: "
@@ -471,73 +471,73 @@ datatypes:
     Description: "Used to keep track of the correspondence between MC and reconstructed particles"
     Author: "EDM4hep authors"
     Members:
-      - float weight                        // weight of this association.
+      - float weight                        // weight of this association
     OneToOneRelations:
-     - edm4hep::ReconstructedParticle  rec  // reference to the reconstructed particle.
-     - edm4hep::MCParticle sim              // reference to the Monte-Carlo particle.
+     - edm4hep::ReconstructedParticle  rec  // reference to the reconstructed particle
+     - edm4hep::MCParticle sim              // reference to the Monte-Carlo particle
 
   edm4hep::MCRecoCaloAssociation:
     Description: "Association between a CaloHit and the corresponding simulated CaloHit"
     Author: "EDM4hep authors"
     Members:
-      - float weight                    // weight of this association.
+      - float weight                    // weight of this association
     OneToOneRelations:
-     - edm4hep::CalorimeterHit rec     // reference to the reconstructed hit.
-     - edm4hep::SimCalorimeterHit sim  // reference to the simulated hit.
+     - edm4hep::CalorimeterHit rec     // reference to the reconstructed hit
+     - edm4hep::SimCalorimeterHit sim  // reference to the simulated hit
 
   edm4hep::MCRecoTrackerAssociation:
     Description: "Association between a TrackerHit and the corresponding simulated TrackerHit"
     Author: "EDM4hep authors"
     Members:
-      - float weight              // weight of this association.
+      - float weight              // weight of this association
     OneToOneRelations:
-     - edm4hep::TrackerHit rec    // reference to the reconstructed hit.
-     - edm4hep::SimTrackerHit sim // reference to the simulated hit.
+     - edm4hep::TrackerHit rec    // reference to the reconstructed hit
+     - edm4hep::SimTrackerHit sim // reference to the simulated hit
 
   edm4hep::MCRecoTrackerHitPlaneAssociation:
     Description: "Association between a TrackerHitPlane and the corresponding simulated TrackerHit"
     Author: "EDM4hep authors"
     Members:
-      - float weight                // weight of this association.
+      - float weight                // weight of this association
     OneToOneRelations:
-     - edm4hep::TrackerHitPlane rec // reference to the reconstructed hit.
-     - edm4hep::SimTrackerHit sim   // reference to the simulated hit.
+     - edm4hep::TrackerHitPlane rec // reference to the reconstructed hit
+     - edm4hep::SimTrackerHit sim   // reference to the simulated hit
 
   edm4hep::MCRecoCaloParticleAssociation:
     Description: "Association between a CalorimeterHit and a MCParticle"
     Author: "EDM4hep authors"
     Members:
-      - float weight                // weight of this association.
+      - float weight                // weight of this association
     OneToOneRelations:
-     - edm4hep::CalorimeterHit rec  // reference to the reconstructed hit.
-     - edm4hep::MCParticle sim      // reference to the Monte-Carlo particle.
+     - edm4hep::CalorimeterHit rec  // reference to the reconstructed hit
+     - edm4hep::MCParticle sim      // reference to the Monte-Carlo particle
 
   edm4hep::MCRecoClusterParticleAssociation:
     Description: "Association between a Cluster and a MCParticle"
     Author: "EDM4hep authors"
     Members:
-      - float weight                // weight of this association.
+      - float weight                // weight of this association
     OneToOneRelations:
-     - edm4hep::Cluster rec         // reference to the cluster.
-     - edm4hep::MCParticle sim      // reference to the Monte-Carlo particle.
+     - edm4hep::Cluster rec         // reference to the cluster
+     - edm4hep::MCParticle sim      // reference to the Monte-Carlo particle
 
   edm4hep::MCRecoTrackParticleAssociation:
     Description: "Association between a Track and a MCParticle"
     Author: "EDM4hep authors"
     Members:
-      - float weight                // weight of this association.
+      - float weight                // weight of this association
     OneToOneRelations:
-     - edm4hep::Track   rec         // reference to the track.
-     - edm4hep::MCParticle sim      // reference to the Monte-Carlo particle.
+     - edm4hep::Track   rec         // reference to the track
+     - edm4hep::MCParticle sim      // reference to the Monte-Carlo particle
 
   edm4hep::RecoParticleVertexAssociation:
     Description: "Association between a Reconstructed Particle and a Vertex"
     Author: "EDM4hep authors"
     Members:
-      - float weight                      // weight of this association.
+      - float weight                      // weight of this association
     OneToOneRelations:
-     - edm4hep::ReconstructedParticle rec // reference to the reconstructed particle.
-     - edm4hep::Vertex vertex             // reference to the vertex.
+     - edm4hep::ReconstructedParticle rec // reference to the reconstructed particle
+     - edm4hep::Vertex vertex             // reference to the vertex
 
 
   #----------- SimPrimaryIonizationCluster
@@ -545,18 +545,18 @@ datatypes:
     Description: "Simulated Primary Ionization"
     Author: "EDM4hep authors"
     Members:
-      - uint64_t cellID                      // cell id.
-      - float time                           // the primary ionization's time in the lab frame [ns].
-      - edm4hep::Vector3d position           // the primary ionization's position [mm].
-      - int16_t type                         // type.
+      - uint64_t cellID                      // cell id
+      - float time                           // the primary ionization's time in the lab frame [ns]
+      - edm4hep::Vector3d position           // the primary ionization's position [mm]
+      - int16_t type                         // type
     VectorMembers:
-       - uint64_t electronCellID             // cell id.
-       - float electronTime                  // the time in the lab frame [ns].
-       - edm4hep::Vector3d electronPosition  // the position in the lab frame [mm].
-       - float pulseTime                     // the pulse's time in the lab frame [ns].
-       - float pulseAmplitude                // the pulse's amplitude [fC].
+       - uint64_t electronCellID             // cell id
+       - float electronTime                  // the time in the lab frame [ns]
+       - edm4hep::Vector3d electronPosition  // the position in the lab frame [mm]
+       - float pulseTime                     // the pulse's time in the lab frame [ns]
+       - float pulseAmplitude                // the pulse's amplitude [fC]
     OneToOneRelations:
-      - edm4hep::MCParticle particle       // the particle that caused the ionizing collisions.
+      - edm4hep::MCParticle particle       // the particle that caused the ionizing collisions
     MutableExtraCode:
       includes: "
       #include <cmath>\n
@@ -579,35 +579,35 @@ datatypes:
     Description: "Reconstructed Tracker Pulse"
     Author: "EDM4hep authors"
     Members:
-       - uint64_t cellID                 // cell id.
-       - float time                      // time [ns].
-       - float charge                    // charge [fC].
-       - int16_t quality                 // quality.
-       - std::array<float,3> covMatrix   // lower triangle covariance matrix of the charge(c) and time(t) measurements.
+       - uint64_t cellID                 // cell id
+       - float time                      // time [ns]
+       - float charge                    // charge [fC]
+       - int16_t quality                 // quality
+       - std::array<float,3> covMatrix   // lower triangle covariance matrix of the charge(c) and time(t) measurements
     OneToOneRelations:
-      - edm4hep::TimeSeries timeSeries   // Optionally, the timeSeries that has been used to create the pulse can be stored with the pulse.
+      - edm4hep::TimeSeries timeSeries   // Optionally, the timeSeries that has been used to create the pulse can be stored with the pulse
 
  #----------  RecIonizationCluster
   edm4hep::RecIonizationCluster:
     Description: "Reconstructed Ionization Cluster"
     Author: "EDM4hep authors"
     Members:
-       - uint64_t cellID            // cell id.
-       - float significance         // significance.
-       - int16_t type               // type.
+       - uint64_t cellID            // cell id
+       - float significance         // significance
+       - int16_t type               // type
     OneToManyRelations:
-       - edm4hep::TrackerPulse trackerPulse // the TrackerPulse used to create the ionization cluster.
+       - edm4hep::TrackerPulse trackerPulse // the TrackerPulse used to create the ionization cluster
 
  #----------  TimeSeries
   edm4hep::TimeSeries:
     Description: "Calibrated Detector Data"
     Author: "EDM4hep authors"
     Members:
-       - uint64_t cellID            // cell id.
-       - float time                 // begin time [ns].
-       - float interval             // interval of each sampling [ns].
+       - uint64_t cellID            // cell id
+       - float time                 // begin time [ns]
+       - float interval             // interval of each sampling [ns]
     VectorMembers:
-       - float amplitude            // calibrated detector data.
+       - float amplitude            // calibrated detector data
 
 
   #-------------  RecDqdx
@@ -615,11 +615,11 @@ datatypes:
     Description: "dN/dx or dE/dx info of Track."
     Author: "EDM4hep authors"
     Members:
-      - edm4hep::Quantity dQdx         // the reconstructed dEdx or dNdx and its error.
-      - int16_t particleType           // particle type, e(0),mu(1),pi(2),K(3),p(4).
-      - int16_t type                   // type.
-      - std::array<edm4hep::Hypothesis, 5> hypotheses // 5 particle hypothesis.
+      - edm4hep::Quantity dQdx         // the reconstructed dEdx or dNdx and its error
+      - int16_t particleType           // particle type, e(0),mu(1),pi(2),K(3),p(4)
+      - int16_t type                   // type
+      - std::array<edm4hep::Hypothesis, 5> hypotheses // 5 particle hypothesis
     VectorMembers:
-      - edm4hep::HitLevelData hitData   // hit level data.
+      - edm4hep::HitLevelData hitData   // hit level data
     OneToOneRelations:
-      - edm4hep::Track track           // the corresponding track.
+      - edm4hep::Track track           // the corresponding track

--- a/include/edm4hep/Constants.h
+++ b/include/edm4hep/Constants.h
@@ -23,6 +23,7 @@ namespace edm4hep {
 static constexpr const char* CellIDEncoding = "CellIDEncoding";
 static constexpr const char* EventHeaderName = "EventHeader";
 static constexpr const char* EventWeights = "EventWeightNames";
+static constexpr const char* shapeParameterNames = "shapeParameterNames";
 } // namespace edm4hep
 
 #endif // EDM4HEP_CONSTANTS_H


### PR DESCRIPTION

BEGINRELEASENOTES
- "EDM4hep authors" as `Author` field for all data types. Fixes https://github.com/key4hep/EDM4hep/issues/255
- Remove the confusing reference to collection parameters. Fixes https://github.com/key4hep/EDM4hep/issues/191
- Homogenize the comments (dot at the end or not, space after // or not). 

ENDRELEASENOTES

Let me know if you want me to remove the two commits homogenizing comments.