### PR TITLE
Remove any path containing /fccanalyses/ for one test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -56,11 +56,15 @@ IF(TARGET ROOT::ROOTDataFrame)
 
   add_test(NAME py_test_rdf COMMAND python ${CMAKE_CURRENT_LIST_DIR}/test_rdf.py)
   set_test_env(py_test_rdf)
-  get_property(ENVIRONMENT TEST py_test_rdf PROPERTY ENVIRONMENT)
-  set_property(TEST py_test_rdf PROPERTY ENVIRONMENT
+  set_property(TEST py_test_rdf APPEND PROPERTY ENVIRONMENT
       ${ENVIRONMENT}
       PYTHONPATH=${PROJECT_SOURCE_DIR}/python:$ENV{PYTHONPATH}
   )
+  get_property(ENVIRONMENT TEST py_test_rdf PROPERTY ENVIRONMENT)
+  # Remove fccanalyses to prevent ROOT from loading their dictionaries
+  # for RDataFrame
+  string(REGEX REPLACE "[^:]*\\/fccanalyses\\/[^:]*(:?|$)" "" ENVIRONMENT "${ENVIRONMENT}")
+  set_property(TEST py_test_rdf PROPERTY ENVIRONMENT ${ENVIRONMENT})
   set_tests_properties(py_test_rdf PROPERTIES DEPENDS write_events)
 endif()
 

--- a/test/test_rdf.py
+++ b/test/test_rdf.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import ROOT
-import edm4hep
+import edm4hep  # noqa: F401
 
 ROOT.EnableImplicitMT()
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove any path containing /fccanalyses/ for one test to prevent ROOT from loading FCCAnalyses dictionaries

ENDRELEASENOTES
See this comment: https://github.com/key4hep/EDM4hep/pull/252#issuecomment-1959960236

Tested on top of https://github.com/key4hep/EDM4hep/pull/252, the test runs fine now