### PR TITLE
added static asserting vector components' member ordering and padding

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,36 +12,36 @@ A generic event data model for future HEP collider experiments.
 
 | | | |
 |-|-|-|
-| [Vector4f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L9)       | [Vector3f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L27)  | [Vector3d](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L43)    |
-| [Vector2i](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L63)      | [Vector2f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L78)  | [TrackState](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L93)  |
-| [Quantity](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L116)     | [Hypothesis](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L124) | [HitLevelData](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L131) |
+| [Vector4f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L9)       | [Vector3f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L34)  | [Vector3d](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L56)    |
+| [Vector2i](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L84)      | [Vector2f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L104)  | [TrackState](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L124)  |
+| [Quantity](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L147)     | [Hypothesis](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L155) | [HitLevelData](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L162) |
 
 
 **Datatypes**
 
 | | | |
 |-|-|-|
-| [EventHeader](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L141)         | [MCParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L153)        | [SimTrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L221)         |
-| [CaloHitContribution](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L263) | [SimCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L275) | [RawCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L287)     |
-| [CalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L296)      | [ParticleID](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L308)        | [Cluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L321)               |
-| [TrackerHit3D](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L342)          | [TrackerHitPlane](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L357)   | [RawTimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L376)                |
-| [Track](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L389)               | [Vertex](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L408)            | [ReconstructedParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L425) |
-| [SimPrimaryIonizationCluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L533) | [TrackerPulse](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L567) | [RecIonizationCluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L580) |
-| [TimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L591) | [RecDqdx](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L603) |                                                                                          |
+| [EventHeader](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L172)         | [MCParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L184)        | [SimTrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L252)         |
+| [CaloHitContribution](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L294) | [SimCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L306) | [RawCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L318)     |
+| [CalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L327)      | [ParticleID](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L339)        | [Cluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L352)               |
+| [TrackerHit3D](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L373)          | [TrackerHitPlane](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L388)   | [RawTimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L407)                |
+| [Track](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L420)               | [Vertex](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L439)            | [ReconstructedParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L456) |
+| [SimPrimaryIonizationCluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L564) | [TrackerPulse](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L598) | [RecIonizationCluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L611) |
+| [TimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L622) | [RecDqdx](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L634) |                                                                                          |
 
 **Associations**
 
 | | | |
 |-|-|-|
-| [MCRecoParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L459)        | [MCRecoCaloAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L468)         | [MCRecoTrackerAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L477)         |
-| [MCRecoTrackerHitPlaneAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L486) | [MCRecoCaloParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L495) | [MCRecoClusterParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L504) |
-| [MCRecoTrackParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L513)   | [RecoParticleVertexAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L522) |                                                                                                      |
+| [MCRecoParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L490)        | [MCRecoCaloAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L499)         | [MCRecoTrackerAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L508)         |
+| [MCRecoTrackerHitPlaneAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L517) | [MCRecoCaloParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L526) | [MCRecoClusterParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L535) |
+| [MCRecoTrackParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L544)   | [RecoParticleVertexAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L553) |                                                                                                      |
 
 **Interfaces**
 
 | | | |
 |-|-|-|
-| [TrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L617) | | |
+| [TrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L648) | | |
 
 
 The tests and examples in the `tests` directory show how to read, write, and use these types in your code.

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -14,13 +14,20 @@ components:
         - float z
         - float t
       ExtraCode:
+        includes: "#include <cstddef>"
         declaration: "
         constexpr Vector4f() : x(0),y(0),z(0),t(0) {}\n
         constexpr Vector4f(float xx, float yy, float zz, float tt) : x(xx),y(yy),z(zz),t(tt) {}\n
         constexpr Vector4f(const float* v) : x(v[0]),y(v[1]),z(v[2]),t(v[3]) {}\n
         constexpr bool operator==(const Vector4f& v) const { return (x==v.x&&y==v.y&&z==v.z&&t==v.t) ; }\n
         constexpr bool operator!=(const Vector4f& v) const { return !(*this == v) ; }\n
-        constexpr float operator[](unsigned i) const { return *( &x + i ) ; }\n
+        constexpr float operator[](unsigned i) const {\n
+          static_assert(\n
+            (offsetof(Vector4f,x)+sizeof(Vector4f::x) == offsetof(Vector4f,y)) &&\n
+            (offsetof(Vector4f,y)+sizeof(Vector4f::y) == offsetof(Vector4f,z)) &&\n
+            (offsetof(Vector4f,z)+sizeof(Vector4f::z) == offsetof(Vector4f,t)),\n
+            \"operator[] requires no padding\");\n
+          return *( &x + i ) ; }\n
       "
 
     # Vector3D with floats
@@ -30,13 +37,19 @@ components:
         - float y
         - float z
       ExtraCode:
+        includes: "#include <cstddef>"
         declaration: "
         constexpr Vector3f() : x(0),y(0),z(0) {}\n
         constexpr Vector3f(float xx, float yy, float zz) : x(xx),y(yy),z(zz) {}\n
         constexpr Vector3f(const float* v) : x(v[0]),y(v[1]),z(v[2]) {}\n
         constexpr bool operator==(const Vector3f& v) const { return (x==v.x&&y==v.y&&z==v.z) ; }\n
         constexpr bool operator!=(const Vector3f& v) const { return !(*this == v) ; }\n
-        constexpr float operator[](unsigned i) const { return *( &x + i ) ; }\n
+        constexpr float operator[](unsigned i) const {\n
+          static_assert(\n
+            (offsetof(Vector3f,x)+sizeof(Vector3f::x) == offsetof(Vector3f,y)) &&\n
+            (offsetof(Vector3f,y)+sizeof(Vector3f::y) == offsetof(Vector3f,z)),\n
+            \"operator[] requires no padding\");\n
+          return *( &x + i ) ; }\n
         "
 
     # Vector3D with doubles
@@ -46,7 +59,10 @@ components:
         - double y
         - double z
       ExtraCode:
-        includes: "#include <edm4hep/Vector3f.h>"
+        includes: "
+        #include <edm4hep/Vector3f.h>\n
+        #include <cstddef>\n
+        "
         declaration: "
         constexpr Vector3d() : x(0),y(0),z(0) {}\n
         constexpr Vector3d(double xx, double yy, double zz) : x(xx),y(yy),z(zz) {}\n
@@ -56,7 +72,12 @@ components:
         constexpr Vector3d(const Vector3f& v) : x(v.x), y(v.y), z(v.z) {}\n
         constexpr bool operator==(const Vector3d& v) const { return (x==v.x&&y==v.y&&z==v.z) ; }\n
         constexpr bool operator!=(const Vector3d& v) const { return !(*this == v) ; }\n
-        constexpr double operator[](unsigned i) const { return *( &x + i ) ; }\n
+        constexpr float operator[](unsigned i) const {\n
+          static_assert(\n
+            (offsetof(Vector3d,x)+sizeof(Vector3d::x) == offsetof(Vector3d,y)) &&\n
+            (offsetof(Vector3d,y)+sizeof(Vector3d::y) == offsetof(Vector3d,z)),\n
+            \"operator[] requires no padding\");\n
+          return *( &x + i ) ; }\n
         "
 
     # Vector2D with ints
@@ -65,13 +86,18 @@ components:
         - int32_t a
         - int32_t b
       ExtraCode:
+        includes: "#include <cstddef>"
         declaration: "
         constexpr Vector2i() : a(0),b(0) {}\n
         constexpr Vector2i(int32_t aa, int32_t bb) : a(aa),b(bb) {}\n
         constexpr Vector2i( const int32_t* v) : a(v[0]), b(v[1]) {}\n
         constexpr bool operator==(const Vector2i& v) const { return (a==v.a&&b==v.b) ; }\n
         constexpr bool operator!=(const Vector2i& v) const { return !(*this == v) ; }\n
-        constexpr int operator[](unsigned i) const { return *( &a + i ) ; }\n
+        constexpr float operator[](unsigned i) const {\n
+          static_assert(\n
+            offsetof(Vector2i,a)+sizeof(Vector2i::a) == offsetof(Vector2i,b),\n
+            \"operator[] requires no padding\");\n
+          return *( &a + i ) ; }\n
         "
 
     # Vector2D with floats
@@ -80,13 +106,18 @@ components:
         - float a
         - float b
       ExtraCode:
+        includes: "#include <cstddef>"
         declaration: "
         constexpr Vector2f() : a(0),b(0) {}\n
         constexpr Vector2f(float aa,float bb) : a(aa),b(bb) {}\n
         constexpr Vector2f(const float* v) : a(v[0]), b(v[1]) {}\n
         constexpr bool operator==(const Vector2f& v) const { return (a==v.a&&b==v.b) ; }\n
         constexpr bool operator!=(const Vector2f& v) const { return !(*this == v) ; }\n
-        constexpr float operator[](unsigned i) const { return *( &a + i ) ; }\n
+        constexpr float operator[](unsigned i) const {\n
+          static_assert(\n
+            offsetof(Vector2f,a)+sizeof(Vector2f::a) == offsetof(Vector2f,b),\n
+            \"operator[] requires no padding\");\n
+          return *( &a + i ) ; }\n
         "
 
       # Parametrized description of a particle track


### PR DESCRIPTION

BEGINRELEASENOTES
- added static asserting vector components' member ordering and padding

ENDRELEASENOTES

The `operator[]` of generated vector classes assumes no padding and member ordering same as in the source code. These are reasonable assumptions but not required by the standard. The assumptions can be checked at a compile time