### PR TITLE
Add dedicated covariance matrix components and use them

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,8 @@ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/edm4hep/edm4hep/EDM4hepVersion.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/edm4hep )
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/python/edm4hep/__version__.py.in
   ${CMAKE_CURRENT_SOURCE_DIR}/python/edm4hep/__version__.py)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/edm4hep
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 #--- add CMake infrastructure --------------------------------------------------
 include(cmake/EDM4HEPCreateConfig.cmake)

--- a/README.md
+++ b/README.md
@@ -13,35 +13,35 @@ A generic event data model for future HEP collider experiments.
 | | | |
 |-|-|-|
 | [Vector4f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L9)       | [Vector3f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L34)  | [Vector3d](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L56)    |
-| [Vector2i](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L84)      | [Vector2f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L104)  | [TrackState](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L183)  |
-| [Quantity](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L212)     | [Hypothesis](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L220) | [HitLevelData](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L227) |
+| [Vector2i](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L84)      | [Vector2f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L104)  | [TrackState](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L191)  |
+| [Quantity](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L220)     | [Hypothesis](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L228) | [HitLevelData](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L235) |
 
 
 **Datatypes**
 
 | | | |
 |-|-|-|
-| [EventHeader](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L237)         | [MCParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L249)        | [SimTrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L317)         |
-| [CaloHitContribution](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L359) | [SimCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L371) | [RawCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L383)     |
-| [CalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L392)      | [ParticleID](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L404)        | [Cluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L417)               |
-| [TrackerHit3D](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L451)          | [TrackerHitPlane](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L478)   | [RawTimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L509)                |
-| [Track](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L522)               | [Vertex](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L541)            | [ReconstructedParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L570) |
-| [SimPrimaryIonizationCluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L685) | [TrackerPulse](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L719) | [RecIonizationCluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L744) |
-| [TimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L755) | [RecDqdx](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L767) |                                                                                          |
+| [EventHeader](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L246)         | [MCParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L258)        | [SimTrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L326)         |
+| [CaloHitContribution](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L368) | [SimCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L380) | [RawCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L392)     |
+| [CalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L401)      | [ParticleID](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L413)        | [Cluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L426)               |
+| [TrackerHit3D](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L460)          | [TrackerHitPlane](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L486)   | [RawTimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L516)                |
+| [Track](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L529)               | [Vertex](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L548)            | [ReconstructedParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L576) |
+| [SimPrimaryIonizationCluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L690) | [TrackerPulse](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L724) | [RecIonizationCluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L749) |
+| [TimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L760) | [RecDqdx](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L772) |                                                                                          |
 
 **Associations**
 
 | | | |
 |-|-|-|
-| [MCRecoParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L611)        | [MCRecoCaloAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L620)         | [MCRecoTrackerAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L629)         |
-| [MCRecoTrackerHitPlaneAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L638) | [MCRecoCaloParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L647) | [MCRecoClusterParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L656) |
-| [MCRecoTrackParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L665)   | [RecoParticleVertexAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L674) |                                                                                                      |
+| [MCRecoParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L616)        | [MCRecoCaloAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L625)         | [MCRecoTrackerAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L634)         |
+| [MCRecoTrackerHitPlaneAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L643) | [MCRecoCaloParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L652) | [MCRecoClusterParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L661) |
+| [MCRecoTrackParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L670)   | [RecoParticleVertexAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L679) |                                                                                                      |
 
 **Interfaces**
 
 | | | |
 |-|-|-|
-| [TrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L781) | | |
+| [TrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L786) | | |
 
 
 The tests and examples in the `tests` directory show how to read, write, and use these types in your code.

--- a/README.md
+++ b/README.md
@@ -26,24 +26,24 @@ A generic event data model for future HEP collider experiments.
 | [EventHeader](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L246)         | [MCParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L258)        | [SimTrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L326)         |
 | [CaloHitContribution](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L368) | [SimCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L380) | [RawCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L392)     |
 | [CalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L401)      | [ParticleID](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L413)        | [Cluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L426)               |
-| [TrackerHit3D](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L460)          | [TrackerHitPlane](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L486)   | [RawTimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L516)                |
-| [Track](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L529)               | [Vertex](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L548)            | [ReconstructedParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L576) |
-| [SimPrimaryIonizationCluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L690) | [TrackerPulse](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L724) | [RecIonizationCluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L749) |
-| [TimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L760) | [RecDqdx](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L772) |                                                                                          |
+| [TrackerHit3D](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L459)          | [TrackerHitPlane](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L485)   | [RawTimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L515)                |
+| [Track](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L528)               | [Vertex](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L547)            | [ReconstructedParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L575) |
+| [SimPrimaryIonizationCluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L689) | [TrackerPulse](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L723) | [RecIonizationCluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L748) |
+| [TimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L759) | [RecDqdx](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L771) |                                                                                          |
 
 **Associations**
 
 | | | |
 |-|-|-|
-| [MCRecoParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L616)        | [MCRecoCaloAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L625)         | [MCRecoTrackerAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L634)         |
-| [MCRecoTrackerHitPlaneAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L643) | [MCRecoCaloParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L652) | [MCRecoClusterParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L661) |
-| [MCRecoTrackParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L670)   | [RecoParticleVertexAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L679) |                                                                                                      |
+| [MCRecoParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L615)        | [MCRecoCaloAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L624)         | [MCRecoTrackerAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L633)         |
+| [MCRecoTrackerHitPlaneAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L642) | [MCRecoCaloParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L651) | [MCRecoClusterParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L660) |
+| [MCRecoTrackParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L669)   | [RecoParticleVertexAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L678) |                                                                                                      |
 
 **Interfaces**
 
 | | | |
 |-|-|-|
-| [TrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L786) | | |
+| [TrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L785) | | |
 
 
 The tests and examples in the `tests` directory show how to read, write, and use these types in your code.

--- a/README.md
+++ b/README.md
@@ -13,35 +13,35 @@ A generic event data model for future HEP collider experiments.
 | | | |
 |-|-|-|
 | [Vector4f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L9)       | [Vector3f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L34)  | [Vector3d](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L56)    |
-| [Vector2i](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L84)      | [Vector2f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L104)  | [TrackState](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L124)  |
-| [Quantity](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L147)     | [Hypothesis](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L155) | [HitLevelData](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L162) |
+| [Vector2i](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L84)      | [Vector2f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L104)  | [TrackState](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L183)  |
+| [Quantity](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L212)     | [Hypothesis](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L220) | [HitLevelData](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L227) |
 
 
 **Datatypes**
 
 | | | |
 |-|-|-|
-| [EventHeader](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L172)         | [MCParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L184)        | [SimTrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L252)         |
-| [CaloHitContribution](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L294) | [SimCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L306) | [RawCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L318)     |
-| [CalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L327)      | [ParticleID](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L339)        | [Cluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L352)               |
-| [TrackerHit3D](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L373)          | [TrackerHitPlane](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L388)   | [RawTimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L407)                |
-| [Track](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L420)               | [Vertex](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L439)            | [ReconstructedParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L456) |
-| [SimPrimaryIonizationCluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L564) | [TrackerPulse](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L598) | [RecIonizationCluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L611) |
-| [TimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L622) | [RecDqdx](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L634) |                                                                                          |
+| [EventHeader](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L237)         | [MCParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L249)        | [SimTrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L317)         |
+| [CaloHitContribution](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L359) | [SimCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L371) | [RawCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L383)     |
+| [CalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L392)      | [ParticleID](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L404)        | [Cluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L417)               |
+| [TrackerHit3D](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L451)          | [TrackerHitPlane](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L478)   | [RawTimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L509)                |
+| [Track](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L522)               | [Vertex](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L541)            | [ReconstructedParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L570) |
+| [SimPrimaryIonizationCluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L685) | [TrackerPulse](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L719) | [RecIonizationCluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L744) |
+| [TimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L755) | [RecDqdx](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L767) |                                                                                          |
 
 **Associations**
 
 | | | |
 |-|-|-|
-| [MCRecoParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L490)        | [MCRecoCaloAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L499)         | [MCRecoTrackerAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L508)         |
-| [MCRecoTrackerHitPlaneAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L517) | [MCRecoCaloParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L526) | [MCRecoClusterParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L535) |
-| [MCRecoTrackParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L544)   | [RecoParticleVertexAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L553) |                                                                                                      |
+| [MCRecoParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L611)        | [MCRecoCaloAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L620)         | [MCRecoTrackerAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L629)         |
+| [MCRecoTrackerHitPlaneAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L638) | [MCRecoCaloParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L647) | [MCRecoClusterParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L656) |
+| [MCRecoTrackParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L665)   | [RecoParticleVertexAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L674) |                                                                                                      |
 
 **Interfaces**
 
 | | | |
 |-|-|-|
-| [TrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L648) | | |
+| [TrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L781) | | |
 
 
 The tests and examples in the `tests` directory show how to read, write, and use these types in your code.

--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ A generic event data model for future HEP collider experiments.
 
 | | | |
 |-|-|-|
-| [Vector4f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L9)       | [Vector3f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L34)  | [Vector3d](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L56)    |
-| [Vector2i](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L84)      | [Vector2f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L104)  | [TrackState](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L191)  |
-| [Quantity](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L220)     | [Hypothesis](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L228) | [HitLevelData](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L235) |
+| [Vector4f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L9)      | [Vector3f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L34)     | [Vector3d](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L56)      |
+| [Vector2i](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L84)     | [Vector2f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L104)    | [TrackState](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L192)   |
+| [Quantity](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L221)    | [Hypothesis](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L229)  | [HitLevelData](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L236) |
+| [CovMatrix2f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L123)  |[CovMatrix3f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L140)   |[CovMatrix4f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L157)   |
+| [CovMatrix6f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L174) | | |
 
 
 **Datatypes**

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -132,22 +132,8 @@ components:
           constexpr CovMatrix2f& operator=(std::array<float, 3> v) { values = v; return *this; }\n
           bool operator==(const CovMatrix2f& v) const { return v.values == values; }\n
           bool operator!=(const CovMatrix2f& v) const { return v.values != values; }\n
-          constexpr float operator[](unsigned i) const { return values[i]; }\n
-          constexpr float& operator[](unsigned i) { return values[i]; }\n
-          constexpr auto begin() const { return values.begin(); }\n
-          constexpr auto begin() { return values.begin(); }\n
-          constexpr auto end() const { return values.begin(); }\n
-          constexpr auto end() { return values.begin(); }\n
-          float* data() { return values.data(); }\n
-          const float* data() const { return values.data(); }\n
-          /// Get the value of the covariance matrix for the two passed dimensions\n
-          template<typename DimEnum>\n
-          constexpr float getValue(DimEnum dimI, DimEnum dimJ) const { return utils::get_cov_value(values, dimI, dimJ); }\n
-          /// Set a value in the covariance matrix for the two passed dimensions\n
-          template<typename DimEnum>\n
-          constexpr void setValue(float value, DimEnum dimI, DimEnum dimJ) { utils::set_cov_value(value, values, dimI, dimJ); }\n
-        "
-
+          #include <edm4hep/detail/CovMatrixCommon.ipp>
+          "
     edm4hep::CovMatrix3f:
       Description: "A generic 3 dimensional covariance matrix with values stored in lower triangular form"
       Members:
@@ -160,20 +146,7 @@ components:
           constexpr CovMatrix3f& operator=(std::array<float, 6> v) { values = v; return *this; }\n
           bool operator==(const CovMatrix3f& v) const { return v.values == values; }\n
           bool operator!=(const CovMatrix3f& v) const { return v.values != values; }\n
-          constexpr float operator[](unsigned i) const { return values[i]; }\n
-          constexpr float& operator[](unsigned i) { return values[i]; }\n
-          constexpr auto begin() const { return values.begin(); }\n
-          constexpr auto begin() { return values.begin(); }\n
-          constexpr auto end() const { return values.begin(); }\n
-          constexpr auto end() { return values.begin(); }\n
-          float* data() { return values.data(); }\n
-          const float* data() const { return values.data(); }\n
-          /// Get the value of the covariance matrix for the two passed dimensions\n
-          template<typename DimEnum>\n
-          constexpr float getValue(DimEnum dimI, DimEnum dimJ) const { return utils::get_cov_value(values, dimI, dimJ); }\n
-          /// Set a value in the covariance matrix for the two passed dimensions\n
-          template<typename DimEnum>\n
-          constexpr void setValue(float value, DimEnum dimI, DimEnum dimJ) { utils::set_cov_value(value, values, dimI, dimJ); }\n
+          #include <edm4hep/detail/CovMatrixCommon.ipp>
         "
 
     edm4hep::CovMatrix4f:
@@ -188,21 +161,8 @@ components:
           constexpr CovMatrix4f& operator=(std::array<float, 10> v) { values = v; return *this; }\n
           bool operator==(const CovMatrix4f& v) const { return v.values == values; }\n
           bool operator!=(const CovMatrix4f& v) const { return v.values != values; }\n
-          constexpr float operator[](unsigned i) const { return values[i]; }\n
-          constexpr float& operator[](unsigned i) { return values[i]; }\n
-          constexpr auto begin() const { return values.begin(); }\n
-          constexpr auto begin() { return values.begin(); }\n
-          constexpr auto end() const { return values.begin(); }\n
-          constexpr auto end() { return values.begin(); }\n
-          float* data() { return values.data(); }\n
-          const float* data() const { return values.data(); }\n
-          /// Get the value of the covariance matrix for the two passed dimensions\n
-          template<typename DimEnum>\n
-          constexpr float getValue(DimEnum dimI, DimEnum dimJ) const { return utils::get_cov_value(values, dimI, dimJ); }\n
-          /// Set a value in the covariance matrix for the two passed dimensions\n
-          template<typename DimEnum>\n
-          constexpr void setValue(float value, DimEnum dimI, DimEnum dimJ) { utils::set_cov_value(value, values, dimI, dimJ); }\n
-        "
+          #include <edm4hep/detail/CovMatrixCommon.ipp>
+          "
 
     edm4hep::CovMatrix6f:
       Description: "A generic 6 dimensional covariance matrix with values stored in lower triangular form"
@@ -216,20 +176,7 @@ components:
           constexpr CovMatrix6f& operator=(std::array<float, 21> v) { values = v; return *this; }\n
           bool operator==(const CovMatrix6f& v) const { return v.values == values; }\n
           bool operator!=(const CovMatrix6f& v) const { return v.values != values; }\n
-          constexpr float operator[](unsigned i) const { return values[i]; }\n
-          constexpr float& operator[](unsigned i) { return values[i]; }\n
-          constexpr auto begin() const { return values.begin(); }\n
-          constexpr auto begin() { return values.begin(); }\n
-          constexpr auto end() const { return values.begin(); }\n
-          constexpr auto end() { return values.begin(); }\n
-          float* data() { return values.data(); }\n
-          const float* data() const { return values.data(); }\n
-          /// Get the value of the covariance matrix for the two passed dimensions\n
-          template<typename DimEnum>\n
-          constexpr float getValue(DimEnum dimI, DimEnum dimJ) const { return utils::get_cov_value(values, dimI, dimJ); }\n
-          /// Set a value in the covariance matrix for the two passed dimensions\n
-          template<typename DimEnum>\n
-          constexpr void setValue(float value, DimEnum dimI, DimEnum dimJ) { utils::set_cov_value(value, values, dimI, dimJ); }\n
+          #include <edm4hep/detail/CovMatrixCommon.ipp>\n
         "
 
       # Parametrized description of a particle track

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -471,7 +471,7 @@ datatypes:
       declaration: "
       /// Set the position covariance matrix value for the two passed dimensions\n
       void setCovMatrix(float value, edm4hep::Cartesian dimI, edm4hep::Cartesian dimJ) { getCovMatrix().setValue(value, dimI, dimJ); }\n
-      void setCovMatrix(std::array<float, 6> values) { getCovMatrix() = values; }
+      void setCovMatrix(const std::array<float, 6>& values) { getCovMatrix() = values; }
       "
 
   #-------------  TrackerHitPlane
@@ -502,7 +502,7 @@ datatypes:
       declaration: "
       /// Set the position covariance matrix value for the two passed dimensions\n
       void setCovMatrix(float value, edm4hep::Cartesian dimI, edm4hep::Cartesian dimJ) { getCovMatrix().setValue(value, dimI, dimJ); }\n
-      void setCovMatrix(std::array<float, 6> values) { getCovMatrix() = values; }
+      void setCovMatrix(const std::array<float, 6>& values) { getCovMatrix() = values; }
       "
 
  #---------- RawTimeSeries
@@ -563,7 +563,7 @@ datatypes:
       declaration: "
       /// Set the position covariance matrix value for the two passed dimensions\n
       void setCovMatrix(float value, edm4hep::Cartesian dimI, edm4hep::Cartesian dimJ) { getCovMatrix().setValue(value, dimI, dimJ); }\n
-      void setCovMatrix(std::array<float, 6> values) { getCovMatrix() = values; }
+      void setCovMatrix(const std::array<float, 6>& values) { getCovMatrix() = values; }
       "
 
   #------- ReconstructedParticle
@@ -605,7 +605,7 @@ datatypes:
       void setType(int32_t pdg) { setPDG(pdg); }\n
       /// Set the four momentum covariance matrix value for the two passed dimensions\n
       void setCovMatrix(float value, edm4hep::FourMomCoords dimI, edm4hep::FourMomCoords dimJ) { getCovMatrix().setValue(value, dimI, dimJ); }\n
-      void setCovMatrix(std::array<float, 10> values) { getCovMatrix() = values; }
+      void setCovMatrix(const std::array<float, 10>& values) { getCovMatrix() = values; }
       "
 
   edm4hep::MCRecoParticleAssociation:

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -139,6 +139,25 @@ components:
           constexpr void setValue(float value, DimEnum dimI, DimEnum dimJ) { utils::set_cov_value(value, values, dimI, dimJ); }\n
         "
 
+    edm4hep::CovMatrix4f:
+      Description: "A generic 4 dimensional covariance matrix with values stored in lower triangular form"
+      Members:
+        - std::array<float, 10> values // the covariance matrix values
+      ExtraCode:
+        includes: "#include <edm4hep/utils/cov_matrix_utils.h>"
+        declaration: "
+          bool operator==(const CovMatrix4f& v) const { return v.values == values; }\n
+          bool operator!=(const CovMatrix4f& v) const { return v.values != values; }\n
+          float* data() { return values.data(); }\n
+          const float* data() const { return values.data(); }\n
+          /// Get the value of the covariance matrix for the two passed dimensions\n
+          template<typename DimEnum>\n
+          constexpr float getValue(DimEnum dimI, DimEnum dimJ) const { return utils::get_cov_value(values, dimI, dimJ); }\n
+          /// Set a value in the covariance matrix for the two passed dimensions\n
+          template<typename DimEnum>\n
+          constexpr void setValue(float value, DimEnum dimI, DimEnum dimJ) { utils::set_cov_value(value, values, dimI, dimJ); }\n
+        "
+
     edm4hep::CovMatrix6f:
       Description: "A generic 6 dimensional covariance matrix with values stored in lower triangular form"
       Members:
@@ -553,7 +572,7 @@ datatypes:
       - float                  charge         // charge of the reconstructed particle
       - float                  mass  [GeV]    //  mass of the reconstructed particle, set independently from four vector. Four momentum state is not kept consistent internally
       - float                  goodnessOfPID  // overall goodness of the PID on a scale of [0;1]
-      - std::array<float,10>   covMatrix      // cvariance matrix of the reconstructed particle 4vector (10 parameters). Stored as lower triangle matrix of the four momentum (px,py,pz,E), i.e. cov(px,px), cov(py,##
+      - edm4hep::CovMatrix4f   covMatrix      // cvariance matrix of the reconstructed particle 4vector (10 parameters). Stored as lower triangle matrix of the four momentum (px,py,pz,E), i.e. cov(px,px), cov(py,##
     OneToOneRelations:
       - edm4hep::Vertex          startVertex    // start vertex associated to this particle
       - edm4hep::ParticleID      particleIDUsed // particle Id used for the kinematics of this particle
@@ -563,17 +582,23 @@ datatypes:
       - edm4hep::ReconstructedParticle particles    // reconstructed particles that have been combined to this particle
       - edm4hep::ParticleID            particleIDs  // particle Ids (not sorted by their likelihood)
     ExtraCode:
+      includes: "#include <edm4hep/Constants.h>"
       declaration: "
       bool isCompound() const { return particles_size() > 0 ;}\n
       [[deprecated(\"use setPDG instead\")]]\n
       int32_t getType() const { return getPDG(); }\n
+      /// Get the four momentum covariance matrix value for the two passed dimensions\n
+      float getCovMatrix(edm4hep::FourMomCoords dimI, edm4hep::FourMomCoords dimJ) const { return getCovMatrix().getValue(dimI, dimJ); }\n
       "
     MutableExtraCode:
+      includes: "#include <edm4hep/Constants.h>"
       declaration: "
       //vertex where the particle decays. This method actually returns the start vertex from the first daughter particle found.\n
       //TODO: edm4hep::Vertex  getEndVertex() { return  edm4hep::Vertex(  (getParticles(0).isAvailable() ? getParticles(0).getStartVertex() :  edm4hep::Vertex(0,0) ) ) ; }\n
       [[deprecated(\"use setPDG instead\")]]\n
       void setType(int32_t pdg) { setPDG(pdg); }\n
+      /// Set the four momentum covariance matrix value for the two passed dimensions\n
+      void setCovMatrix(float value, edm4hep::FourMomCoords dimI, edm4hep::FourMomCoords dimJ) { getCovMatrix().setValue(value, dimI, dimJ); }\n
       "
 
   edm4hep::MCRecoParticleAssociation:

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -453,7 +453,6 @@ datatypes:
       declaration: "
       /// Set the position error value for the two passed dimensions\n
       void setPositionError(float value, edm4hep::Cartesian dimI, edm4hep::Cartesian dimJ) { return getPositionError().setValue(value, dimI, dimJ); }\n
-      void setPositionError(std::array<float, 6> values) { getPositionError() = values; }
       "
 
   #-------------  TrackerHit

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -128,8 +128,8 @@ components:
         includes: "#include <edm4hep/utils/cov_matrix_utils.h>"
         declaration: "
           constexpr CovMatrix2f() = default;\n
-          constexpr CovMatrix2f(const std::array<float, 3> v) : values(v) {}\n
-          constexpr CovMatrix2f& operator=(std::array<float, 3> v) { values = v; return *this; }\n
+          constexpr CovMatrix2f(const std::array<float, 3>& v) : values(v) {}\n
+          constexpr CovMatrix2f& operator=(std::array<float, 3>& v) { values = v; return *this; }\n
           bool operator==(const CovMatrix2f& v) const { return v.values == values; }\n
           bool operator!=(const CovMatrix2f& v) const { return v.values != values; }\n
           #include <edm4hep/detail/CovMatrixCommon.ipp>
@@ -142,8 +142,8 @@ components:
         includes: "#include <edm4hep/utils/cov_matrix_utils.h>"
         declaration: "
           constexpr CovMatrix3f() = default;\n
-          constexpr CovMatrix3f(const std::array<float, 6> v) : values(v) {}\n
-          constexpr CovMatrix3f& operator=(std::array<float, 6> v) { values = v; return *this; }\n
+          constexpr CovMatrix3f(const std::array<float, 6>& v) : values(v) {}\n
+          constexpr CovMatrix3f& operator=(std::array<float, 6>& v) { values = v; return *this; }\n
           bool operator==(const CovMatrix3f& v) const { return v.values == values; }\n
           bool operator!=(const CovMatrix3f& v) const { return v.values != values; }\n
           #include <edm4hep/detail/CovMatrixCommon.ipp>
@@ -157,8 +157,8 @@ components:
         includes: "#include <edm4hep/utils/cov_matrix_utils.h>"
         declaration: "
           constexpr CovMatrix4f() = default;\n
-          constexpr CovMatrix4f(const std::array<float, 10> v) : values(v) {}\n
-          constexpr CovMatrix4f& operator=(std::array<float, 10> v) { values = v; return *this; }\n
+          constexpr CovMatrix4f(const std::array<float, 10>& v) : values(v) {}\n
+          constexpr CovMatrix4f& operator=(std::array<float, 10>& v) { values = v; return *this; }\n
           bool operator==(const CovMatrix4f& v) const { return v.values == values; }\n
           bool operator!=(const CovMatrix4f& v) const { return v.values != values; }\n
           #include <edm4hep/detail/CovMatrixCommon.ipp>
@@ -172,8 +172,8 @@ components:
         includes: "#include <edm4hep/utils/cov_matrix_utils.h>"
         declaration: "
           constexpr CovMatrix6f() = default;\n
-          constexpr CovMatrix6f(const std::array<float, 21> v) : values(v) {}\n
-          constexpr CovMatrix6f& operator=(std::array<float, 21> v) { values = v; return *this; }\n
+          constexpr CovMatrix6f(const std::array<float, 21>& v) : values(v) {}\n
+          constexpr CovMatrix6f& operator=(std::array<float, 21>& v) { values = v; return *this; }\n
           bool operator==(const CovMatrix6f& v) const { return v.values == values; }\n
           bool operator!=(const CovMatrix6f& v) const { return v.values != values; }\n
           #include <edm4hep/detail/CovMatrixCommon.ipp>\n

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -120,6 +120,25 @@ components:
           return *( &a + i ) ; }\n
         "
 
+    edm4hep::CovMatrix2f:
+      Description: "A generic 2 dimensional covariance matrix with values stored in lower triangular form"
+      Members:
+        - std::array<float, 3> values // the covariance matrix values
+      ExtraCode:
+        includes: "#include <edm4hep/utils/cov_matrix_utils.h>"
+        declaration: "
+          bool operator==(const CovMatrix2f& v) const { return v.values == values; }\n
+          bool operator!=(const CovMatrix2f& v) const { return v.values != values; }\n
+          float* data() { return values.data(); }\n
+          const float* data() const { return values.data(); }\n
+          /// Get the value of the covariance matrix for the two passed dimensions\n
+          template<typename DimEnum>\n
+          constexpr float getValue(DimEnum dimI, DimEnum dimJ) const { return utils::get_cov_value(values, dimI, dimJ); }\n
+          /// Set a value in the covariance matrix for the two passed dimensions\n
+          template<typename DimEnum>\n
+          constexpr void setValue(float value, DimEnum dimI, DimEnum dimJ) { utils::set_cov_value(value, values, dimI, dimJ); }\n
+        "
+
     edm4hep::CovMatrix3f:
       Description: "A generic 3 dimensional covariance matrix with values stored in lower triangular form"
       Members:
@@ -717,9 +736,21 @@ datatypes:
        - float time [ns]                 // time
        - float charge [fC]               // charge
        - int16_t quality                 // quality
-       - std::array<float,3> covMatrix   // lower triangle covariance matrix of the charge(c) and time(t) measurements
+       - edm4hep::CovMatrix2f covMatrix  // lower triangle covariance matrix of the charge(c) and time(t) measurements
     OneToOneRelations:
       - edm4hep::TimeSeries timeSeries   // Optionally, the timeSeries that has been used to create the pulse can be stored with the pulse
+    ExtraCode:
+      includes: "#include <edm4hep/Constants.h>"
+      declaration: "
+      /// Get the postion covariance matrix value for the two passed dimensions\n
+      float getCovMatrix(edm4hep::TrackerPulseDims dimI, edm4hep::TrackerPulseDims dimJ) const { return getCovMatrix().getValue(dimI, dimJ); }\n
+      "
+    MutableExtraCode:
+      includes: "#include <edm4hep/Constants.h>"
+      declaration: "
+      /// Set the postion covariance matrix value for the two passed dimensions\n
+      void setCovMatrix(float value, edm4hep::TrackerPulseDims dimI, edm4hep::TrackerPulseDims dimJ) { getCovMatrix().setValue(value, dimI, dimJ); }\n
+      "
 
  #----------  RecIonizationCluster
   edm4hep::RecIonizationCluster:

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -243,7 +243,7 @@ components:
         - float tanLambda // lambda is the dip angle of the track in r-z
         - float time [ns] // time of the track at this trackstate
         - edm4hep::Vector3f referencePoint [mm] // Reference point of the track parameters, e.g. the origin at the IP, or the position  of the first/last hits or the entry point into the calorimeter
-        - edm4hep::CovMatrix6f covMatrix // lower triangular covariance matrix of the track parameters.  the order of parameters is  d0, phi, omega, z0, tan(lambda), time. the array is a row-major flattening of the matrix
+        - edm4hep::CovMatrix6f covMatrix // covariance matrix of the track parameters.
       ExtraCode:
         includes: "#include <edm4hep/Constants.h>"
         declaration: "
@@ -475,10 +475,10 @@ datatypes:
       - float                energy [GeV]        // energy of the cluster
       - float                energyError [GeV]   // error on the energy
       - edm4hep::Vector3f    position [mm]       // position of the cluster
-      - edm4hep::CovMatrix3f positionError   // covariance matrix of the position (6 Parameters)
+      - edm4hep::CovMatrix3f positionError   // covariance matrix of the position
       - float                iTheta          // intrinsic direction of cluster at position  Theta. Not to be confused with direction cluster is seen from IP
       - float                phi             // intrinsic direction of cluster at position - Phi. Not to be confused with direction cluster is seen from IP
-      - edm4hep::Vector3f    directionError [mm**2]  // covariance matrix of the direction (3 Parameters)
+      - edm4hep::Vector3f    directionError [mm**2]  // covariance matrix of the direction
     VectorMembers:
       - float   shapeParameters      // shape parameters. This should be accompanied by a descriptive list of names in the shapeParameterNames collection level metadata, as a vector of strings with the same ordering
       - float   subdetectorEnergies  // energy observed in a particular subdetector
@@ -512,7 +512,7 @@ datatypes:
       - float eDep [GeV]                   // energy deposited on the hit
       - float eDepError [GeV]              // error measured on EDep
       - edm4hep::Vector3d position [mm]    // hit position
-      - edm4hep::CovMatrix3f covMatrix // covariance of the position (x,y,z), stored as lower triangle matrix. i.e. cov(x,x) , cov(y,x) , cov(y,y) , cov(z,x) , cov(z,y) , cov(z,z)
+      - edm4hep::CovMatrix3f covMatrix // covariance matrix of the position (x,y,z)
     ExtraCode:
       includes: "#include <edm4hep/Constants.h>"
       declaration: "
@@ -543,7 +543,7 @@ datatypes:
       - float du                       // measurement error along the direction
       - float dv                       // measurement error along the direction
       - edm4hep::Vector3d position [mm]   // hit position
-      - edm4hep::CovMatrix3f covMatrix // covariance of the position (x,y,z), stored as lower triangle matrix. i.e. cov(x,x) , cov(y,x) , cov(y,y) , cov(z,x) , cov(z,y) , cov(z,z)
+      - edm4hep::CovMatrix3f covMatrix // covariance of the position (x,y,z)
     ExtraCode:
       includes: "#include <edm4hep/Constants.h>"
       declaration: "
@@ -599,7 +599,7 @@ datatypes:
       - float               chi2          // chi-squared of the vertex fit
       - float               probability   // probability of the vertex fit
       - edm4hep::Vector3f   position      // [mm] position of the vertex
-      - edm4hep::CovMatrix3f covMatrix // covariance of the position (x,y,z), stored as lower triangle matrix. i.e. cov(x,x) , cov(y,x) , cov(y,y) , cov(z,x) , cov(z,y) , cov(z,z)
+      - edm4hep::CovMatrix3f covMatrix // covariance matrix of the position
       - int32_t                 algorithmType // type code for the algorithm that has been used to create the vertex
     VectorMembers:
       - float               parameters    // additional parameters related to this vertex
@@ -631,7 +631,7 @@ datatypes:
       - float                  charge         // charge of the reconstructed particle
       - float                  mass  [GeV]    //  mass of the reconstructed particle, set independently from four vector. Four momentum state is not kept consistent internally
       - float                  goodnessOfPID  // overall goodness of the PID on a scale of [0;1]
-      - edm4hep::CovMatrix4f   covMatrix      // covariance matrix of the reconstructed particle 4vector (10 parameters). Stored as lower triangle matrix of the four momentum (px,py,pz,E), i.e. cov(px,px), cov(py,##
+      - edm4hep::CovMatrix4f   covMatrix      // covariance matrix of the reconstructed particle 4vector
     OneToOneRelations:
       - edm4hep::Vertex          startVertex    // start vertex associated to this particle
       - edm4hep::ParticleID      particleIDUsed // particle Id used for the kinematics of this particle
@@ -777,7 +777,7 @@ datatypes:
        - float time [ns]                 // time
        - float charge [fC]               // charge
        - int16_t quality                 // quality
-       - edm4hep::CovMatrix2f covMatrix  // lower triangle covariance matrix of the charge(c) and time(t) measurements
+       - edm4hep::CovMatrix2f covMatrix  // covariance matrix of the charge and time measurements
     OneToOneRelations:
       - edm4hep::TimeSeries timeSeries   // Optionally, the timeSeries that has been used to create the pulse can be stored with the pulse
     ExtraCode:

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -120,9 +120,29 @@ components:
           return *( &a + i ) ; }\n
         "
 
-    edm4hep::CovMatrix6f:
+    edm4hep::CovMatrix3f:
+      Description: "A generic 3 dimensional covariance matrix with values stored in lower triangular form"
       Members:
-        - std::array<float, 21> values // the covariance matrix values stored in lower triangular matrix form (i.e. row-major flattening of the matrix)
+        - std::array<float, 6> values // the covariance matrix values
+      ExtraCode:
+        includes: "#include <edm4hep/utils/cov_matrix_utils.h>"
+        declaration: "
+          bool operator==(const CovMatrix3f& v) const { return v.values == values; }\n
+          bool operator!=(const CovMatrix3f& v) const { return v.values != values; }\n
+          float* data() { return values.data(); }\n
+          const float* data() const { return values.data(); }\n
+          /// Get the value of the covariance matrix for the two passed dimensions\n
+          template<typename DimEnum>\n
+          constexpr float getValue(DimEnum dimI, DimEnum dimJ) const { return utils::get_cov_value(values, dimI, dimJ); }\n
+          /// Set a value in the covariance matrix for the two passed dimensions\n
+          template<typename DimEnum>\n
+          constexpr void setValue(float value, DimEnum dimI, DimEnum dimJ) { utils::set_cov_value(value, values, dimI, dimJ); }\n
+        "
+
+    edm4hep::CovMatrix6f:
+      Description: "A generic 6 dimensional covariance matrix with values stored in lower triangular form"
+      Members:
+        - std::array<float, 21> values // the covariance matrix values
       ExtraCode:
         includes: "#include <edm4hep/utils/cov_matrix_utils.h>"
         declaration: "
@@ -381,7 +401,7 @@ datatypes:
       - float                energy [GeV]        // energy of the cluster
       - float                energyError [GeV]   // error on the energy
       - edm4hep::Vector3f    position [mm]       // position of the cluster
-      - std::array<float,6>  positionError   // covariance matrix of the position (6 Parameters)
+      - edm4hep::CovMatrix3f positionError   // covariance matrix of the position (6 Parameters)
       - float                iTheta          // intrinsic direction of cluster at position  Theta. Not to be confused with direction cluster is seen from IP
       - float                phi             // intrinsic direction of cluster at position - Phi. Not to be confused with direction cluster is seen from IP
       - edm4hep::Vector3f    directionError [mm**2]  // covariance matrix of the direction (3 Parameters)
@@ -392,6 +412,18 @@ datatypes:
       - edm4hep::Cluster        clusters     // clusters that have been combined to this cluster
       - edm4hep::CalorimeterHit hits         // hits that have been combined to this cluster
       - edm4hep::ParticleID     particleIDs  // particle IDs (sorted by their likelihood)
+    ExtraCode:
+      includes: "#include <edm4hep/Constants.h>"
+      declaration: "
+      /// Get the postion error value for the two passed dimensions\n
+      float getPositionError(edm4hep::Cartesian dimI, edm4hep::Cartesian dimJ) const { return getPositionError().getValue(dimI, dimJ); }\n
+      "
+    MutableExtraCode:
+      includes: "#include <edm4hep/Constants.h>"
+      declaration: "
+      /// Set the postion error value for the two passed dimensions\n
+      void setPositionError(float value, edm4hep::Cartesian dimI, edm4hep::Cartesian dimJ) { return getPositionError().setValue(value, dimI, dimJ); }\n
+      "
 
   #-------------  TrackerHit
   edm4hep::TrackerHit3D:
@@ -405,8 +437,19 @@ datatypes:
       - float eDep [GeV]                   // energy deposited on the hit
       - float eDepError [GeV]              // error measured on EDep
       - edm4hep::Vector3d position [mm]    // hit position
-      - std::array<float,6> covMatrix  // covariance of the position (x,y,z), stored as lower triangle matrix. i.e. cov(x,x) , cov(y,x) , cov(y,y) , cov(z,x) , cov(z,y) , cov(z,z)
-
+      - edm4hep::CovMatrix3f covMatrix // covariance of the position (x,y,z), stored as lower triangle matrix. i.e. cov(x,x) , cov(y,x) , cov(y,y) , cov(z,x) , cov(z,y) , cov(z,z)
+    ExtraCode:
+      includes: "#include <edm4hep/Constants.h>"
+      declaration: "
+      /// Get the postion covariance matrix value for the two passed dimensions\n
+      float getCovMatrix(edm4hep::Cartesian dimI, edm4hep::Cartesian dimJ) const { return getCovMatrix().getValue(dimI, dimJ); }\n
+      "
+    MutableExtraCode:
+      includes: "#include <edm4hep/Constants.h>"
+      declaration: "
+      /// Set the postion covariance matrix value for the two passed dimensions\n
+      void setCovMatrix(float value, edm4hep::Cartesian dimI, edm4hep::Cartesian dimJ) { getCovMatrix().setValue(value, dimI, dimJ); }\n
+      "
 
   #-------------  TrackerHitPlane
   edm4hep::TrackerHitPlane:
@@ -424,8 +467,19 @@ datatypes:
       - float du                       // measurement error along the direction
       - float dv                       // measurement error along the direction
       - edm4hep::Vector3d position [mm]   // hit position
-      - std::array<float,6> covMatrix  // covariance of the position (x,y,z), stored as lower triangle matrix. i.e. cov(x,x) , cov(y,x) , cov(y,y) , cov(z,x) , cov(z,y) , cov(z,z)
-
+      - edm4hep::CovMatrix3f covMatrix // covariance of the position (x,y,z), stored as lower triangle matrix. i.e. cov(x,x) , cov(y,x) , cov(y,y) , cov(z,x) , cov(z,y) , cov(z,z)
+    ExtraCode:
+      includes: "#include <edm4hep/Constants.h>"
+      declaration: "
+      /// Get the postion covariance matrix value for the two passed dimensions\n
+      float getCovMatrix(edm4hep::Cartesian dimI, edm4hep::Cartesian dimJ) const { return getCovMatrix().getValue(dimI, dimJ); }\n
+      "
+    MutableExtraCode:
+      includes: "#include <edm4hep/Constants.h>"
+      declaration: "
+      /// Set the postion covariance matrix value for the two passed dimensions\n
+      void setCovMatrix(float value, edm4hep::Cartesian dimI, edm4hep::Cartesian dimJ) { getCovMatrix().setValue(value, dimI, dimJ); }\n
+      "
 
  #---------- RawTimeSeries
   edm4hep::RawTimeSeries:
@@ -468,13 +522,24 @@ datatypes:
       - float               chi2          // chi-squared of the vertex fit
       - float               probability   // probability of the vertex fit
       - edm4hep::Vector3f   position      // [mm] position of the vertex
-      - std::array<float,6> covMatrix     // covariance matrix of the position (stored as lower triangle matrix, i.e. cov(xx),cov(y,x),cov(z,x),cov(y,y),... )
+      - edm4hep::CovMatrix3f covMatrix // covariance of the position (x,y,z), stored as lower triangle matrix. i.e. cov(x,x) , cov(y,x) , cov(y,y) , cov(z,x) , cov(z,y) , cov(z,z)
       - int32_t                 algorithmType // type code for the algorithm that has been used to create the vertex
     VectorMembers:
       - float               parameters    // additional parameters related to this vertex
     OneToOneRelations:
       - edm4hep::ReconstructedParticle associatedParticle // reconstructed particle associated to this vertex
-
+    ExtraCode:
+      includes: "#include <edm4hep/Constants.h>"
+      declaration: "
+      /// Get the postion covariance matrix value for the two passed dimensions\n
+      float getCovMatrix(edm4hep::Cartesian dimI, edm4hep::Cartesian dimJ) const { return getCovMatrix().getValue(dimI, dimJ); }\n
+      "
+    MutableExtraCode:
+      includes: "#include <edm4hep/Constants.h>"
+      declaration: "
+      /// Set the postion covariance matrix value for the two passed dimensions\n
+      void setCovMatrix(float value, edm4hep::Cartesian dimI, edm4hep::Cartesian dimJ) { getCovMatrix().setValue(value, dimI, dimJ); }\n
+      "
 
   #------- ReconstructedParticle
   edm4hep::ReconstructedParticle:

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -489,13 +489,13 @@ datatypes:
     ExtraCode:
       includes: "#include <edm4hep/Constants.h>"
       declaration: "
-      /// Get the postion error value for the two passed dimensions\n
+      /// Get the position error value for the two passed dimensions\n
       float getPositionError(edm4hep::Cartesian dimI, edm4hep::Cartesian dimJ) const { return getPositionError().getValue(dimI, dimJ); }\n
       "
     MutableExtraCode:
       includes: "#include <edm4hep/Constants.h>"
       declaration: "
-      /// Set the postion error value for the two passed dimensions\n
+      /// Set the position error value for the two passed dimensions\n
       void setPositionError(float value, edm4hep::Cartesian dimI, edm4hep::Cartesian dimJ) { return getPositionError().setValue(value, dimI, dimJ); }\n
       void setPositionError(std::array<float, 6> values) { getPositionError() = values; }
       "
@@ -516,13 +516,13 @@ datatypes:
     ExtraCode:
       includes: "#include <edm4hep/Constants.h>"
       declaration: "
-      /// Get the postion covariance matrix value for the two passed dimensions\n
+      /// Get the position covariance matrix value for the two passed dimensions\n
       float getCovMatrix(edm4hep::Cartesian dimI, edm4hep::Cartesian dimJ) const { return getCovMatrix().getValue(dimI, dimJ); }\n
       "
     MutableExtraCode:
       includes: "#include <edm4hep/Constants.h>"
       declaration: "
-      /// Set the postion covariance matrix value for the two passed dimensions\n
+      /// Set the position covariance matrix value for the two passed dimensions\n
       void setCovMatrix(float value, edm4hep::Cartesian dimI, edm4hep::Cartesian dimJ) { getCovMatrix().setValue(value, dimI, dimJ); }\n
       void setCovMatrix(std::array<float, 6> values) { getCovMatrix() = values; }
       "
@@ -547,13 +547,13 @@ datatypes:
     ExtraCode:
       includes: "#include <edm4hep/Constants.h>"
       declaration: "
-      /// Get the postion covariance matrix value for the two passed dimensions\n
+      /// Get the position covariance matrix value for the two passed dimensions\n
       float getCovMatrix(edm4hep::Cartesian dimI, edm4hep::Cartesian dimJ) const { return getCovMatrix().getValue(dimI, dimJ); }\n
       "
     MutableExtraCode:
       includes: "#include <edm4hep/Constants.h>"
       declaration: "
-      /// Set the postion covariance matrix value for the two passed dimensions\n
+      /// Set the position covariance matrix value for the two passed dimensions\n
       void setCovMatrix(float value, edm4hep::Cartesian dimI, edm4hep::Cartesian dimJ) { getCovMatrix().setValue(value, dimI, dimJ); }\n
       void setCovMatrix(std::array<float, 6> values) { getCovMatrix() = values; }
       "
@@ -608,13 +608,13 @@ datatypes:
     ExtraCode:
       includes: "#include <edm4hep/Constants.h>"
       declaration: "
-      /// Get the postion covariance matrix value for the two passed dimensions\n
+      /// Get the position covariance matrix value for the two passed dimensions\n
       float getCovMatrix(edm4hep::Cartesian dimI, edm4hep::Cartesian dimJ) const { return getCovMatrix().getValue(dimI, dimJ); }\n
       "
     MutableExtraCode:
       includes: "#include <edm4hep/Constants.h>"
       declaration: "
-      /// Set the postion covariance matrix value for the two passed dimensions\n
+      /// Set the position covariance matrix value for the two passed dimensions\n
       void setCovMatrix(float value, edm4hep::Cartesian dimI, edm4hep::Cartesian dimJ) { getCovMatrix().setValue(value, dimI, dimJ); }\n
       void setCovMatrix(std::array<float, 6> values) { getCovMatrix() = values; }
       "
@@ -631,7 +631,7 @@ datatypes:
       - float                  charge         // charge of the reconstructed particle
       - float                  mass  [GeV]    //  mass of the reconstructed particle, set independently from four vector. Four momentum state is not kept consistent internally
       - float                  goodnessOfPID  // overall goodness of the PID on a scale of [0;1]
-      - edm4hep::CovMatrix4f   covMatrix      // cvariance matrix of the reconstructed particle 4vector (10 parameters). Stored as lower triangle matrix of the four momentum (px,py,pz,E), i.e. cov(px,px), cov(py,##
+      - edm4hep::CovMatrix4f   covMatrix      // covariance matrix of the reconstructed particle 4vector (10 parameters). Stored as lower triangle matrix of the four momentum (px,py,pz,E), i.e. cov(px,px), cov(py,##
     OneToOneRelations:
       - edm4hep::Vertex          startVertex    // start vertex associated to this particle
       - edm4hep::ParticleID      particleIDUsed // particle Id used for the kinematics of this particle
@@ -783,13 +783,13 @@ datatypes:
     ExtraCode:
       includes: "#include <edm4hep/Constants.h>"
       declaration: "
-      /// Get the postion covariance matrix value for the two passed dimensions\n
+      /// Get the position covariance matrix value for the two passed dimensions\n
       float getCovMatrix(edm4hep::TrackerPulseDims dimI, edm4hep::TrackerPulseDims dimJ) const { return getCovMatrix().getValue(dimI, dimJ); }\n
       "
     MutableExtraCode:
       includes: "#include <edm4hep/Constants.h>"
       declaration: "
-      /// Set the postion covariance matrix value for the two passed dimensions\n
+      /// Set the position covariance matrix value for the two passed dimensions\n
       void setCovMatrix(float value, edm4hep::TrackerPulseDims dimI, edm4hep::TrackerPulseDims dimJ) { getCovMatrix().setValue(value, dimI, dimJ); }\n
       "
 

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -127,8 +127,17 @@ components:
       ExtraCode:
         includes: "#include <edm4hep/utils/cov_matrix_utils.h>"
         declaration: "
+          constexpr CovMatrix2f() = default;\n
+          constexpr CovMatrix2f(const std::array<float, 3> v) : values(v) {}\n
+          constexpr CovMatrix2f& operator=(std::array<float, 3> v) { values = v; return *this; }\n
           bool operator==(const CovMatrix2f& v) const { return v.values == values; }\n
           bool operator!=(const CovMatrix2f& v) const { return v.values != values; }\n
+          constexpr float operator[](unsigned i) const { return values[i]; }\n
+          constexpr float& operator[](unsigned i) { return values[i]; }\n
+          constexpr auto begin() const { return values.begin(); }\n
+          constexpr auto begin() { return values.begin(); }\n
+          constexpr auto end() const { return values.begin(); }\n
+          constexpr auto end() { return values.begin(); }\n
           float* data() { return values.data(); }\n
           const float* data() const { return values.data(); }\n
           /// Get the value of the covariance matrix for the two passed dimensions\n
@@ -146,8 +155,17 @@ components:
       ExtraCode:
         includes: "#include <edm4hep/utils/cov_matrix_utils.h>"
         declaration: "
+          constexpr CovMatrix3f() = default;\n
+          constexpr CovMatrix3f(const std::array<float, 6> v) : values(v) {}\n
+          constexpr CovMatrix3f& operator=(std::array<float, 6> v) { values = v; return *this; }\n
           bool operator==(const CovMatrix3f& v) const { return v.values == values; }\n
           bool operator!=(const CovMatrix3f& v) const { return v.values != values; }\n
+          constexpr float operator[](unsigned i) const { return values[i]; }\n
+          constexpr float& operator[](unsigned i) { return values[i]; }\n
+          constexpr auto begin() const { return values.begin(); }\n
+          constexpr auto begin() { return values.begin(); }\n
+          constexpr auto end() const { return values.begin(); }\n
+          constexpr auto end() { return values.begin(); }\n
           float* data() { return values.data(); }\n
           const float* data() const { return values.data(); }\n
           /// Get the value of the covariance matrix for the two passed dimensions\n
@@ -165,8 +183,17 @@ components:
       ExtraCode:
         includes: "#include <edm4hep/utils/cov_matrix_utils.h>"
         declaration: "
+          constexpr CovMatrix4f() = default;\n
+          constexpr CovMatrix4f(const std::array<float, 10> v) : values(v) {}\n
+          constexpr CovMatrix4f& operator=(std::array<float, 10> v) { values = v; return *this; }\n
           bool operator==(const CovMatrix4f& v) const { return v.values == values; }\n
           bool operator!=(const CovMatrix4f& v) const { return v.values != values; }\n
+          constexpr float operator[](unsigned i) const { return values[i]; }\n
+          constexpr float& operator[](unsigned i) { return values[i]; }\n
+          constexpr auto begin() const { return values.begin(); }\n
+          constexpr auto begin() { return values.begin(); }\n
+          constexpr auto end() const { return values.begin(); }\n
+          constexpr auto end() { return values.begin(); }\n
           float* data() { return values.data(); }\n
           const float* data() const { return values.data(); }\n
           /// Get the value of the covariance matrix for the two passed dimensions\n
@@ -184,8 +211,17 @@ components:
       ExtraCode:
         includes: "#include <edm4hep/utils/cov_matrix_utils.h>"
         declaration: "
+          constexpr CovMatrix6f() = default;\n
+          constexpr CovMatrix6f(const std::array<float, 21> v) : values(v) {}\n
+          constexpr CovMatrix6f& operator=(std::array<float, 21> v) { values = v; return *this; }\n
           bool operator==(const CovMatrix6f& v) const { return v.values == values; }\n
           bool operator!=(const CovMatrix6f& v) const { return v.values != values; }\n
+          constexpr float operator[](unsigned i) const { return values[i]; }\n
+          constexpr float& operator[](unsigned i) { return values[i]; }\n
+          constexpr auto begin() const { return values.begin(); }\n
+          constexpr auto begin() { return values.begin(); }\n
+          constexpr auto end() const { return values.begin(); }\n
+          constexpr auto end() { return values.begin(); }\n
           float* data() { return values.data(); }\n
           const float* data() const { return values.data(); }\n
           /// Get the value of the covariance matrix for the two passed dimensions\n
@@ -461,6 +497,7 @@ datatypes:
       declaration: "
       /// Set the postion error value for the two passed dimensions\n
       void setPositionError(float value, edm4hep::Cartesian dimI, edm4hep::Cartesian dimJ) { return getPositionError().setValue(value, dimI, dimJ); }\n
+      void setPositionError(std::array<float, 6> values) { getPositionError() = values; }
       "
 
   #-------------  TrackerHit
@@ -487,6 +524,7 @@ datatypes:
       declaration: "
       /// Set the postion covariance matrix value for the two passed dimensions\n
       void setCovMatrix(float value, edm4hep::Cartesian dimI, edm4hep::Cartesian dimJ) { getCovMatrix().setValue(value, dimI, dimJ); }\n
+      void setCovMatrix(std::array<float, 6> values) { getCovMatrix() = values; }
       "
 
   #-------------  TrackerHitPlane
@@ -517,6 +555,7 @@ datatypes:
       declaration: "
       /// Set the postion covariance matrix value for the two passed dimensions\n
       void setCovMatrix(float value, edm4hep::Cartesian dimI, edm4hep::Cartesian dimJ) { getCovMatrix().setValue(value, dimI, dimJ); }\n
+      void setCovMatrix(std::array<float, 6> values) { getCovMatrix() = values; }
       "
 
  #---------- RawTimeSeries
@@ -577,6 +616,7 @@ datatypes:
       declaration: "
       /// Set the postion covariance matrix value for the two passed dimensions\n
       void setCovMatrix(float value, edm4hep::Cartesian dimI, edm4hep::Cartesian dimJ) { getCovMatrix().setValue(value, dimI, dimJ); }\n
+      void setCovMatrix(std::array<float, 6> values) { getCovMatrix() = values; }
       "
 
   #------- ReconstructedParticle
@@ -618,6 +658,7 @@ datatypes:
       void setType(int32_t pdg) { setPDG(pdg); }\n
       /// Set the four momentum covariance matrix value for the two passed dimensions\n
       void setCovMatrix(float value, edm4hep::FourMomCoords dimI, edm4hep::FourMomCoords dimJ) { getCovMatrix().setValue(value, dimI, dimJ); }\n
+      void setCovMatrix(std::array<float, 10> values) { getCovMatrix() = values; }
       "
 
   edm4hep::MCRecoParticleAssociation:

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -128,6 +128,8 @@ components:
         includes: "#include <edm4hep/utils/cov_matrix_utils.h>"
         declaration: "
           constexpr CovMatrix2f() = default;\n
+          template<typename... Vs>\n
+          constexpr CovMatrix2f(Vs... v) : values{v...} {}\n
           constexpr CovMatrix2f(const std::array<float, 3>& v) : values(v) {}\n
           constexpr CovMatrix2f& operator=(std::array<float, 3>& v) { values = v; return *this; }\n
           bool operator==(const CovMatrix2f& v) const { return v.values == values; }\n
@@ -143,6 +145,8 @@ components:
         declaration: "
           constexpr CovMatrix3f() = default;\n
           constexpr CovMatrix3f(const std::array<float, 6>& v) : values(v) {}\n
+          template<typename... Vs>\n
+          constexpr CovMatrix3f(Vs... v) : values{v...} {}\n
           constexpr CovMatrix3f& operator=(std::array<float, 6>& v) { values = v; return *this; }\n
           bool operator==(const CovMatrix3f& v) const { return v.values == values; }\n
           bool operator!=(const CovMatrix3f& v) const { return v.values != values; }\n
@@ -157,6 +161,8 @@ components:
         includes: "#include <edm4hep/utils/cov_matrix_utils.h>"
         declaration: "
           constexpr CovMatrix4f() = default;\n
+          template<typename... Vs>\n
+          constexpr CovMatrix4f(Vs... v) : values{v...} {}\n
           constexpr CovMatrix4f(const std::array<float, 10>& v) : values(v) {}\n
           constexpr CovMatrix4f& operator=(std::array<float, 10>& v) { values = v; return *this; }\n
           bool operator==(const CovMatrix4f& v) const { return v.values == values; }\n
@@ -172,6 +178,8 @@ components:
         includes: "#include <edm4hep/utils/cov_matrix_utils.h>"
         declaration: "
           constexpr CovMatrix6f() = default;\n
+          template<typename... Vs>\n
+          constexpr CovMatrix6f(Vs... v) : values{v...} {}\n
           constexpr CovMatrix6f(const std::array<float, 21>& v) : values(v) {}\n
           constexpr CovMatrix6f& operator=(std::array<float, 21>& v) { values = v; return *this; }\n
           bool operator==(const CovMatrix6f& v) const { return v.values == values; }\n
@@ -471,7 +479,6 @@ datatypes:
       declaration: "
       /// Set the position covariance matrix value for the two passed dimensions\n
       void setCovMatrix(float value, edm4hep::Cartesian dimI, edm4hep::Cartesian dimJ) { getCovMatrix().setValue(value, dimI, dimJ); }\n
-      void setCovMatrix(const std::array<float, 6>& values) { getCovMatrix() = values; }
       "
 
   #-------------  TrackerHitPlane
@@ -502,7 +509,6 @@ datatypes:
       declaration: "
       /// Set the position covariance matrix value for the two passed dimensions\n
       void setCovMatrix(float value, edm4hep::Cartesian dimI, edm4hep::Cartesian dimJ) { getCovMatrix().setValue(value, dimI, dimJ); }\n
-      void setCovMatrix(const std::array<float, 6>& values) { getCovMatrix() = values; }
       "
 
  #---------- RawTimeSeries
@@ -563,7 +569,6 @@ datatypes:
       declaration: "
       /// Set the position covariance matrix value for the two passed dimensions\n
       void setCovMatrix(float value, edm4hep::Cartesian dimI, edm4hep::Cartesian dimJ) { getCovMatrix().setValue(value, dimI, dimJ); }\n
-      void setCovMatrix(const std::array<float, 6>& values) { getCovMatrix() = values; }
       "
 
   #------- ReconstructedParticle
@@ -605,7 +610,6 @@ datatypes:
       void setType(int32_t pdg) { setPDG(pdg); }\n
       /// Set the four momentum covariance matrix value for the two passed dimensions\n
       void setCovMatrix(float value, edm4hep::FourMomCoords dimI, edm4hep::FourMomCoords dimJ) { getCovMatrix().setValue(value, dimI, dimJ); }\n
-      void setCovMatrix(const std::array<float, 10>& values) { getCovMatrix() = values; }
       "
 
   edm4hep::MCRecoParticleAssociation:

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -136,6 +136,7 @@ components:
           bool operator!=(const CovMatrix2f& v) const { return v.values != values; }\n
           #include <edm4hep/detail/CovMatrixCommon.ipp>
           "
+
     edm4hep::CovMatrix3f:
       Description: "A generic 3 dimensional covariance matrix with values stored in lower triangular form"
       Members:

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -120,6 +120,24 @@ components:
           return *( &a + i ) ; }\n
         "
 
+    edm4hep::CovMatrix6f:
+      Members:
+        - std::array<float, 21> values // the covariance matrix values stored in lower triangular matrix form (i.e. row-major flattening of the matrix)
+      ExtraCode:
+        includes: "#include <edm4hep/utils/cov_matrix_utils.h>"
+        declaration: "
+          bool operator==(const CovMatrix6f& v) const { return v.values == values; }\n
+          bool operator!=(const CovMatrix6f& v) const { return v.values != values; }\n
+          float* data() { return values.data(); }\n
+          const float* data() const { return values.data(); }\n
+          /// Get the value of the covariance matrix for the two passed dimensions\n
+          template<typename DimEnum>\n
+          constexpr float getValue(DimEnum dimI, DimEnum dimJ) const { return utils::get_cov_value(values, dimI, dimJ); }\n
+          /// Set a value in the covariance matrix for the two passed dimensions\n
+          template<typename DimEnum>\n
+          constexpr void setValue(float value, DimEnum dimI, DimEnum dimJ) { utils::set_cov_value(value, values, dimI, dimJ); }\n
+        "
+
       # Parametrized description of a particle track
     edm4hep::TrackState:
       Members:
@@ -131,8 +149,9 @@ components:
         - float tanLambda // lambda is the dip angle of the track in r-z
         - float time [ns] // time of the track at this trackstate
         - edm4hep::Vector3f referencePoint [mm] // Reference point of the track parameters, e.g. the origin at the IP, or the position  of the first/last hits or the entry point into the calorimeter
-        - std::array<float, 21> covMatrix // lower triangular covariance matrix of the track parameters.  the order of parameters is  d0, phi, omega, z0, tan(lambda), time. the array is a row-major flattening of the matrix
+        - edm4hep::CovMatrix6f covMatrix // lower triangular covariance matrix of the track parameters.  the order of parameters is  d0, phi, omega, z0, tan(lambda), time. the array is a row-major flattening of the matrix
       ExtraCode:
+        includes: "#include <edm4hep/Constants.h>"
         declaration: "
         static const int AtOther = 0 ; // any location other than the ones defined below\n
         static const int AtIP = 1 ;\n
@@ -141,6 +160,11 @@ components:
         static const int AtCalorimeter = 4 ;\n
         static const int AtVertex = 5 ;\n
         static const int LastLocation = AtVertex  ;\n
+
+        /// Get the covariance matrix value for the two passed parameters\n
+        constexpr float getCovMatrix(edm4hep::TrackParams parI, edm4hep::TrackParams parJ) const { return covMatrix.getValue(parI, parJ); }\n
+        /// Set the covariance matrix value for the two passed parameters\n
+        constexpr void setCovMatrix(float value, edm4hep::TrackParams parI, edm4hep::TrackParams parJ) { covMatrix.setValue(value, parI, parJ); }
         "
 
     # quantity with an identifier, a value and an error

--- a/edm4hep/CMakeLists.txt
+++ b/edm4hep/CMakeLists.txt
@@ -4,6 +4,10 @@
 PODIO_GENERATE_DATAMODEL(edm4hep ../edm4hep.yaml headers sources IO_BACKEND_HANDLERS ${PODIO_IO_HANDLERS})
 
 PODIO_ADD_DATAMODEL_CORE_LIB(edm4hep "${headers}" "${sources}")
+target_include_directories(edm4hep PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/utils/include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
 add_library(EDM4HEP::edm4hep ALIAS edm4hep)
 
 file(GLOB_RECURSE top_headers ${PROJECT_SOURCE_DIR}/include/*.h)

--- a/include/edm4hep/Constants.h
+++ b/include/edm4hep/Constants.h
@@ -40,6 +40,9 @@ enum class FourMomCoords : DimType { x = 0, y, z, t };
 
 /// The enum for accessing track parameter values in covariance matrices
 enum class TrackParams : DimType { d0 = 0, phi, omega, z0, tanLambda, time };
+
+/// Enum for accessing the covariance matrix in the TrackerPulse
+enum class TrackerPulseDims : DimType { charge = 0, time };
 } // namespace edm4hep
 
 #endif // EDM4HEP_CONSTANTS_H

--- a/include/edm4hep/Constants.h
+++ b/include/edm4hep/Constants.h
@@ -31,6 +31,9 @@ static constexpr const char* shapeParameterNames = "shapeParameterNames";
 // Could go to 8 bits, but would need a fix in podio first
 using DimType = std::uint16_t;
 
+/// The enum for accessing cartesian coordinate values in covariance matrices
+enum class Cartesian : DimType { x = 0, y, z };
+
 /// The enum for accessing track parameter values in covariance matrices
 enum class TrackParams : DimType { d0 = 0, phi, omega, z0, tanLambda, time };
 } // namespace edm4hep

--- a/include/edm4hep/Constants.h
+++ b/include/edm4hep/Constants.h
@@ -19,11 +19,20 @@
 #ifndef EDM4HEP_CONSTANTS_H
 #define EDM4HEP_CONSTANTS_H
 
+#include <cstdint>
+
 namespace edm4hep {
 static constexpr const char* CellIDEncoding = "CellIDEncoding";
 static constexpr const char* EventHeaderName = "EventHeader";
 static constexpr const char* EventWeights = "EventWeightNames";
 static constexpr const char* shapeParameterNames = "shapeParameterNames";
+
+// Use 16 bits to encode the dimension
+// Could go to 8 bits, but would need a fix in podio first
+using DimType = std::uint16_t;
+
+/// The enum for accessing track parameter values in covariance matrices
+enum class TrackParams : DimType { d0 = 0, phi, omega, z0, tanLambda, time };
 } // namespace edm4hep
 
 #endif // EDM4HEP_CONSTANTS_H

--- a/include/edm4hep/Constants.h
+++ b/include/edm4hep/Constants.h
@@ -34,6 +34,10 @@ using DimType = std::uint16_t;
 /// The enum for accessing cartesian coordinate values in covariance matrices
 enum class Cartesian : DimType { x = 0, y, z };
 
+/// The enum for accessing four momentum coordinate values in covariance
+/// matrices
+enum class FourMomCoords : DimType { x = 0, y, z, t };
+
 /// The enum for accessing track parameter values in covariance matrices
 enum class TrackParams : DimType { d0 = 0, phi, omega, z0, tanLambda, time };
 } // namespace edm4hep

--- a/include/edm4hep/detail/CovMatrixCommon.ipp
+++ b/include/edm4hep/detail/CovMatrixCommon.ipp
@@ -1,0 +1,90 @@
+// This file is meant to be included inside the declaration part of the
+// ExtraCode for the CovMatrixNx components. They live in this file because they
+// can be written very generically and reduce the clutter and code repetition in
+// the edm4hep.yaml file
+//
+// NOTE: All of these functions are intended to be member functions, and the
+// only member of a CovMatrixNx component is an apropriately sized std::array
+// named values.
+//
+// NOTE: It is also assumed that the edm4hep/utils/cov_matrix_utils.h header is
+// included via the corresponding ExtraCode: include directive
+
+/// Get the i-th element of the underlying storage
+///
+/// \note The values are stored in a flat array assuming a lower
+/// triangular matrix representation
+constexpr float operator[](unsigned i) const {
+  return values[i];
+}
+
+/// Get the i-th element of the underlying storage
+///
+/// \note The values are stored in a flat array assuming a lower
+/// triangular matrix representation
+constexpr float& operator[](unsigned i) {
+  return values[i];
+}
+
+/// Get the begin iterator to the underlying storage
+constexpr auto begin() const {
+  return values.begin();
+}
+
+/// Get the begin iterator to the underlying storage
+constexpr auto begin() {
+  return values.begin();
+}
+
+/// Get the end iterator to the underlying storage
+constexpr auto end() const {
+  return values.end();
+}
+
+/// Get the end iterator to the underlying storage
+constexpr auto end() {
+  return values.end();
+}
+
+/// Get a pointer to the underlying storage data
+auto* data() {
+  return values.data();
+}
+
+/// Get a pointer to the underlying storage data
+const auto* data() const {
+  return values.data();
+}
+
+/// Get the value of the covariance matrix for the passed dimensions
+///
+/// @tparam DimEnum The enum (class) type that describes the dimenstions of this
+///                 covariance matrix. This will be deduced from the passed
+///                 arguments!
+///
+/// @param dimI The first dimension for which the covariance matrix value should
+///             be obtained
+/// @param dimJ The second dimension for which the covariance matrix value
+///             should be obtained
+///
+/// @returns The value of the covariance matrix for dimension dimI and dimJ
+template <typename DimEnum>
+constexpr float getValue(DimEnum dimI, DimEnum dimJ) const {
+  return edm4hep::utils::get_cov_value(values, dimI, dimJ);
+}
+
+/// Set the value of the covariance matrix for the passed dimensions
+///
+/// @tparam DimEnum The enum (class) type that describes the dimenstions of this
+///                 covariance matrix. This will be deduced from the passed
+///                 arguments!
+///
+/// @param value The value to be set
+/// @param dimI  The first dimension for which the covariance matrix value
+///              should be obtained
+/// @param dimJ  The second dimension for which the covariance matrix value
+///              should be obtained
+template <typename DimEnum>
+constexpr void setValue(float value, DimEnum dimI, DimEnum dimJ) {
+  utils::set_cov_value(value, values, dimI, dimJ);
+}

--- a/test/utils/CMakeLists.txt
+++ b/test/utils/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 include(Catch)
 
 add_executable(unittests_edm4hep
-  test_kinematics.cpp test_vector_utils.cpp)
+  test_kinematics.cpp test_vector_utils.cpp test_covmatrix_utils.cpp)
 target_link_libraries(unittests_edm4hep edm4hep EDM4HEP::utils Catch2::Catch2 Catch2::Catch2WithMain)
 
 option(SKIP_CATCH_DISCOVERY "Skip the Catch2 test discovery" OFF)

--- a/test/utils/test_covmatrix_utils.cpp
+++ b/test/utils/test_covmatrix_utils.cpp
@@ -1,5 +1,7 @@
 #include "edm4hep/Constants.h"
+#include "edm4hep/MutableTrackerHit3D.h"
 #include "edm4hep/TrackState.h"
+#include "edm4hep/TrackerHit3D.h"
 #include "edm4hep/utils/cov_matrix_utils.h"
 
 #include <catch2/catch_test_macros.hpp>
@@ -53,4 +55,15 @@ TEST_CASE("TrackState covariance", "[cov_matrix_utils]") {
   // We know the expected index in this case
   REQUIRE(trackState.covMatrix.values[1] == 1.23f);
   REQUIRE(trackState.getCovMatrix(edm4hep::TrackParams::time, edm4hep::TrackParams::omega) == 0);
+}
+
+TEST_CASE("TrackerHit3D covariance", "[cov_matrix_utils]") {
+  auto trackerHit = edm4hep::MutableTrackerHit3D{};
+  trackerHit.setCovMatrix(3.14f, edm4hep::Cartesian::x, edm4hep::Cartesian::z);
+  REQUIRE(trackerHit.getCovMatrix(edm4hep::Cartesian::x, edm4hep::Cartesian::z) == 3.14f);
+  // We can also use the expected index of (x, y)
+  REQUIRE(trackerHit.getCovMatrix().values[3] == 3.14f);
+
+  auto hit = edm4hep::TrackerHit3D(trackerHit);
+  REQUIRE(hit.getCovMatrix(edm4hep::Cartesian::x, edm4hep::Cartesian::z) == 3.14f);
 }

--- a/test/utils/test_covmatrix_utils.cpp
+++ b/test/utils/test_covmatrix_utils.cpp
@@ -117,4 +117,11 @@ TEST_CASE("TrackerHit3D covariance", "[cov_matrix_utils]") {
 
   auto hit = edm4hep::TrackerHit3D(trackerHit);
   REQUIRE(hit.getCovMatrix(edm4hep::Cartesian::x, edm4hep::Cartesian::z) == 3.14f);
+
+  trackerHit.setCovMatrix({1.f, 2.f, 3.f, 4.f, 5.f, 6.f});
+  REQUIRE(trackerHit.getCovMatrix() == std::array{1.f, 2.f, 3.f, 4.f, 5.f, 6.f});
+
+  const std::array arrValues = {6.f, 5.f, 4.f, 3.f, 2.f, 1.f};
+  trackerHit.setCovMatrix(arrValues);
+  REQUIRE(trackerHit.getCovMatrix() == std::array{6.f, 5.f, 4.f, 3.f, 2.f, 1.f});
 }

--- a/test/utils/test_covmatrix_utils.cpp
+++ b/test/utils/test_covmatrix_utils.cpp
@@ -10,7 +10,7 @@
 #include <stdexcept>
 
 TEST_CASE("CovarianceMatrix indexing", "[cov_matrix_utils]") {
-  using namespace edm4hep::utils;
+  using namespace edm4hep::utils::detail;
 
   STATIC_REQUIRE(get_cov_dim(21) == 6);
   STATIC_REQUIRE(get_cov_dim(1) == 1);
@@ -80,6 +80,15 @@ TEST_CASE("CovMatrixNf enum access", "[cov_matrix_utils]") {
   auto covMatrix = edm4hep::CovMatrix3f{};
   covMatrix.setValue(1.23f, TestDims::a, TestDims::c);
   REQUIRE(covMatrix.getValue(TestDims::a, TestDims::c) == 1.23f);
+}
+
+TEST_CASE("CovMatrixNf invalid enum access", "[cov_matrix_utils]") {
+  // Invalid dimensions with too many elements to fit the 3D convariance matrix
+  enum class InvalidDims : edm4hep::DimType { i = 0, j, k, l, m };
+
+  auto covMatrix = edm4hep::CovMatrix3f{};
+  REQUIRE_THROWS_AS(covMatrix.setValue(1.23f, InvalidDims::k, InvalidDims::l), std::invalid_argument);
+  REQUIRE_THROWS_AS(covMatrix.getValue(InvalidDims::m, InvalidDims::i), std::invalid_argument);
 }
 
 TEST_CASE("CovMatrixNf equality operators", "[cov_matrix_utils]") {

--- a/test/utils/test_covmatrix_utils.cpp
+++ b/test/utils/test_covmatrix_utils.cpp
@@ -14,7 +14,10 @@ TEST_CASE("CovarianceMatrix indexing", "[cov_matrix_utils]") {
 
   STATIC_REQUIRE(get_cov_dim(21) == 6);
   STATIC_REQUIRE(get_cov_dim(1) == 1);
+#if !__cpp_consteval
+  // This will fail to compile if we have consteval
   REQUIRE_THROWS_AS(get_cov_dim(14), std::invalid_argument);
+#endif
 
   // clang-format off
   // For better interpretability of the tests below, these are the indices of a

--- a/test/utils/test_covmatrix_utils.cpp
+++ b/test/utils/test_covmatrix_utils.cpp
@@ -1,0 +1,56 @@
+#include "edm4hep/Constants.h"
+#include "edm4hep/TrackState.h"
+#include "edm4hep/utils/cov_matrix_utils.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <stdexcept>
+
+TEST_CASE("CovarianceMatrix indexing", "[cov_matrix_utils]") {
+  using namespace edm4hep::utils;
+
+  STATIC_REQUIRE(get_cov_dim(21) == 6);
+  STATIC_REQUIRE(get_cov_dim(1) == 1);
+  REQUIRE_THROWS_AS(get_cov_dim(14), std::invalid_argument);
+
+  // clang-format off
+  // For better interpretability of the tests below, these are the indices of a
+  // 2D matrix in lower triangular form together with the matrix indices
+  //
+  //   | 0  1  2  3  4  5
+  // --+------------------
+  // 0 | 0  1  3  6  10 15
+  // 1 | 1  2  4  7  11 16
+  // 2 | 3  4  5  8  12 17
+  // 3 | 6  7  8  9  13 18
+  // 4 | 10 11 12 13 14 19
+  // 5 | 15 16 17 18 19 20
+  // clang-format on
+
+  // diagonal elements
+  STATIC_REQUIRE(to_lower_tri(0, 0) == 0);
+  STATIC_REQUIRE(to_lower_tri(1, 1) == 2);
+  STATIC_REQUIRE(to_lower_tri(2, 2) == 5);
+  STATIC_REQUIRE(to_lower_tri(3, 3) == 9);
+  STATIC_REQUIRE(to_lower_tri(4, 4) == 14);
+  STATIC_REQUIRE(to_lower_tri(5, 5) == 20);
+
+  // some off diagonal elements
+  STATIC_REQUIRE(to_lower_tri(1, 0) == 1);
+  STATIC_REQUIRE(to_lower_tri(0, 1) == 1);
+  STATIC_REQUIRE(to_lower_tri(0, 2) == 3);
+  STATIC_REQUIRE(to_lower_tri(2, 0) == 3);
+  STATIC_REQUIRE(to_lower_tri(2, 3) == 8);
+  STATIC_REQUIRE(to_lower_tri(3, 2) == 8);
+  STATIC_REQUIRE(to_lower_tri(5, 3) == 18);
+  STATIC_REQUIRE(to_lower_tri(2, 5) == 17);
+}
+
+TEST_CASE("TrackState covariance", "[cov_matrix_utils]") {
+  auto trackState = edm4hep::TrackState{};
+
+  trackState.setCovMatrix(1.23f, edm4hep::TrackParams::d0, edm4hep::TrackParams::phi);
+  // We know the expected index in this case
+  REQUIRE(trackState.covMatrix.values[1] == 1.23f);
+  REQUIRE(trackState.getCovMatrix(edm4hep::TrackParams::time, edm4hep::TrackParams::omega) == 0);
+}

--- a/test/utils/test_covmatrix_utils.cpp
+++ b/test/utils/test_covmatrix_utils.cpp
@@ -1,4 +1,5 @@
 #include "edm4hep/Constants.h"
+#include "edm4hep/CovMatrix3f.h"
 #include "edm4hep/MutableTrackerHit3D.h"
 #include "edm4hep/TrackState.h"
 #include "edm4hep/TrackerHit3D.h"
@@ -46,6 +47,44 @@ TEST_CASE("CovarianceMatrix indexing", "[cov_matrix_utils]") {
   STATIC_REQUIRE(to_lower_tri(3, 2) == 8);
   STATIC_REQUIRE(to_lower_tri(5, 3) == 18);
   STATIC_REQUIRE(to_lower_tri(2, 5) == 17);
+}
+
+TEST_CASE("CovMatrixNf array access", "[cov_matrix_utils]") {
+  // We use the 3D version here, but since the ExtraCode is effectively
+  // duplicated for the others as well it shouldn't really matter
+  auto covMatrix = edm4hep::CovMatrix3f{};
+
+  covMatrix[3] = 3.14f;
+  REQUIRE(covMatrix[3] == 3.14f);
+
+  REQUIRE(covMatrix.data()[3] == 3.14f);
+  covMatrix.data()[2] = 2.13f;
+  REQUIRE(covMatrix[2] == 2.13f);
+
+  float i = 0.f;
+  for (auto& v : covMatrix) {
+    v = i++;
+  }
+  i = 0.f;
+  for (const auto& v : covMatrix) {
+    REQUIRE(v == i++);
+  }
+}
+
+TEST_CASE("CovMatrixNf enum access", "[cov_matrix_utils]") {
+  enum class TestDims : uint32_t { a = 0, b, c };
+
+  auto covMatrix = edm4hep::CovMatrix3f{};
+  covMatrix.setValue(1.23f, TestDims::a, TestDims::c);
+  REQUIRE(covMatrix.getValue(TestDims::a, TestDims::c) == 1.23f);
+}
+
+TEST_CASE("CovMatrixNf equality operators", "[cov_matrix_utils]") {
+  auto covMatrix = edm4hep::CovMatrix3f{};
+  covMatrix[3] = 3.14f;
+  covMatrix[2] = 2.13f;
+  REQUIRE(covMatrix == std::array<float, 6>{0, 0, 2.13f, 3.14f, 0, 0});
+  REQUIRE(covMatrix != std::array<float, 6>{});
 }
 
 TEST_CASE("TrackState covariance", "[cov_matrix_utils]") {

--- a/test/utils/test_kinematics.py
+++ b/test/utils/test_kinematics.py
@@ -48,7 +48,7 @@ class TestKinematics(unittest.TestCase):
                                       1.0,  # charge
                                       125.0,  # mass
                                       0.0,  # goodnessOfPID
-                                      cppyy.gbl.std.array('float', 10)()  # covMatrix
+                                      edm4hep.CovMatrix4f() # covMatrix
                                       )
 
     self.assertEqual(p4(p), LVM(1.0, 2.0, 3.0, 125.0))

--- a/utils/include/edm4hep/utils/cov_matrix_utils.h
+++ b/utils/include/edm4hep/utils/cov_matrix_utils.h
@@ -1,0 +1,119 @@
+#ifndef EDM4HEP_UTILS_COVMATRIXUTILS_H
+#define EDM4HEP_UTILS_COVMATRIXUTILS_H
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <iostream>
+#include <stdexcept>
+#include <type_traits>
+
+namespace edm4hep {
+
+namespace utils {
+
+  namespace detail {
+// From c++23 this is functionality offerd by the STL
+#if __cpp_lib_to_underlying
+    using to_index = std::to_underlying;
+#else
+    // Otherwise it is simple enough to roll our own
+    template <typename E>
+    constexpr auto to_index(E e) {
+      return static_cast<std::underlying_type_t<E>>(e);
+    }
+#endif
+
+    /// Cast an index to an enum value
+    template <typename DimEnum>
+    constexpr DimEnum to_enum(DimEnum index) {
+      return static_cast<DimEnum>(index);
+    }
+
+    /// Need a constexpr swap for integers before c++20
+    constexpr void swap(int& i, int& j) {
+      int tmp = j;
+      j = i;
+      i = tmp;
+    }
+  } // namespace detail
+
+  /**
+   * Get the dimension of the covariance matrix from the size of the 1D array in
+   * which it is stored
+   *
+   * **NOTE: to avoid having to do a square root operation and in order to keep
+   * this constexpr this is currently only implemented for storage sizes up to
+   * 21 (corresponding to covariance matrix dimensions of 6 x 6)**
+   *
+   * @param N the size of the 1D storage
+   *
+   * @returns the dimension of the covariance matrix
+   */
+  inline constexpr std::size_t get_cov_dim(std::size_t N) {
+    switch (N) {
+    case 21:
+      return 6;
+    case 15:
+      return 5;
+    case 10:
+      return 4;
+    case 6:
+      return 3;
+    case 3:
+      return 2;
+    case 1:
+      return 1;
+    }
+
+    // We simply use throwing an exception to make compilation fail in constexpr
+    // cases.
+    throw std::invalid_argument("Not a valid size for a covariance matrix stored in lower triangular form");
+  }
+
+  /**
+   * Transform a 2D index to a 1D index in lower triangular storage.
+   *
+   * @param i row index
+   * @param j column index
+   *
+   * @returns the index into the 1D storage
+   */
+  constexpr int to_lower_tri(int i, int j) {
+    if (i < j) {
+      detail::swap(i, j);
+    }
+    return i * (i + 1) / 2 + j;
+  }
+
+  template <typename DimEnum, typename Scalar, std::size_t N>
+  constexpr Scalar get_cov_value(const std::array<Scalar, N>& cov, DimEnum dimI, DimEnum dimJ) {
+    const auto i = detail::to_index(dimI);
+    const auto j = detail::to_index(dimJ);
+
+    const auto dim = get_cov_dim(N);
+    if (i < 0 || j < 0 || i >= dim || j >= dim) {
+      // TODO: error handling
+    }
+
+    return cov[to_lower_tri(i, j)];
+  }
+
+  template <typename DimEnum, typename Scalar, std::size_t N>
+  constexpr void set_cov_value(Scalar value, std::array<Scalar, N>& cov, DimEnum dimI, DimEnum dimJ) {
+    auto i = detail::to_index(dimI);
+    auto j = detail::to_index(dimJ);
+
+    const auto dim = get_cov_dim(N);
+    if (i < 0 || j < 0 || i >= dim || j >= dim) {
+      // TODO: error handling
+    }
+
+    // Covariance is in lower triangle this brings us from 2D indices to 1D
+    cov[to_lower_tri(i, j)] = value;
+  }
+} // namespace utils
+
+} // namespace edm4hep
+
+#endif // EDM4HEP_UTILS_COVMATRIXUTILS_H

--- a/utils/include/edm4hep/utils/cov_matrix_utils.h
+++ b/utils/include/edm4hep/utils/cov_matrix_utils.h
@@ -13,7 +13,7 @@ namespace edm4hep {
 namespace utils {
 
   namespace detail {
-// From c++23 this is functionality offerd by the STL
+    // From c++23 this is functionality offered by the STL
 #if __cpp_lib_to_underlying
     using to_index = std::to_underlying;
 #else

--- a/utils/include/edm4hep/utils/cov_matrix_utils.h
+++ b/utils/include/edm4hep/utils/cov_matrix_utils.h
@@ -1,10 +1,7 @@
 #ifndef EDM4HEP_UTILS_COVMATRIXUTILS_H
 #define EDM4HEP_UTILS_COVMATRIXUTILS_H
 
-#include <algorithm>
 #include <array>
-#include <cstdint>
-#include <iostream>
 #include <stdexcept>
 #include <type_traits>
 
@@ -44,13 +41,19 @@ namespace utils {
    *
    * **NOTE: to avoid having to do a square root operation and in order to keep
    * this constexpr this is currently only implemented for storage sizes up to
-   * 21 (corresponding to covariance matrix dimensions of 6 x 6)**
+   * 21 (corresponding to covariance matrix dimensions of 6 x 6)**. This
+   * function is intended to be called in constexpr or immediate contexts in
+   * order to fail at compilation already for invalid values of N.
    *
    * @param N the size of the 1D storage
    *
    * @returns the dimension of the covariance matrix
    */
-  inline constexpr std::size_t get_cov_dim(std::size_t N) {
+#if cpp_consteval
+  consteval std::size_t get_cov_dim(std::size_t N) {
+#else
+  constexpr std::size_t get_cov_dim(std::size_t N) {
+#endif
     switch (N) {
     case 21:
       return 6;
@@ -91,7 +94,7 @@ namespace utils {
     const auto i = detail::to_index(dimI);
     const auto j = detail::to_index(dimJ);
 
-    const auto dim = get_cov_dim(N);
+    constexpr auto dim = get_cov_dim(N);
     if (i < 0 || j < 0 || i >= dim || j >= dim) {
       // TODO: error handling
     }
@@ -104,7 +107,7 @@ namespace utils {
     auto i = detail::to_index(dimI);
     auto j = detail::to_index(dimJ);
 
-    const auto dim = get_cov_dim(N);
+    constexpr auto dim = get_cov_dim(N);
     if (i < 0 || j < 0 || i >= dim || j >= dim) {
       // TODO: error handling
     }

--- a/utils/include/edm4hep/utils/cov_matrix_utils.h
+++ b/utils/include/edm4hep/utils/cov_matrix_utils.h
@@ -3,6 +3,7 @@
 
 #include <array>
 #include <stdexcept>
+#include <string>
 #include <type_traits>
 
 namespace edm4hep {
@@ -33,73 +34,76 @@ namespace utils {
       j = i;
       i = tmp;
     }
-  } // namespace detail
 
-  /**
-   * Get the dimension of the covariance matrix from the size of the 1D array in
-   * which it is stored
-   *
-   * **NOTE: to avoid having to do a square root operation and in order to keep
-   * this constexpr this is currently only implemented for storage sizes up to
-   * 21 (corresponding to covariance matrix dimensions of 6 x 6)**. This
-   * function is intended to be called in constexpr or immediate contexts in
-   * order to fail at compilation already for invalid values of N.
-   *
-   * @param N the size of the 1D storage
-   *
-   * @returns the dimension of the covariance matrix
-   */
+    /**
+     * Get the dimension of the covariance matrix from the size of the 1D array in
+     * which it is stored
+     *
+     * **NOTE: to avoid having to do a square root operation and in order to keep
+     * this constexpr this is currently only implemented for storage sizes up to
+     * 21 (corresponding to covariance matrix dimensions of 6 x 6)**. This
+     * function is intended to be called in constexpr or immediate contexts in
+     * order to fail at compilation already for invalid values of N.
+     *
+     * @param N the size of the 1D storage
+     *
+     * @returns the dimension of the covariance matrix
+     */
 #if cpp_consteval
-  consteval std::size_t get_cov_dim(std::size_t N) {
+    consteval std::size_t get_cov_dim(std::size_t N) {
 #else
-  constexpr std::size_t get_cov_dim(std::size_t N) {
+    constexpr std::size_t get_cov_dim(std::size_t N) {
 #endif
-    switch (N) {
-    case 21:
-      return 6;
-    case 15:
-      return 5;
-    case 10:
-      return 4;
-    case 6:
-      return 3;
-    case 3:
-      return 2;
-    case 1:
-      return 1;
+      switch (N) {
+      case 21:
+        return 6;
+      case 15:
+        return 5;
+      case 10:
+        return 4;
+      case 6:
+        return 3;
+      case 3:
+        return 2;
+      case 1:
+        return 1;
+      }
+
+      // We simply use throwing an exception to make compilation fail in constexpr
+      // cases.
+      throw std::invalid_argument(
+          "Not a valid size for a covariance matrix stored in lower triangular form (N = " + std::to_string(N) + ")");
     }
 
-    // We simply use throwing an exception to make compilation fail in constexpr
-    // cases.
-    throw std::invalid_argument("Not a valid size for a covariance matrix stored in lower triangular form");
-  }
-
-  /**
-   * Transform a 2D index to a 1D index in lower triangular storage.
-   *
-   * @param i row index
-   * @param j column index
-   *
-   * @returns the index into the 1D storage
-   */
-  constexpr int to_lower_tri(int i, int j) {
-    if (i < j) {
-      detail::swap(i, j);
+    /**
+     * Transform a 2D index to a 1D index in lower triangular storage.
+     *
+     * @param i row index
+     * @param j column index
+     *
+     * @returns the index into the 1D storage
+     */
+    constexpr int to_lower_tri(int i, int j) {
+      if (i < j) {
+        detail::swap(i, j);
+      }
+      return i * (i + 1) / 2 + j;
     }
-    return i * (i + 1) / 2 + j;
-  }
+  } // namespace detail
 
   template <typename DimEnum, typename Scalar, std::size_t N>
   constexpr Scalar get_cov_value(const std::array<Scalar, N>& cov, DimEnum dimI, DimEnum dimJ) {
     const auto i = detail::to_index(dimI);
     const auto j = detail::to_index(dimJ);
 
-    constexpr auto dim = get_cov_dim(N);
+    constexpr auto dim = detail::get_cov_dim(N);
     if (i < 0 || j < 0 || i >= dim || j >= dim) {
-      // TODO: error handling
+      throw std::invalid_argument("The covariance matrix dimensions (" + std::to_string(dim) +
+                                  ") and the passed dimensions are not compatible (dimI = " + std::to_string(i) +
+                                  ", dimJ = " + std::to_string(j) + ")");
     }
 
-    return cov[to_lower_tri(i, j)];
+    return cov[detail::to_lower_tri(i, j)];
   }
 
   template <typename DimEnum, typename Scalar, std::size_t N>
@@ -107,13 +111,15 @@ namespace utils {
     auto i = detail::to_index(dimI);
     auto j = detail::to_index(dimJ);
 
-    constexpr auto dim = get_cov_dim(N);
+    constexpr auto dim = detail::get_cov_dim(N);
     if (i < 0 || j < 0 || i >= dim || j >= dim) {
-      // TODO: error handling
+      throw std::invalid_argument("The covariance matrix dimensions (" + std::to_string(dim) +
+                                  ") and the passed dimensions are not compatible (dimI = " + std::to_string(i) +
+                                  ", dimJ = " + std::to_string(j) + ")");
     }
 
     // Covariance is in lower triangle this brings us from 2D indices to 1D
-    cov[to_lower_tri(i, j)] = value;
+    cov[detail::to_lower_tri(i, j)] = value;
   }
 } // namespace utils
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Introduce `edm4hep::CovMatrix[2,3,4,6}f` components to represent covariance matrices
  - using `std::array<float, N>` under the hood
  - Access functionality that works on enums for defining dimensions and some utilities to do the indexing into the underlying storage
- Introduce some `enum class`es for defining dimensions, e.g. `TrackParams` or `Cartesian`
- Use these components instead of the raw `std::array`s in datatypes and other components and tie the interpretation of the values to the approriate dimension `enum class`

Usage example:
```cpp
#include "edm4hep/TrackerHit3D.h"

void foo(const edm4hep::TrackerHit3D& hit) {
  const auto covXY  = hit.getCovMatrix(edm4hep::Cartesian::x, edm4hep::Cartesian:y);
}
```

ENDRELEASENOTES

I am not yet sure whether I really like the duplication of all the extra code here. Especially for the components it is effectively always the same and this could in principle be easily templated. However, then we would have to mix jinja and c++ templates, so I am not entirely sure if we want that.

One possibility would be to put that part of the extra code into some `ipp` file and just `#include` it in the ExtraCode declaration.

- [ ] Check breakages downstream
  -  https://github.com/HEP-FCC/FCCAnalyses/pull/362 to build the stack with and without these changes
  - https://github.com/key4hep/k4EDM4hep2LcioConv/pull/56 in order to not break the tests there
