### PR TITLE
Improve Doxygen config to only include what is strictly necessary

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -146,7 +146,8 @@ FULL_PATH_NAMES        = YES
 
 STRIP_FROM_PATH        = @PROJECT_SOURCE_DIR@/include \
                          @PROJECT_SOURCE_DIR@/utils/include \
-                         @PROJECT_SOURCE_DIR@/edm4hep
+                         @PROJECT_SOURCE_DIR@/edm4hep \
+                         @PROJECT_SOURCE_DIR@
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which
@@ -750,7 +751,9 @@ WARN_LOGFILE           = @PROJECT_BINARY_DIR@/doxygen-warnings.log
 
 INPUT                  = @PROJECT_SOURCE_DIR@/edm4hep \
                          @PROJECT_SOURCE_DIR@/utils/include \
-                         @PROJECT_SOURCE_DIR@/include
+                         @PROJECT_SOURCE_DIR@/include \
+                         @PROJECT_SOURCE_DIR@/doc \
+                         @PROJECT_SOURCE_DIR@/README.md
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -144,8 +144,9 @@ FULL_PATH_NAMES        = YES
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        = @PROJECT_SOURCE_DIR@ @PROJECT_BINARY_DIR@
-STRIP_FROM_PATH       += @PROJECT_SOURCE_DIR@/edm4hep
+STRIP_FROM_PATH        = @PROJECT_SOURCE_DIR@/include \
+                         @PROJECT_SOURCE_DIR@/utils/include \
+                         @PROJECT_SOURCE_DIR@/edm4hep
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which
@@ -154,8 +155,10 @@ STRIP_FROM_PATH       += @PROJECT_SOURCE_DIR@/edm4hep
 # specify the list of include paths that are normally passed to the compiler
 # using the -I flag.
 
-STRIP_FROM_INC_PATH    = @DOXYGEN_INCLUDE_DIRS@ @PROJECT_BINARY_DIR@/include
-STRIP_FROM_INC_PATH   += @PROJECT_SOURCE_DIR@/edm4hep
+STRIP_FROM_INC_PATH    = @PROJECT_SOURCE_DIR@/include \
+                         @PROJECT_SOURCE_DIR@/utils/include \
+                         @PROJECT_SOURCE_DIR@/edm4hep
+
 
 # If the SHORT_NAMES tag is set to YES, doxygen will generate much shorter (but
 # less readable) file names. This can be useful is your file systems doesn't
@@ -745,9 +748,9 @@ WARN_LOGFILE           = @PROJECT_BINARY_DIR@/doxygen-warnings.log
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = @PROJECT_SOURCE_DIR@
-INPUT                 += @PROJECT_BINARY_DIR@/include
-INPUT                 += @CMAKE_CURRENT_BINARY_DIR@
+INPUT                  = @PROJECT_SOURCE_DIR@/edm4hep \
+                         @PROJECT_SOURCE_DIR@/utils/include \
+                         @PROJECT_SOURCE_DIR@/include
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -805,6 +808,7 @@ EXCLUDE_SYMLINKS       = NO
 
 EXCLUDE_PATTERNS       = */podio/* */test/* */tests/*
 EXCLUDE_PATTERNS      += */dict/* */cmake/* */scripts/*
+EXCLUDE_PATTERNS      += */edm4hep/src/*
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the
@@ -815,7 +819,7 @@ EXCLUDE_PATTERNS      += */dict/* */cmake/* */scripts/*
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories use the pattern */test/*
 
-EXCLUDE_SYMBOLS        =
+EXCLUDE_SYMBOLS        = podio
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include


### PR DESCRIPTION

BEGINRELEASENOTES
- Only pass what is strictly necessary as input to doxygen
- Exclude dependencies to avoid generating empty namespaces in the EDM4hep API reference

ENDRELEASENOTES