### PR TITLE
Use non-deprecated versions of SIO Reader/Writer

### DIFF
--- a/test/write_events_sio.cc
+++ b/test/write_events_sio.cc
@@ -1,8 +1,16 @@
 #include "write_events.h"
 
+#include "podio/podioVersion.h"
+#if PODIO_BUILD_VERSION >= PODIO_VERSION(0, 99, 0)
+#include "podio/SIOWriter.h"
+#else
 #include "podio/SIOFrameWriter.h"
+namespace podio {
+using SIOWriter = podio::SIOFrameWriter;
+}
+#endif
 
 int main(int, char**) {
-  write<podio::SIOFrameWriter>("edm4hep_events.sio");
+  write<podio::SIOWriter>("edm4hep_events.sio");
   return 0;
 }


### PR DESCRIPTION

BEGINRELEASENOTES
- Use non deprecated versions of the `SIOWriter` and `SIOReader` 

ENDRELEASENOTES

Similar to #263 but for SIO