### PR TITLE
Give the utils target a more discernible output name

### DIFF
--- a/cmake/EDM4HEPConfig.cmake.in
+++ b/cmake/EDM4HEPConfig.cmake.in
@@ -21,5 +21,4 @@ include("${CMAKE_CURRENT_LIST_DIR}/EDM4HEPTargets.cmake")
 # print the default "Found:" message and check library location
 include(FindPackageHandleStandardArgs)
 get_property(TEST_EDM4HEP_LIBRARY TARGET EDM4HEP::edm4hep PROPERTY LOCATION)
-
 find_package_handle_standard_args(EDM4HEP DEFAULT_MSG CMAKE_CURRENT_LIST_FILE TEST_EDM4HEP_LIBRARY)

--- a/cmake/EDM4HEPConfig.cmake.in
+++ b/cmake/EDM4HEPConfig.cmake.in
@@ -22,7 +22,4 @@ include("${CMAKE_CURRENT_LIST_DIR}/EDM4HEPTargets.cmake")
 include(FindPackageHandleStandardArgs)
 get_property(TEST_EDM4HEP_LIBRARY TARGET EDM4HEP::edm4hep PROPERTY LOCATION)
 
-# For backwards compatibility and for slightly less typing
-add_library(EDM4HEP::utils ALIAS EDM4HEP::edm4hepUtils)
-
 find_package_handle_standard_args(EDM4HEP DEFAULT_MSG CMAKE_CURRENT_LIST_FILE TEST_EDM4HEP_LIBRARY)

--- a/cmake/EDM4HEPConfig.cmake.in
+++ b/cmake/EDM4HEPConfig.cmake.in
@@ -21,4 +21,8 @@ include("${CMAKE_CURRENT_LIST_DIR}/EDM4HEPTargets.cmake")
 # print the default "Found:" message and check library location
 include(FindPackageHandleStandardArgs)
 get_property(TEST_EDM4HEP_LIBRARY TARGET EDM4HEP::edm4hep PROPERTY LOCATION)
+
+# For backwards compatibility and for slightly less typing
+add_library(EDM4HEP::utils ALIAS EDM4HEP::edm4hepUtils)
+
 find_package_handle_standard_args(EDM4HEP DEFAULT_MSG CMAKE_CURRENT_LIST_FILE TEST_EDM4HEP_LIBRARY)

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -13,6 +13,7 @@ set_target_properties(utils PROPERTIES OUTPUT_NAME "edm4hepUtils")
 add_library(EDM4HEP::utils ALIAS utils)
 target_link_libraries(utils INTERFACE kinematics)
 
+
 set(sources src/dataframe.cc)
 set(headers include/edm4hep/utils/dataframe.h)
 

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -8,9 +8,10 @@ target_include_directories(kinematics
 target_link_libraries(kinematics PUBLIC INTERFACE ROOT::Core)
 target_compile_features(kinematics INTERFACE cxx_std_17)
 
-add_library(edm4hepUtils INTERFACE)
-add_library(EDM4HEP::utils ALIAS edm4hepUtils)
-target_link_libraries(edm4hepUtils INTERFACE kinematics)
+add_library(utils INTERFACE)
+set_target_properties(utils PROPERTIES OUTPUT_NAME "edm4hepUtils")
+add_library(EDM4HEP::utils ALIAS utils)
+target_link_libraries(utils INTERFACE kinematics)
 
 set(sources src/dataframe.cc)
 set(headers include/edm4hep/utils/dataframe.h)
@@ -25,7 +26,7 @@ target_link_libraries(edm4hepRDF PUBLIC edm4hep ROOT::Physics ROOT::ROOTVecOps)
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
   PATTERN "CMakeLists.txt" EXCLUDE)
 
-install(TARGETS edm4hepUtils kinematics edm4hepRDF
+install(TARGETS utils kinematics edm4hepRDF
   EXPORT EDM4HEPTargets
   RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT bin
   RUNTIME DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT shlib

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -8,10 +8,9 @@ target_include_directories(kinematics
 target_link_libraries(kinematics PUBLIC INTERFACE ROOT::Core)
 target_compile_features(kinematics INTERFACE cxx_std_17)
 
-add_library(utils INTERFACE)
-add_library(EDM4HEP::utils ALIAS utils)
-target_link_libraries(utils INTERFACE kinematics)
-
+add_library(edm4hepUtils INTERFACE)
+add_library(EDM4HEP::utils ALIAS edm4hepUtils)
+target_link_libraries(edm4hepUtils INTERFACE kinematics)
 
 set(sources src/dataframe.cc)
 set(headers include/edm4hep/utils/dataframe.h)
@@ -26,7 +25,7 @@ target_link_libraries(edm4hepRDF PUBLIC edm4hep ROOT::Physics ROOT::ROOTVecOps)
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
   PATTERN "CMakeLists.txt" EXCLUDE)
 
-install(TARGETS utils kinematics edm4hepRDF
+install(TARGETS edm4hepUtils kinematics edm4hepRDF
   EXPORT EDM4HEPTargets
   RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT bin
   RUNTIME DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT shlib


### PR DESCRIPTION
BEGINRELEASENOTES
- Make sure that the `utils` (currently INTERFACE only) target appears as `edm4hepUtils` "on disk" in order to avoid having on overly generic `libutils.so` once it actually becomes a shared library.

ENDRELEASENOTES

This is a small side-effect that can easily be split off from #268 