### PR TITLE
Transparently introduce switch to optional param values

### DIFF
--- a/test/read_events.h
+++ b/test/read_events.h
@@ -11,12 +11,10 @@
 
 // podio specific includes
 #include "podio/Frame.h"
+#include "podio/podioVersion.h"
 
 // STL
-#include <cassert>
-#include <exception>
 #include <iostream>
-#include <vector>
 
 void processEvent(const podio::Frame& event) {
   auto& mcps = event.get<edm4hep::MCParticleCollection>("MCParticles");
@@ -240,7 +238,11 @@ void processEvent(const podio::Frame& event) {
   //    throw std::runtime_error("Collection 'SimCalorimeterHitContributions' should be present");
   //  }
 
+#if PODIO_BUILD_VERSION > PODIO_VERSION(0, 99, 0)
+  const auto evtType = event.getParameter<std::string>("EventType").value();
+#else
   const auto& evtType = event.getParameter<std::string>("EventType");
+#endif
   std::cout << "Event Type: " << evtType << std::endl;
 }
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Introduce pre-processor checks to transparently switch to the new `std::optional` return values of `podio::Frame::getParameter` (introduced with [AIDASoft/podio#580](https://github.com/AIDASoft/podio/pull/580))

ENDRELEASENOTES