### PR TITLE
Use 'declarationFile' instead of  #include in CovMatrix component

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,37 +13,37 @@ A generic event data model for future HEP collider experiments.
 | | | |
 |-|-|-|
 | [Vector4f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L9)      | [Vector3f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L34)     | [Vector3d](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L56)      |
-| [Vector2i](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L84)     | [Vector2f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L104)    | [TrackState](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L192)   |
-| [Quantity](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L221)    | [Hypothesis](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L229)  | [HitLevelData](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L236) |
-| [CovMatrix2f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L123)  |[CovMatrix3f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L140)   |[CovMatrix4f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L157)   |
-| [CovMatrix6f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L174) | | |
+| [Vector2i](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L84)     | [Vector2f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L104)    | [TrackState](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L195)   |
+| [Quantity](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L224)    | [Hypothesis](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L232)  | [HitLevelData](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L239) |
+| [CovMatrix2f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L123)  |[CovMatrix3f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L141)   |[CovMatrix4f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L158)   |
+| [CovMatrix6f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L176) | | |
 
 
 **Datatypes**
 
 | | | |
 |-|-|-|
-| [EventHeader](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L246)         | [MCParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L258)        | [SimTrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L326)         |
-| [CaloHitContribution](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L368) | [SimCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L380) | [RawCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L392)     |
-| [CalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L401)      | [ParticleID](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L413)        | [Cluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L428)               |
-| [TrackerHit3D](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L460)          | [TrackerHitPlane](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L486)   | [RawTimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L516)                |
-| [Track](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L529)               | [Vertex](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L548)            | [ReconstructedParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L576) |
-| [SimPrimaryIonizationCluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L688) | [TrackerPulse](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L722) | [RecIonizationCluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L747) |
-| [TimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L758) | [RecDqdx](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L770) |                                                                                          |
+| [EventHeader](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L249)         | [MCParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L261)        | [SimTrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L329)         |
+| [CaloHitContribution](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L371) | [SimCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L383) | [RawCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L395)     |
+| [CalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L404)      | [ParticleID](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L416)        | [Cluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L431)               |
+| [TrackerHit3D](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L463)          | [TrackerHitPlane](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L489)   | [RawTimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L519)                |
+| [Track](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L532)               | [Vertex](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L551)            | [ReconstructedParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L579) |
+| [SimPrimaryIonizationCluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L691) | [TrackerPulse](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L725) | [RecIonizationCluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L750) |
+| [TimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L761) | [RecDqdx](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L773) |                                                                                          |
 
 **Associations**
 
 | | | |
 |-|-|-|
-| [MCRecoParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L614)        | [MCRecoCaloAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L623)         | [MCRecoTrackerAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L632)         |
-| [MCRecoTrackerHitPlaneAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L641) | [MCRecoCaloParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L650) | [MCRecoClusterParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L659) |
-| [MCRecoTrackParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L668)   | [RecoParticleVertexAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L677) |                                                                                                      |
+| [MCRecoParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L617)        | [MCRecoCaloAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L626)         | [MCRecoTrackerAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L635)         |
+| [MCRecoTrackerHitPlaneAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L644) | [MCRecoCaloParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L653) | [MCRecoClusterParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L662) |
+| [MCRecoTrackParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L671)   | [RecoParticleVertexAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L680) |                                                                                                      |
 
 **Interfaces**
 
 | | | |
 |-|-|-|
-| [TrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L784) | | |
+| [TrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L787) | | |
 
 
 The tests and examples in the `tests` directory show how to read, write, and use these types in your code.

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -134,8 +134,9 @@ components:
           constexpr CovMatrix2f& operator=(std::array<float, 3>& v) { values = v; return *this; }\n
           bool operator==(const CovMatrix2f& v) const { return v.values == values; }\n
           bool operator!=(const CovMatrix2f& v) const { return v.values != values; }\n
-          #include <edm4hep/detail/CovMatrixCommon.ipp>
-          "
+        "
+        declarationFile: "edm4hep/extra_code/CovMatrixCommon.ipp"
+
 
     edm4hep::CovMatrix3f:
       Description: "A generic 3 dimensional covariance matrix with values stored in lower triangular form"
@@ -151,8 +152,8 @@ components:
           constexpr CovMatrix3f& operator=(std::array<float, 6>& v) { values = v; return *this; }\n
           bool operator==(const CovMatrix3f& v) const { return v.values == values; }\n
           bool operator!=(const CovMatrix3f& v) const { return v.values != values; }\n
-          #include <edm4hep/detail/CovMatrixCommon.ipp>
         "
+        declarationFile: "edm4hep/extra_code/CovMatrixCommon.ipp"
 
     edm4hep::CovMatrix4f:
       Description: "A generic 4 dimensional covariance matrix with values stored in lower triangular form"
@@ -168,8 +169,9 @@ components:
           constexpr CovMatrix4f& operator=(std::array<float, 10>& v) { values = v; return *this; }\n
           bool operator==(const CovMatrix4f& v) const { return v.values == values; }\n
           bool operator!=(const CovMatrix4f& v) const { return v.values != values; }\n
-          #include <edm4hep/detail/CovMatrixCommon.ipp>
-          "
+        "
+        declarationFile: "edm4hep/extra_code/CovMatrixCommon.ipp"
+
 
     edm4hep::CovMatrix6f:
       Description: "A generic 6 dimensional covariance matrix with values stored in lower triangular form"
@@ -185,8 +187,9 @@ components:
           constexpr CovMatrix6f& operator=(std::array<float, 21>& v) { values = v; return *this; }\n
           bool operator==(const CovMatrix6f& v) const { return v.values == values; }\n
           bool operator!=(const CovMatrix6f& v) const { return v.values != values; }\n
-          #include <edm4hep/detail/CovMatrixCommon.ipp>\n
         "
+        declarationFile: "edm4hep/extra_code/CovMatrixCommon.ipp"
+
 
       # Parametrized description of a particle track
     edm4hep::TrackState:

--- a/edm4hep/CMakeLists.txt
+++ b/edm4hep/CMakeLists.txt
@@ -49,3 +49,7 @@ install(FILES
 install(FILES
   ../edm4hep.yaml
   DESTINATION "${CMAKE_INSTALL_DATADIR}/edm4hep" COMPONENT dev)
+
+install(DIRECTORY
+  extra_code
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/edm4hep/edm4hep" COMPONENT dev)

--- a/edm4hep/CMakeLists.txt
+++ b/edm4hep/CMakeLists.txt
@@ -1,7 +1,11 @@
+# files used in ExtraCode directives
+set(extra_code extra_code/CovMatrixCommon.ipp)
 
 # For now unconditionally generate all the code that is supported by the
 # installed podio
-PODIO_GENERATE_DATAMODEL(edm4hep ../edm4hep.yaml headers sources IO_BACKEND_HANDLERS ${PODIO_IO_HANDLERS})
+PODIO_GENERATE_DATAMODEL(edm4hep ../edm4hep.yaml headers sources
+  IO_BACKEND_HANDLERS ${PODIO_IO_HANDLERS} DEPENDS ${extra_code}
+)
 
 PODIO_ADD_DATAMODEL_CORE_LIB(edm4hep "${headers}" "${sources}")
 target_include_directories(edm4hep PUBLIC

--- a/edm4hep/extra_code/CovMatrixCommon.ipp
+++ b/edm4hep/extra_code/CovMatrixCommon.ipp
@@ -1,5 +1,5 @@
-// This file is meant to be included inside the declaration part of the
-// ExtraCode for the CovMatrixNx components. They live in this file because they
+// This file is meant to be included with ExtraCode  declarationFile directive
+// for the CovMatrixNx components. They live in this file because they
 // can be written very generically and reduce the clutter and code repetition in
 // the edm4hep.yaml file
 //

--- a/edm4hep/extra_code/CovMatrixCommon.ipp
+++ b/edm4hep/extra_code/CovMatrixCommon.ipp
@@ -1,4 +1,4 @@
-// This file is meant to be included with ExtraCode  declarationFile directive
+// This file is meant to be included via the ExtraCode declarationFile directive
 // for the CovMatrixNx components. They live in this file because they
 // can be written very generically and reduce the clutter and code repetition in
 // the edm4hep.yaml file


### PR DESCRIPTION
BEGINRELEASENOTES
- Use declarationFile instead of include in CovMatrix to fix generated documentation for covariance matrix components. Fixes [#296](https://github.com/key4hep/EDM4hep/issues/296)

ENDRELEASENOTES

Closes #296 

Declarations added with `#include` were not appearing in a documentation generated with doxygen. New podio direcative 'declarationFile'  (https://github.com/AIDASoft/podio/pull/601)  includes  these declaration during file generation without relaying on pre-processor and make them visible to doxygen
| Old | New |
|-|-|
|![Screenshot_2024-05-01_14-27-21](https://github.com/key4hep/EDM4hep/assets/37295697/16444c50-cc7e-4aa6-b53c-ff7332dfbc6f)|![covmatrix_fix](https://github.com/key4hep/EDM4hep/assets/37295697/debde81e-972b-40ab-b671-14b43c91c64f) | 