### PR TITLE
Remove the dQ/dx information from the track

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,29 +26,29 @@ A generic event data model for future HEP collider experiments.
 | [CaloHitContribution](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L355) | [SimCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L367) | [RawCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L379)     |
 | [CalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L388)      | [ParticleID](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L400)        | [Cluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L415)               |
 | [TrackerHit3D](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L447)          | [TrackerHitPlane](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L473)   | [RawTimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L503)                |
-| [Track](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L517)               | [Vertex](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L535)            | [ReconstructedParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L581) |
-| [TimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L683) | [RecDqdx](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L695) |                                                                                          |
+| [Track](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L517)               | [Vertex](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L532)            | [ReconstructedParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L578) |
+| [TimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L680) | [RecDqdx](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L692) |                                                                                          |
 
 **Associations**
 
 | | | |
 |-|-|-|
-| [MCRecoParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L619)        | [MCRecoCaloAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L628)         | [MCRecoTrackerAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L637)         |
-| [MCRecoCaloParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L646) | [MCRecoClusterParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L655) | [MCRecoTrackParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L664)   |
-| [RecoParticleVertexAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L673) | | |
+| [MCRecoParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L616)        | [MCRecoCaloAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L625)         | [MCRecoTrackerAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L634)         |
+| [MCRecoCaloParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L643) | [MCRecoClusterParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L652) | [MCRecoTrackParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L661)   |
+| [RecoParticleVertexAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L670) | | |
 
 **Generator related (meta-)data**
 
 | | | |
 |-|-|-|
-| [GeneratorEventParameters](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L707) | | |
-| [GeneratorPdfInfo](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L724) | | |
+| [GeneratorEventParameters](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L704) | | |
+| [GeneratorPdfInfo](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L721) | | |
 
 **Interfaces**
 
 | | | |
 |-|-|-|
-| [TrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L735) | | |
+| [TrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L732) | | |
 
 The tests and examples in the `tests` directory show how to read, write, and use these types in your code.
 

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -521,12 +521,9 @@ datatypes:
       - int32_t type                         // flagword that defines the type of track
       - float chi2                       // Chi^2 of the track fit
       - int32_t ndf                          // number of degrees of freedom of the track fit
-      - float dEdx                       // dEdx of the track
-      - float dEdxError                  // error of dEdx
     VectorMembers:
       - int32_t subdetectorHitNumbers        // number of hits in particular subdetectors
       - edm4hep::TrackState trackStates  // track states
-      - edm4hep::Quantity dxQuantities // different measurements of dx quantities
     OneToManyRelations:
       - edm4hep::TrackerHit trackerHits  // hits that have been used to create this track
       - edm4hep::Track tracks            // tracks (segments) that have been combined to create this track

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -690,7 +690,7 @@ datatypes:
 
   #-------------  RecDqdx
   edm4hep::RecDqdx:
-    Description: "dN/dx or dE/dx info of Track."
+    Description: "dN/dx or dE/dx info of a Track"
     Author: "EDM4hep authors"
     Members:
       - edm4hep::Quantity dQdx         // the reconstructed dEdx or dNdx and its error

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -11,6 +11,7 @@ target_compile_features(kinematics INTERFACE cxx_std_17)
 set(utils_sources
   src/ParticleIDUtils.cc
   src/MurmurHash3.cpp
+  src/TrackUtils.cc
 )
 
 add_library(utils SHARED ${utils_sources})

--- a/utils/include/edm4hep/utils/TrackUtils.h
+++ b/utils/include/edm4hep/utils/TrackUtils.h
@@ -1,0 +1,27 @@
+#ifndef EDM4HEP_UTILS_TRACKUTILS_H
+#define EDM4HEP_UTILS_TRACKUTILS_H
+
+#include <edm4hep/RecDqdxCollection.h>
+#include <edm4hep/Track.h>
+
+#include <podio/Frame.h>
+
+#include <map>
+#include <vector>
+
+namespace edm4hep::utils {
+/// Utility class to invert the relations between RecDqdx to Track relation
+class TrackPIDHandler {
+  using TrackMapT = std::multimap<edm4hep::Track, edm4hep::RecDqdx>;
+
+  TrackMapT m_trackDqMap{}; ///< The internal map from tracks to RecDqdx
+public:
+  /// Add the information from the passed collection to the handler
+  void addColl(const edm4hep::RecDqdxCollection& coll);
+
+  /// Get all RecDqdx objects for the given track
+  std::vector<edm4hep::RecDqdx> getDqdxValues(const edm4hep::Track& track) const;
+};
+} // namespace edm4hep::utils
+
+#endif // EDM4HEP_UTILS_TRACKUTILS_H

--- a/utils/src/TrackUtils.cc
+++ b/utils/src/TrackUtils.cc
@@ -1,0 +1,26 @@
+#include "edm4hep/utils/TrackUtils.h"
+#include "edm4hep/RecDqdxCollection.h"
+
+#include <iterator>
+
+namespace edm4hep::utils {
+
+void TrackPIDHandler::addColl(const edm4hep::RecDqdxCollection& coll) {
+  for (const auto dqdx : coll) {
+    m_trackDqMap.emplace(dqdx.getTrack(), dqdx);
+  }
+}
+
+std::vector<edm4hep::RecDqdx> TrackPIDHandler::getDqdxValues(const edm4hep::Track& track) const {
+  const auto& [begin, end] = m_trackDqMap.equal_range(track);
+  std::vector<edm4hep::RecDqdx> dqdxs{};
+  dqdxs.reserve(std::distance(begin, end));
+
+  for (auto it = begin; it != end; ++it) {
+    dqdxs.emplace_back(it->second);
+  }
+
+  return dqdxs;
+}
+
+} // namespace edm4hep::utils


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove the `dQ/dx` information from the Track
- Add `TrackPIDHandler` to allow for the reverse lookup

ENDRELEASENOTES

- [x] Needs check of things that break downstream
	- [x] https://github.com/key4hep/k4FWCore/pull/198
- [x] Currently breaks in the following packages
  - k4EDM4hep2LcioConv (https://github.com/key4hep/k4EDM4hep2LcioConv/pull/69)
  - k4SimDelphes (https://github.com/key4hep/k4SimDelphes/pull/121)
  - FCCAnalyses (https://github.com/HEP-FCC/FCCAnalyses/pull/387)
  - k4RecTracker (https://github.com/key4hep/k4RecTracker/pull/23)