### PR TITLE
Make the python install prefix conform to python conventions

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,4 +1,20 @@
-install(DIRECTORY edm4hep DESTINATION python
+find_package(Python3 REQUIRED)
+
+# Setup the python install dir. See the discussion in
+# https://github.com/AIDASoft/podio/pull/599 for more details on why this is
+# done the way it is
+set(edm4hep_python_lib_dir lib)
+if("${Python3_SITEARCH}" MATCHES "/lib64/")
+  set(edm4hep_python_lib_dir lib64)
+endif()
+
+set(EDM4HEP_PYTHON_INSTALLDIR
+  "${CMAKE_INSTALL_PREFIX}/${edm4hep_python_lib_dir}/python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}/site-packages"
+  CACHE STRING
+  "The install prefix for the python bindings"
+)
+
+install(DIRECTORY edm4hep DESTINATION ${EDM4HEP_PYTHON_INSTALLDIR}
   REGEX .*\\.in EXCLUDE
   PATTERN __pycache__ EXCLUDE
 )


### PR DESCRIPTION

BEGINRELEASENOTES
- Make the python bindings install prefix conform to python conventions by default and allow overriding with the `EDM4HEP_PYTHON_INSTALLDIR` cmake variable
  - Default prefix is now `<prefix>/lib[64]/pythonX.Y/site-packages` (where `lib` or `lib64` is defined from the platform defaults and `X.Y` is the python major and minor version).

ENDRELEASENOTES

Fixes #220 

See https://github.com/AIDASoft/podio/pull/599 for some discussion on how we arrived at this solution.