### PR TITLE
Introduce a `labels` namespace for the string constants

### DIFF
--- a/include/edm4hep/Constants.h
+++ b/include/edm4hep/Constants.h
@@ -41,7 +41,7 @@ namespace labels {
 
 DEPRECATED_LABEL(CellIDEncoding, CellIDEncoding);
 DEPRECATED_LABEL(EventHeaderName, EventHeader);
-DEPRECATED_LABEL(EventWeights, EventWeights);
+DEPRECATED_LABEL(EventWeights, EventWeightsNames);
 DEPRECATED_LABEL(shapeParameterNames, ShapeParameterNames);
 DEPRECATED_LABEL(EventFilterStats, EventFilterStats);
 

--- a/include/edm4hep/Constants.h
+++ b/include/edm4hep/Constants.h
@@ -21,12 +21,33 @@
 
 #include <cstdint>
 
+#define DEPRECATED_LABEL(name, newname)                                                                                \
+  static constexpr const auto name [[deprecated("Use 'edm4hep::labels::" #newname "' instead")]] = labels::newname
+
 namespace edm4hep {
-static constexpr const char* CellIDEncoding = "CellIDEncoding";
-static constexpr const char* EventHeaderName = "EventHeader";
-static constexpr const char* EventWeights = "EventWeightNames";
-static constexpr const char* shapeParameterNames = "shapeParameterNames";
-static constexpr const char* EventFilterStats = "EventFilterStats";
+namespace labels {
+  static constexpr const char* CellIDEncoding = "CellIDEncoding";
+  static constexpr const char* EventHeader = "EventHeader";
+  static constexpr const char* EventWeights = "EventWeightNames";
+  static constexpr const char* ShapeParameterNames = "shapeParameterNames";
+  static constexpr const char* EventFilterStats = "EventFilterStats";
+
+  /// The collection parameter name for accessing the names of the parameters for
+  /// a ParticleID collection
+  static constexpr const char* PIDParameterNames = "ParameterNames";
+  static constexpr const char* PIDAlgoName = "AlgoName";
+  static constexpr const char* PIDAlgoType = "AlgoType";
+} // namespace labels
+
+DEPRECATED_LABEL(CellIDEncoding, CellIDEncoding);
+DEPRECATED_LABEL(EventHeaderName, EventHeader);
+DEPRECATED_LABEL(EventWeights, EventWeights);
+DEPRECATED_LABEL(shapeParameterNames, ShapeParameterNames);
+DEPRECATED_LABEL(EventFilterStats, EventFilterStats);
+
+DEPRECATED_LABEL(pidParameterNames, PIDParameterNames);
+DEPRECATED_LABEL(pidAlgoName, PIDAlgoName);
+DEPRECATED_LABEL(pidAlgoType, PIDAlgoType);
 
 // Use 16 bits to encode the dimension
 // Could go to 8 bits, but would need a fix in podio first
@@ -45,12 +66,8 @@ enum class TrackParams : DimType { d0 = 0, phi, omega, z0, tanLambda, time };
 /// Enum for accessing the covariance matrix in the TrackerPulse
 enum class TrackerPulseDims : DimType { charge = 0, time };
 
-/// The collection parameter name for accessing the names of the parameters for
-/// a ParticleID collection
-static constexpr const char* pidParameterNames = "ParameterNames";
-static constexpr const char* pidAlgoName = "AlgoName";
-static constexpr const char* pidAlgoType = "AlgoType";
-
 } // namespace edm4hep
+
+#undef DEPRECATED_LABEL
 
 #endif // EDM4HEP_CONSTANTS_H

--- a/include/edm4hep/Constants.h
+++ b/include/edm4hep/Constants.h
@@ -28,7 +28,7 @@ namespace edm4hep {
 namespace labels {
   static constexpr const char* CellIDEncoding = "CellIDEncoding";
   static constexpr const char* EventHeader = "EventHeader";
-  static constexpr const char* EventWeights = "EventWeightNames";
+  static constexpr const char* EventWeightsNames = "EventWeightNames";
   static constexpr const char* ShapeParameterNames = "shapeParameterNames";
   static constexpr const char* EventFilterStats = "EventFilterStats";
 

--- a/utils/src/ParticleIDUtils.cc
+++ b/utils/src/ParticleIDUtils.cc
@@ -132,41 +132,44 @@ void PIDHandler::setAlgoInfo(podio::Frame& metadata, edm4hep::ParticleIDCollecti
 
 void PIDHandler::setAlgoInfo(podio::Frame& metadata, const std::string& collName,
                              const edm4hep::utils::ParticleIDMeta& pidMetaInfo) {
-  metadata.putParameter(podio::collMetadataParamName(collName, edm4hep::pidAlgoName), pidMetaInfo.algoName);
-  metadata.putParameter(podio::collMetadataParamName(collName, edm4hep::pidAlgoType), pidMetaInfo.algoType());
-  metadata.putParameter(podio::collMetadataParamName(collName, edm4hep::pidParameterNames), pidMetaInfo.paramNames);
+  metadata.putParameter(podio::collMetadataParamName(collName, edm4hep::labels::PIDAlgoName), pidMetaInfo.algoName);
+  metadata.putParameter(podio::collMetadataParamName(collName, edm4hep::labels::PIDAlgoType), pidMetaInfo.algoType());
+  metadata.putParameter(podio::collMetadataParamName(collName, edm4hep::labels::PIDParameterNames),
+                        pidMetaInfo.paramNames);
 }
 
 std::optional<edm4hep::utils::ParticleIDMeta> PIDHandler::getAlgoInfo(const podio::Frame& metadata,
                                                                       const std::string& collName) {
 
 #if PODIO_BUILD_VERSION > PODIO_VERSION(0, 99, 0)
-  auto maybeAlgoName = metadata.getParameter<std::string>(podio::collMetadataParamName(collName, edm4hep::pidAlgoName));
+  auto maybeAlgoName =
+      metadata.getParameter<std::string>(podio::collMetadataParamName(collName, edm4hep::labels::PIDAlgoName));
   if (!maybeAlgoName.has_value()) {
     return std::nullopt;
   }
 
   ParticleIDMeta pidInfo{
       std::move(maybeAlgoName.value()),
-      metadata.getParameter<int>(podio::collMetadataParamName(collName, edm4hep::pidAlgoType)).value(),
+      metadata.getParameter<int>(podio::collMetadataParamName(collName, edm4hep::labels::PIDAlgoType)).value(),
       metadata
-          .getParameter<std::vector<std::string>>(podio::collMetadataParamName(collName, edm4hep::pidParameterNames))
+          .getParameter<std::vector<std::string>>(
+              podio::collMetadataParamName(collName, edm4hep::labels::PIDParameterNames))
           .value()};
 
 #else
 
   const auto& algoName =
-      metadata.getParameter<std::string>(podio::collMetadataParamName(collName, edm4hep::pidAlgoName));
+      metadata.getParameter<std::string>(podio::collMetadataParamName(collName, edm4hep::labels::PIDAlgoName));
   // Use the algoName as proxy to see whether we could actually get the
   // information from the metadata
   if (algoName.empty()) {
     return std::nullopt;
   }
 
-  ParticleIDMeta pidInfo{algoName,
-                         metadata.getParameter<int>(podio::collMetadataParamName(collName, edm4hep::pidAlgoType)),
-                         metadata.getParameter<std::vector<std::string>>(
-                             podio::collMetadataParamName(collName, edm4hep::pidParameterNames))};
+  ParticleIDMeta pidInfo{
+      algoName, metadata.getParameter<int>(podio::collMetadataParamName(collName, edm4hep::labels::PIDAlgoType)),
+      metadata.getParameter<std::vector<std::string>>(
+          podio::collMetadataParamName(collName, edm4hep::labels::PIDParameterNames))};
 #endif
 
   return pidInfo;


### PR DESCRIPTION
BEGINRELEASENOTES
- Introduce the `edm4hep::labels` namespace to hold the string constants that are used for consistent labeling / naming of collections or parameters.
  - Use this opportunity to homogenize the naming and capitalization of the variables but leave string constants unchanged
- Deprecate existing string constants

ENDRELEASENOTES

As triggered by [this discussion](https://github.com/key4hep/EDM4hep/pull/310#discussion_r1636352789)