### PR TITLE
Add an MCParticles label to denote the canoncial MCParticle collection

### DIFF
--- a/include/edm4hep/Constants.h
+++ b/include/edm4hep/Constants.h
@@ -31,7 +31,9 @@ namespace labels {
   static constexpr const char* EventWeightsNames = "EventWeightNames";
   static constexpr const char* ShapeParameterNames = "shapeParameterNames";
   static constexpr const char* EventFilterStats = "EventFilterStats";
-
+  /// The canonical name for the main MCParticle collection
+  static constexpr const char* MCParticles = "MCParticles";
+  
   /// The collection parameter name for accessing the names of the parameters for
   /// a ParticleID collection
   static constexpr const char* PIDParameterNames = "ParameterNames";


### PR DESCRIPTION


BEGINRELEASENOTES
- Introduce a `edm4hep::labels::MCParticle` label to formalize the name of the canonical MCParticle collection

ENDRELEASENOTES
