### PR TITLE
fix: require podio 1.0 for PODIO_GENERATE_DATAMODEL DEPENDS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ SET( ${PROJECT_NAME}_VERSION_PATCH 99 )
 
 SET( ${PROJECT_NAME}_VERSION  "${${PROJECT_NAME}_VERSION_MAJOR}.${${PROJECT_NAME}_VERSION_MINOR}.${${PROJECT_NAME}_VERSION_PATCH}" )
 
-find_package(podio REQUIRED HINTS $ENV{PODIO})
+find_package(podio 1.0 REQUIRED HINTS $ENV{PODIO})
 find_package(ROOT REQUIRED COMPONENTS RIO Tree Physics)
 
 #--- Define basic build settings -----------------------------------------------

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This project is in a beta stage -- feedback and use of it in production is encou
 
 Required:
 
-* [PODIO](https://github.com/AIDASoft/podio) >= v00-15
+* [PODIO](https://github.com/AIDASoft/podio) >= v01-00
 * [ROOT](https://github.com/root-project/root) >= v6.22/06
 
 Optional:


### PR DESCRIPTION
Podio only provides the DEPENDS argument of  PODIO_GENERATE_DATAMODEL since https://github.com/AIDASoft/podio/commit/0a5af60c203147de1e7f0081810e0b2fcfc6be5f, i.e. as of tagged version 1.0. 

The use of DEPENDS was added in https://github.com/key4hep/EDM4hep/pull/308 (not in tagged release yet).

BEGINRELEASENOTES
- Require podio 1.0

ENDRELEASENOTES