### PR TITLE
Remove no longer relevant bit of docstring relating to `Track::type`

### DIFF
--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -533,7 +533,7 @@ datatypes:
     Description: "Reconstructed track"
     Author: "EDM4hep authors"
     Members:
-      - int32_t type                         // flagword that defines the type of track.Bits 16-31 are used internally
+      - int32_t type                         // flagword that defines the type of track
       - float chi2                       // Chi^2 of the track fit
       - int32_t ndf                          // number of degrees of freedom of the track fit
       - float dEdx                       // dEdx of the track


### PR DESCRIPTION

BEGINRELEASENOTES
- Remove docstring of `Track::type` that is no longer relevant for EDM4hep and was a leftover from LCIO.
  - EDM4hep does not (yet) reserve any bits in the Track

ENDRELEASENOTES