### PR TITLE
Remove the `MCRecoTrackerHitPlaneAssociation`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,28 +27,28 @@ A generic event data model for future HEP collider experiments.
 | [CalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L388)      | [ParticleID](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L400)        | [Cluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L415)               |
 | [TrackerHit3D](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L447)          | [TrackerHitPlane](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L473)   | [RawTimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L503)                |
 | [Track](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L517)               | [Vertex](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L536)            | [ReconstructedParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L564) |
-| [TimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L675) | [RecDqdx](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L687) |                                                                                          |
+| [TimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L666) | [RecDqdx](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L678) |                                                                                          |
 
 **Associations**
 
 | | | |
 |-|-|-|
 | [MCRecoParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L602)        | [MCRecoCaloAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L611)         | [MCRecoTrackerAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L620)         |
-| [MCRecoTrackerHitPlaneAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L629) | [MCRecoCaloParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L638) | [MCRecoClusterParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L647) |
-| [MCRecoTrackParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L656)   | [RecoParticleVertexAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L665) |                                                                                                      |
+| [MCRecoCaloParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L629) | [MCRecoClusterParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L638) | [MCRecoTrackParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L647)   |
+| [RecoParticleVertexAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L656) | | |
 
 **Generator related (meta-)data**
 
 | | | |
 |-|-|-|
-| [GeneratorEventParameters](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L699) | | |
-| [GeneratorPdfInfo](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L716) | | |
+| [GeneratorEventParameters](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L690) | | |
+| [GeneratorPdfInfo](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L707) | | |
 
 **Interfaces**
 
 | | | |
 |-|-|-|
-| [TrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L727) | | |
+| [TrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L718) | | |
 
 The tests and examples in the `tests` directory show how to read, write, and use these types in your code.
 

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -626,15 +626,6 @@ datatypes:
      - edm4hep::TrackerHit rec    // reference to the reconstructed hit
      - edm4hep::SimTrackerHit sim // reference to the simulated hit
 
-  edm4hep::MCRecoTrackerHitPlaneAssociation:
-    Description: "Association between a TrackerHitPlane and the corresponding SimTrackerHit"
-    Author: "EDM4hep authors"
-    Members:
-      - float weight                // weight of this association
-    OneToOneRelations:
-     - edm4hep::TrackerHitPlane rec // reference to the reconstructed hit
-     - edm4hep::SimTrackerHit sim   // reference to the simulated hit
-
   edm4hep::MCRecoCaloParticleAssociation:
     Description: "Association between a CalorimeterHit and the corresponding MCParticle"
     Author: "EDM4hep authors"

--- a/tools/include/edm4hep2json.hxx
+++ b/tools/include/edm4hep2json.hxx
@@ -28,7 +28,6 @@
 #include "edm4hep/MCRecoParticleAssociationCollection.h"
 #include "edm4hep/MCRecoTrackParticleAssociationCollection.h"
 #include "edm4hep/MCRecoTrackerAssociationCollection.h"
-#include "edm4hep/MCRecoTrackerHitPlaneAssociationCollection.h"
 #include "edm4hep/RecoParticleVertexAssociationCollection.h"
 
 #include "edm4hep/EDM4hepVersion.h"
@@ -115,8 +114,6 @@ nlohmann::json processEvent(const podio::Frame& frame, std::vector<std::string>&
       insertIntoJson<edm4hep::MCRecoCaloAssociationCollection>(jsonDict, coll, collList[i]);
     } else if (coll->getTypeName() == "edm4hep::MCRecoTrackerAssociationCollection") {
       insertIntoJson<edm4hep::MCRecoTrackerAssociationCollection>(jsonDict, coll, collList[i]);
-    } else if (coll->getTypeName() == "edm4hep::MCRecoTrackerHitPlaneAssociationCollection") {
-      insertIntoJson<edm4hep::MCRecoTrackerHitPlaneAssociationCollection>(jsonDict, coll, collList[i]);
     } else if (coll->getTypeName() == "edm4hep::MCRecoCaloParticleAssociationCollection") {
       insertIntoJson<edm4hep::MCRecoCaloParticleAssociationCollection>(jsonDict, coll, collList[i]);
     } else if (coll->getTypeName() == "edm4hep::MCRecoClusterParticleAssociationCollection") {


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove the `MCRecoTrackerHitPlaneAssociation` as it is no longer necessary

ENDRELEASENOTES

Fixes #301 

- [x] Check downstream breakages and implement fixes
- Downstream PRs that have to go in simultaneously
  - https://github.com/key4hep/k4FWCore/pull/204
  - https://github.com/key4hep/k4EDM4hep2LcioConv/pull/73
  - https://github.com/key4hep/k4Reco/pull/3