### PR TITLE
Remove some of the drift chamber study types again

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,43 +14,41 @@ A generic event data model for future HEP collider experiments.
 |-|-|-|
 | [Vector4f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L9)      | [Vector3f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L34)     | [Vector3d](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L56)      |
 | [Vector2i](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L84)     | [Vector2f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L104)    | [TrackState](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L195)   |
-| [Quantity](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L224)    | [Hypothesis](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L232)  | [HitLevelData](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L239) |
-| [CovMatrix2f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L123)  |[CovMatrix3f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L141)   |[CovMatrix4f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L158)   |
-| [CovMatrix6f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L176) | | |
+| [Quantity](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L224)    |  [CovMatrix2f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L123) | [CovMatrix3f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L141)   |
+| [CovMatrix4f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L158)   | [CovMatrix6f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L176) | |
 
 
 **Datatypes**
 
 | | | |
 |-|-|-|
-| [EventHeader](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L249)         | [MCParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L261)        | [SimTrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L329)         |
-| [CaloHitContribution](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L371) | [SimCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L383) | [RawCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L395)     |
-| [CalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L404)      | [ParticleID](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L416)        | [Cluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L431)               |
-| [TrackerHit3D](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L463)          | [TrackerHitPlane](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L489)   | [RawTimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L519)                |
-| [Track](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L532)               | [Vertex](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L551)            | [ReconstructedParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L579) |
-| [SimPrimaryIonizationCluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L691) | [TrackerPulse](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L725) | [RecIonizationCluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L750) |
-| [TimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L761) | [RecDqdx](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L773) |                                                                                          |
+| [EventHeader](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L233)         | [MCParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L245)        | [SimTrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L313)         |
+| [CaloHitContribution](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L355) | [SimCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L367) | [RawCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L379)     |
+| [CalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L388)      | [ParticleID](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L400)        | [Cluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L415)               |
+| [TrackerHit3D](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L447)          | [TrackerHitPlane](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L473)   | [RawTimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L503)                |
+| [Track](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L517)               | [Vertex](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L536)            | [ReconstructedParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L564) |
+| [TimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L675) | [RecDqdx](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L687) |                                                                                          |
 
 **Associations**
 
 | | | |
 |-|-|-|
-| [MCRecoParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L617)        | [MCRecoCaloAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L626)         | [MCRecoTrackerAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L635)         |
-| [MCRecoTrackerHitPlaneAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L644) | [MCRecoCaloParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L653) | [MCRecoClusterParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L662) |
-| [MCRecoTrackParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L671)   | [RecoParticleVertexAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L680) |                                                                                                      |
+| [MCRecoParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L602)        | [MCRecoCaloAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L611)         | [MCRecoTrackerAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L620)         |
+| [MCRecoTrackerHitPlaneAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L629) | [MCRecoCaloParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L638) | [MCRecoClusterParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L647) |
+| [MCRecoTrackParticleAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L656)   | [RecoParticleVertexAssociation](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L665) |                                                                                                      |
 
 **Generator related (meta-)data**
 
 | | | |
 |-|-|-|
-| [GeneratorEventParameters](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L790) | | |
-| [GeneratorPdfInfo](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L807) | | |
+| [GeneratorEventParameters](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L699) | | |
+| [GeneratorPdfInfo](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L716) | | |
 
 **Interfaces**
 
 | | | |
 |-|-|-|
-| [TrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L818) | | |
+| [TrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L727) | | |
 
 The tests and examples in the `tests` directory show how to read, write, and use these types in your code.
 

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -227,22 +227,6 @@ components:
         - float value  // value of the quantity
         - float error  // error on the value of the quantity
 
-
-    # Hypothesis for 5 particle types
-    edm4hep::Hypothesis:
-      Members:
-        - float chi2       // chi2
-        - float expected   // expected value
-        - float sigma      // sigma value
-
-    # Reconstructed hit information
-    edm4hep::HitLevelData:
-      Members:
-        - uint64_t cellID  // cell id
-        - uint32_t N       // number of reconstructed ionization cluster
-        - float eDep [GeV]      // reconstructed energy deposit
-        - float pathLength [mm] // track path length
-
 datatypes:
 
 
@@ -528,6 +512,7 @@ datatypes:
     VectorMembers:
        - int32_t adcCounts          // raw data (32-bit) word at i
 
+
  #-------- Track
   edm4hep::Track:
     Description: "Reconstructed track"
@@ -686,77 +671,6 @@ datatypes:
      - edm4hep::ReconstructedParticle rec // reference to the reconstructed particle
      - edm4hep::Vertex vertex             // reference to the vertex
 
-
-  #----------- SimPrimaryIonizationCluster
-  edm4hep::SimPrimaryIonizationCluster:
-    Description: "Simulated Primary Ionization"
-    Author: "EDM4hep authors"
-    Members:
-      - uint64_t cellID                      // cell id
-      - float time [ns]                      // the primary ionization's time in the lab frame
-      - edm4hep::Vector3d position [mm]      // the primary ionization's position
-      - int16_t type                         // type
-    VectorMembers:
-       - uint64_t electronCellID             // cell id
-       - float electronTime [ns]             // the time in the lab frame
-       - edm4hep::Vector3d electronPosition [mm]  // the position in the lab frame
-       - float pulseTime [ns]                // the pulse's time in the lab frame
-       - float pulseAmplitude [fC]           // the pulse's amplitude
-    OneToOneRelations:
-      - edm4hep::MCParticle particle       // the particle that caused the ionizing collisions
-    MutableExtraCode:
-      includes: "
-      #include <cmath>\n
-      #include <edm4hep/MCParticle.h>\n
-      "
-      declaration: "
-      [[deprecated(\"use setParticle instead\")]]\n
-      void setMCParticle(edm4hep::MCParticle particle) { setParticle(std::move(particle)); }\n
-      "
-
-    ExtraCode:
-      includes: "#include <edm4hep/MCParticle.h>\n"
-      declaration: "
-      [[deprecated(\"use getParticle instead\")]]
-      edm4hep::MCParticle getMCParticle() const { return getParticle(); }\n
-      "
-
- #----------  TrackerPulse
-  edm4hep::TrackerPulse:
-    Description: "Reconstructed Tracker Pulse"
-    Author: "EDM4hep authors"
-    Members:
-       - uint64_t cellID                 // cell id
-       - float time [ns]                 // time
-       - float charge [fC]               // charge
-       - int16_t quality                 // quality
-       - edm4hep::CovMatrix2f covMatrix  // covariance matrix of the charge and time measurements
-    OneToOneRelations:
-      - edm4hep::TimeSeries timeSeries   // Optionally, the timeSeries that has been used to create the pulse can be stored with the pulse
-    ExtraCode:
-      includes: "#include <edm4hep/Constants.h>"
-      declaration: "
-      /// Get the position covariance matrix value for the two passed dimensions\n
-      float getCovMatrix(edm4hep::TrackerPulseDims dimI, edm4hep::TrackerPulseDims dimJ) const { return getCovMatrix().getValue(dimI, dimJ); }\n
-      "
-    MutableExtraCode:
-      includes: "#include <edm4hep/Constants.h>"
-      declaration: "
-      /// Set the position covariance matrix value for the two passed dimensions\n
-      void setCovMatrix(float value, edm4hep::TrackerPulseDims dimI, edm4hep::TrackerPulseDims dimJ) { getCovMatrix().setValue(value, dimI, dimJ); }\n
-      "
-
- #----------  RecIonizationCluster
-  edm4hep::RecIonizationCluster:
-    Description: "Reconstructed Ionization Cluster"
-    Author: "EDM4hep authors"
-    Members:
-       - uint64_t cellID            // cell id
-       - float significance         // significance
-       - int16_t type               // type
-    OneToManyRelations:
-       - edm4hep::TrackerPulse trackerPulse // the TrackerPulse used to create the ionization cluster
-
  #----------  TimeSeries
   edm4hep::TimeSeries:
     Description: "Calibrated Detector Data"
@@ -775,11 +689,6 @@ datatypes:
     Author: "EDM4hep authors"
     Members:
       - edm4hep::Quantity dQdx         // the reconstructed dEdx or dNdx and its error
-      - int16_t particleType           // particle type, e(0),mu(1),pi(2),K(3),p(4)
-      - int16_t type                   // type
-      - std::array<edm4hep::Hypothesis, 5> hypotheses // 5 particle hypothesis
-    VectorMembers:
-      - edm4hep::HitLevelData hitData   // hit level data
     OneToOneRelations:
       - edm4hep::Track track           // the corresponding track
 

--- a/test/tools/test_all_collections.py
+++ b/test/tools/test_all_collections.py
@@ -21,8 +21,7 @@ def test(yamlfile_path, cxxfile_path):
     datatypes_found = []
 
     with open(cxxfile_path, mode='r', encoding="utf-8") as cxxfile:
-        for cxxline in cxxfile:
-            cxxline = cxxfile.readline()
+        for cxxline in cxxfile.readlines():
             result = re.search('insertIntoJson<edm4hep::(.+?)Collection>',
                                cxxline)
             if result:

--- a/tools/include/edm4hep2json.hxx
+++ b/tools/include/edm4hep2json.hxx
@@ -13,16 +13,13 @@
 #include "edm4hep/RawCalorimeterHitCollection.h"
 #include "edm4hep/RawTimeSeriesCollection.h"
 #include "edm4hep/RecDqdxCollection.h"
-#include "edm4hep/RecIonizationClusterCollection.h"
 #include "edm4hep/ReconstructedParticleCollection.h"
 #include "edm4hep/SimCalorimeterHitCollection.h"
-#include "edm4hep/SimPrimaryIonizationClusterCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
 #include "edm4hep/TimeSeriesCollection.h"
 #include "edm4hep/TrackCollection.h"
 #include "edm4hep/TrackerHit3DCollection.h"
 #include "edm4hep/TrackerHitPlaneCollection.h"
-#include "edm4hep/TrackerPulseCollection.h"
 #include "edm4hep/VertexCollection.h"
 
 #include "edm4hep/MCRecoCaloAssociationCollection.h"
@@ -106,12 +103,6 @@ nlohmann::json processEvent(const podio::Frame& frame, std::vector<std::string>&
       insertIntoJson<edm4hep::VertexCollection>(jsonDict, coll, collList[i]);
     } else if (coll->getTypeName() == "edm4hep::ReconstructedParticleCollection") {
       insertIntoJson<edm4hep::ReconstructedParticleCollection>(jsonDict, coll, collList[i]);
-    } else if (coll->getTypeName() == "edm4hep::SimPrimaryIonizationClusterCollection") {
-      insertIntoJson<edm4hep::SimPrimaryIonizationClusterCollection>(jsonDict, coll, collList[i]);
-    } else if (coll->getTypeName() == "edm4hep::TrackerPulseCollection") {
-      insertIntoJson<edm4hep::TrackerPulseCollection>(jsonDict, coll, collList[i]);
-    } else if (coll->getTypeName() == "edm4hep::RecIonizationClusterCollection") {
-      insertIntoJson<edm4hep::RecIonizationClusterCollection>(jsonDict, coll, collList[i]);
     } else if (coll->getTypeName() == "edm4hep::TimeSeriesCollection") {
       insertIntoJson<edm4hep::TimeSeriesCollection>(jsonDict, coll, collList[i]);
     } else if (coll->getTypeName() == "edm4hep::RecDqdxCollection") {


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove some of the drift chamber study types that were introduced in [#179](https://github.com/key4hep/EDM4hep/pull/179) again since they need a bit more consideration
  - The removed types and components are: `Hypothesis`, `HitLevelData`, `RecIonizationCluster`, `SimPrimaryIonizationCluster`, `TrackerPulse`
  - Keep the types and components that are already in use, mainly `TimeSeries`
- Remove the usage of the removed components from `RecDqdx` to make it a purely reconstruction level type
- Fix script that checks that all types are part of the json dumper

ENDRELEASENOTES

See #322, #323 for discussion on how we arrived at this point.

The changes for `RecDqdx` are also present in #311, leading to a likely merge conflict depending on which PR is merged first

We keep the `TimeSeries` as it is used already, e.g. in dual-readout:
- https://github.com/HEP-FCC/dual-readout/blob/51f9766bb3f9e80644bb032b98f1f5b1d4cb0327/DRdigi/include/DigiSiPM.h#L31

- [x] Downstream checks & fixes
  - https://github.com/key4hep/k4FWCore/pull/205