### PR TITLE
Remove compatibility with podio versions before v1.0

### DIFF
--- a/test/hepmc/edm4hep_testhepmc.cc
+++ b/test/hepmc/edm4hep_testhepmc.cc
@@ -17,11 +17,7 @@
 #include "HepPDT/ParticleID.hh"
 
 #include "podio/Frame.h"
-#if PODIO_VERSION_MAJOR > 0 || (PODIO_VERSION_MAJOR == 0 && PODIO_VERSION_MINOR >= 99)
 #include "podio/ROOTWriter.h"
-#else
-#include "podio/ROOTFrameWriter.h"
-#endif
 
 #include "edm4hep/MCParticleCollection.h"
 
@@ -158,11 +154,7 @@ int main() {
   auto event = podio::Frame();
   event.put(std::move(edm_particle_collection), "TestParticles2");
 
-#if PODIO_VERSION_MAJOR > 0 || (PODIO_VERSION_MAJOR == 0 && PODIO_VERSION_MINOR >= 99)
   auto writer = podio::ROOTWriter("edm4hep_testhepmc.root");
-#else
-  auto writer = podio::ROOTFrameWriter("edm4hep_testhepmc.root");
-#endif
   writer.writeFrame(event, "events");
 
   // after all events

--- a/test/read_events.cc
+++ b/test/read_events.cc
@@ -1,13 +1,5 @@
 #include "read_events.h"
-#include "podio/podioVersion.h"
-#if PODIO_BUILD_VERSION >= PODIO_VERSION(0, 99, 0)
 #include "podio/ROOTReader.h"
-#else
-#include "podio/ROOTFrameReader.h"
-namespace podio {
-using ROOTReader = podio::ROOTFrameReader;
-}
-#endif
 
 int main() {
   read_events<podio::ROOTReader>("edm4hep_events.root");

--- a/test/read_events.h
+++ b/test/read_events.h
@@ -14,7 +14,6 @@
 
 // podio specific includes
 #include "podio/Frame.h"
-#include "podio/podioVersion.h"
 
 // STL
 #include <iostream>
@@ -273,11 +272,7 @@ void processEvent(const podio::Frame& event) {
   //    throw std::runtime_error("Collection 'SimCalorimeterHitContributions' should be present");
   //  }
 
-#if PODIO_BUILD_VERSION > PODIO_VERSION(0, 99, 0)
   const auto evtType = event.getParameter<std::string>("EventType").value();
-#else
-  const auto& evtType = event.getParameter<std::string>("EventType");
-#endif
   std::cout << "Event Type: " << evtType << std::endl;
 }
 

--- a/test/read_events_sio.cc
+++ b/test/read_events_sio.cc
@@ -1,14 +1,6 @@
 #include "read_events.h"
 
-#include "podio/podioVersion.h"
-#if PODIO_BUILD_VERSION >= PODIO_VERSION(0, 99, 0)
 #include "podio/SIOReader.h"
-#else
-#include "podio/SIOFrameReader.h"
-namespace podio {
-using SIOReader = podio::SIOFrameReader;
-}
-#endif
 
 int main(int, char**) {
   read_events<podio::SIOReader>("edm4hep_events.sio");

--- a/test/write_events.cc
+++ b/test/write_events.cc
@@ -1,13 +1,5 @@
 #include "write_events.h"
-#include "podio/podioVersion.h"
-#if PODIO_BUILD_VERSION >= PODIO_VERSION(0, 99, 0)
 #include "podio/ROOTWriter.h"
-#else
-#include "podio/ROOTFrameWriter.h"
-namespace podio {
-using ROOTWriter = podio::ROOTFrameWriter;
-}
-#endif
 
 int main(int, char*[]) {
 

--- a/test/write_events_sio.cc
+++ b/test/write_events_sio.cc
@@ -1,14 +1,6 @@
 #include "write_events.h"
 
-#include "podio/podioVersion.h"
-#if PODIO_BUILD_VERSION >= PODIO_VERSION(0, 99, 0)
 #include "podio/SIOWriter.h"
-#else
-#include "podio/SIOFrameWriter.h"
-namespace podio {
-using SIOWriter = podio::SIOFrameWriter;
-}
-#endif
 
 int main(int, char**) {
   write<podio::SIOWriter>("edm4hep_events.sio");

--- a/tools/src/edm4hep2json.cxx
+++ b/tools/src/edm4hep2json.cxx
@@ -5,16 +5,8 @@
 #include "TFile.h"
 
 // podio
-#include "podio/podioVersion.h"
-#if PODIO_BUILD_VERSION >= PODIO_VERSION(0, 99, 0)
-#include "podio/ROOTReader.h"
-#else
-#include "podio/ROOTFrameReader.h"
-namespace podio {
-using ROOTReader = podio::ROOTFrameReader;
-}
-#endif
 #include "podio/ROOTLegacyReader.h"
+#include "podio/ROOTReader.h"
 
 // std
 #include <filesystem>

--- a/utils/src/ParticleIDUtils.cc
+++ b/utils/src/ParticleIDUtils.cc
@@ -5,7 +5,6 @@
 #include "edm4hep/Constants.h"
 
 #include <podio/FrameCategories.h>
-#include <podio/podioVersion.h>
 
 #include <iterator>
 #include <stdexcept>
@@ -141,7 +140,6 @@ void PIDHandler::setAlgoInfo(podio::Frame& metadata, const std::string& collName
 std::optional<edm4hep::utils::ParticleIDMeta> PIDHandler::getAlgoInfo(const podio::Frame& metadata,
                                                                       const std::string& collName) {
 
-#if PODIO_BUILD_VERSION > PODIO_VERSION(0, 99, 0)
   auto maybeAlgoName =
       metadata.getParameter<std::string>(podio::collMetadataParamName(collName, edm4hep::labels::PIDAlgoName));
   if (!maybeAlgoName.has_value()) {
@@ -155,22 +153,6 @@ std::optional<edm4hep::utils::ParticleIDMeta> PIDHandler::getAlgoInfo(const podi
           .getParameter<std::vector<std::string>>(
               podio::collMetadataParamName(collName, edm4hep::labels::PIDParameterNames))
           .value()};
-
-#else
-
-  const auto& algoName =
-      metadata.getParameter<std::string>(podio::collMetadataParamName(collName, edm4hep::labels::PIDAlgoName));
-  // Use the algoName as proxy to see whether we could actually get the
-  // information from the metadata
-  if (algoName.empty()) {
-    return std::nullopt;
-  }
-
-  ParticleIDMeta pidInfo{
-      algoName, metadata.getParameter<int>(podio::collMetadataParamName(collName, edm4hep::labels::PIDAlgoType)),
-      metadata.getParameter<std::vector<std::string>>(
-          podio::collMetadataParamName(collName, edm4hep::labels::PIDParameterNames))};
-#endif
 
   return pidInfo;
 }


### PR DESCRIPTION

BEGINRELEASENOTES
- Remove compatibility with podio versions before 1.0

ENDRELEASENOTES

Since we already bumped this in our CMake config (https://github.com/key4hep/EDM4hep/pull/327), we can also remove this from our code.

Fixes #306 