### PR TITLE
Remove superfluous association now that it has been removed

### DIFF
--- a/doc/edm4hep_diagram.svg
+++ b/doc/edm4hep_diagram.svg
@@ -24,12 +24,12 @@
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
-     inkscape:window-height="1016"
+     inkscape:window-height="1043"
      id="namedview332"
      showgrid="true"
      inkscape:zoom="0.86342179"
-     inkscape:cx="776.56136"
-     inkscape:cy="422.15752"
+     inkscape:cx="565.77215"
+     inkscape:cy="265.22379"
      inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
@@ -2187,12 +2187,6 @@
      style="fill:none;stroke:#000000;stroke-width:0.217009px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-9-9-9-5-7-8-0-4)"
      d="m 154.91496,107.45876 -17.19791,10.41842"
      id="path6614-2-5-0-1-0-4-8-0"
-     sodipodi:nodetypes="cc" />
-  <path
-     inkscape:connector-curvature="0"
-     style="opacity:0.59600004;fill:none;stroke:#00007e;stroke-width:0.43799999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-5);marker-end:url(#marker22158-5)"
-     d="m 76.260627,116.15611 75.645753,1.64218"
-     id="path7862-8-3-8"
      sodipodi:nodetypes="cc" />
   <path
      inkscape:connector-curvature="0"


### PR DESCRIPTION

BEGINRELEASENOTES
- Remove the association between `TrackerHitPlane` and `SimTrackerHit` from the diagram

ENDRELEASENOTES

Type has been removed in #331 