### PR TITLE
Drop support for the ROOTLegacyReader when converting to JSON

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -12,7 +12,7 @@ if (nlohmann_json_FOUND)
   target_link_libraries(edm4hep2json PUBLIC ROOT::Core
                                             ROOT::Tree
                                             podio::podio
-                                            podio::podioRootIO
+                                            podio::podioIO
                                             edm4hep
                                             nlohmann_json::nlohmann_json)
 

--- a/tools/include/edm4hep2json.hxx
+++ b/tools/include/edm4hep2json.hxx
@@ -191,7 +191,7 @@ int read_frames(const std::string& filename, const std::string& jsonFile, const 
 
   auto collList = splitString(requestedCollections);
   if (collList.empty()) {
-    auto frame = podio::Frame(reader.readFrame(frameName, 0));
+    auto frame = reader.readFrame(frameName, 0);
     collList = frame.getAvailableCollections();
   }
   if (collList.empty()) {
@@ -267,13 +267,13 @@ int read_frames(const std::string& filename, const std::string& jsonFile, const 
         std::cout << "INFO: Reading event " << i << std::endl;
       }
 
-      auto frame = podio::Frame(reader.readFrame(frameName, i));
+      auto frame = reader.readFrame(frameName, i);
       auto eventDict = processEvent(frame, collList, reader.currentFileVersion());
       allEventsDict["Event " + std::to_string(i)] = eventDict;
     }
   } else {
     for (auto& i : eventVec) {
-      auto frame = podio::Frame(reader.readFrame(frameName, i));
+      auto frame = reader.readFrame(frameName, i);
       auto eventDict = processEvent(frame, collList, reader.currentFileVersion());
       allEventsDict["Event " + std::to_string(i)] = eventDict;
     }

--- a/tools/include/edm4hep2json.hxx
+++ b/tools/include/edm4hep2json.hxx
@@ -34,6 +34,7 @@
 
 // podio specific includes
 #include "podio/Frame.h"
+#include "podio/Reader.h"
 #include "podio/UserDataCollection.h"
 #include "podio/podioVersion.h"
 
@@ -170,13 +171,10 @@ std::vector<std::string> splitString(const std::string& inString) {
 
   return outString;
 }
-
-template <typename ReaderT>
 int read_frames(const std::string& filename, const std::string& jsonFile, const std::string& requestedCollections,
                 const std::string& requestedEvents, const std::string& frameName, int nEventsMax = -1,
                 bool verboser = false) {
-  ReaderT reader;
-  reader.openFile(filename);
+  podio::Reader reader = podio::makeReader(filename);
 
   nlohmann::json allEventsDict;
 
@@ -193,7 +191,7 @@ int read_frames(const std::string& filename, const std::string& jsonFile, const 
 
   auto collList = splitString(requestedCollections);
   if (collList.empty()) {
-    auto frame = podio::Frame(reader.readEntry(frameName, 0));
+    auto frame = podio::Frame(reader.readFrame(frameName, 0));
     collList = frame.getAvailableCollections();
   }
   if (collList.empty()) {
@@ -269,13 +267,13 @@ int read_frames(const std::string& filename, const std::string& jsonFile, const 
         std::cout << "INFO: Reading event " << i << std::endl;
       }
 
-      auto frame = podio::Frame(reader.readEntry(frameName, i));
+      auto frame = podio::Frame(reader.readFrame(frameName, i));
       auto eventDict = processEvent(frame, collList, reader.currentFileVersion());
       allEventsDict["Event " + std::to_string(i)] = eventDict;
     }
   } else {
     for (auto& i : eventVec) {
-      auto frame = podio::Frame(reader.readEntry(frameName, i));
+      auto frame = podio::Frame(reader.readFrame(frameName, i));
       auto eventDict = processEvent(frame, collList, reader.currentFileVersion());
       allEventsDict["Event " + std::to_string(i)] = eventDict;
     }

--- a/tools/src/edm4hep2json.cxx
+++ b/tools/src/edm4hep2json.cxx
@@ -9,6 +9,8 @@
 // *nix
 #include <getopt.h>
 
+#include "TFile.h"
+
 void printHelp() {
   std::cout << "Usage: edm4hep2json [olenfvh] FILEPATH\n"
             << "  -o/--out-file           output file path\n"
@@ -115,7 +117,14 @@ int main(int argc, char** argv) {
     outFilePath = std::filesystem::path(outFileStr + ".edm4hep.json");
   }
 
-  return read_frames(inFilePath, outFilePath, requestedCollections, requestedEvents, frameName, nEventsMax, verboser);
+  {
+    std::unique_ptr<TFile> inFile(TFile::Open(inFilePath.c_str(), "READ"));
+    if (!inFile->GetListOfKeys()->FindObject("podio_metadata")) {
+      std::cout << "ERROR: Reading file produced with an incompatible version of EDM4hep. Aborting..." << std::endl;
+      return 1;
+    }
+    inFile->Close();
+  }
 
-  return EXIT_SUCCESS;
+  return read_frames(inFilePath, outFilePath, requestedCollections, requestedEvents, frameName, nEventsMax, verboser);
 }

--- a/tools/src/edm4hep2json.cxx
+++ b/tools/src/edm4hep2json.cxx
@@ -1,12 +1,7 @@
+#include "podio/FrameCategories.h"
+
 // EDM4hep
 #include "edm4hep2json.hxx"
-
-// ROOT
-#include "TFile.h"
-
-// podio
-#include "podio/ROOTLegacyReader.h"
-#include "podio/ROOTReader.h"
 
 // std
 #include <filesystem>
@@ -35,7 +30,7 @@ int main(int argc, char** argv) {
   std::filesystem::path outFilePath;
   std::string requestedCollections;
   std::string requestedEvents;
-  std::string frameName = "events";
+  std::string frameName = podio::Category::Event;
   bool verboser = false;
   int nEventsMax = -1;
 
@@ -120,20 +115,7 @@ int main(int argc, char** argv) {
     outFilePath = std::filesystem::path(outFileStr + ".edm4hep.json");
   }
 
-  bool legacyReader = false;
-  {
-    std::unique_ptr<TFile> inFile(TFile::Open(inFilePath.c_str(), "READ"));
-    legacyReader = !inFile->GetListOfKeys()->FindObject("podio_metadata");
-  }
-
-  if (legacyReader) {
-    std::cout << "WARNING: Reading legacy file, some collections might not be recognized!" << std::endl;
-    return read_frames<podio::ROOTLegacyReader>(inFilePath, outFilePath, requestedCollections, requestedEvents,
-                                                frameName, nEventsMax, verboser);
-  } else {
-    return read_frames<podio::ROOTReader>(inFilePath, outFilePath, requestedCollections, requestedEvents, frameName,
-                                          nEventsMax, verboser);
-  }
+  return read_frames(inFilePath, outFilePath, requestedCollections, requestedEvents, frameName, nEventsMax, verboser);
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
since legacy files were done with incompatible versions of EDM4hep.

BEGINRELEASENOTES
- Drop support for the ROOTLegacyReader when converting to JSON

ENDRELEASENOTES