### PR TITLE
Bump the schema version to 2

### DIFF
--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 2
 options:
   getSyntax: True
   exposePODMembers: False


### PR DESCRIPTION
BEGINRELEASENOTES
- Bump the schema version of EDM4hep to 2 to have a way to differentiate between *before pre-release* and afterwards

ENDRELEASENOTES