### PR TITLE
Update LCG workflow to use LCG_106 instead of LCG_104

### DIFF
--- a/.github/workflows/lcg_linux_with_podio.yml
+++ b/.github/workflows/lcg_linux_with_podio.yml
@@ -13,7 +13,7 @@ jobs:
               "dev4/x86_64-el9-gcc13-opt"]
         CXX_STANDARD: [20]
         include:
-          - LCG: "LCG_104/x86_64-centos8-gcc11-opt"
+          - LCG: "LCG_106/x86_64-el9-gcc13-opt"
             CXX_STANDARD: 17
           - LCG: "dev4/x86_64-ubuntu2004-gcc9-opt"
             CXX_STANDARD: 17


### PR DESCRIPTION
BEGINRELEASENOTES
- Update LCG workflow to use LCG_106 instead of LCG_104

ENDRELEASENOTES