### PR TITLE
Check for the size of the input for one of the constructors of the covariance matrices

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,42 +13,42 @@ A generic event data model for future HEP collider experiments.
 | | | |
 |-|-|-|
 | [Vector4f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L9)      | [Vector3f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L34)     | [Vector3d](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L56)      |
-| [Vector2i](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L84)     | [Vector2f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L104)    | [TrackState](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L195)   |
-| [Quantity](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L224)    |  [CovMatrix2f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L123) | [CovMatrix3f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L141)   |
-| [CovMatrix4f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L158)   | [CovMatrix6f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L176) | |
+| [Vector2i](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L84)     | [Vector2f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L104)    | [TrackState](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L203)   |
+| [Quantity](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L232)    |  [CovMatrix2f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L123) | [CovMatrix3f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L143)   |
+| [CovMatrix4f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L162)   | [CovMatrix6f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L182) | |
 
 
 **Datatypes**
 
 | | | |
 |-|-|-|
-| [EventHeader](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L233)         | [MCParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L245)        | [SimTrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L313)         |
-| [CaloHitContribution](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L355) | [SimCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L367) | [RawCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L379)     |
-| [CalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L388)      | [ParticleID](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L400)        | [Cluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L415)               |
-| [TrackerHit3D](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L447)          | [TrackerHitPlane](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L473)   | [RawTimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L503)                |
-| [Track](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L517)               | [Vertex](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L534)            | [ReconstructedParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L580) |
-| [TimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L809) | [RecDqdx](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L821) |                                                                                          |
+| [EventHeader](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L241)         | [MCParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L253)        | [SimTrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L321)         |
+| [CaloHitContribution](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L363) | [SimCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L375) | [RawCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L387)     |
+| [CalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L396)      | [ParticleID](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L408)        | [Cluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L423)               |
+| [TrackerHit3D](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L455)          | [TrackerHitPlane](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L481)   | [RawTimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L511)                |
+| [Track](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L525)               | [Vertex](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L542)            | [ReconstructedParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L588) |
+| [TimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L817) | [RecDqdx](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L829) |                                                                                          |
 
 **Links**
 
 | | | |
 |-|-|-|
-| [RecoMCParticleLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L618)        | [CaloHitSimCaloHitLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L645)         | [TrackerHitSimTrackerHitLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L673)         |
-| [CaloHitMCParticleLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L700) | [ClusterMCParticleLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L727) | [TrackMCParticleLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L754)   |
-| [VertexRecoParticleLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L781) | | |
+| [RecoMCParticleLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L626)        | [CaloHitSimCaloHitLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L653)         | [TrackerHitSimTrackerHitLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L681)         |
+| [CaloHitMCParticleLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L708) | [ClusterMCParticleLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L735) | [TrackMCParticleLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L762)   |
+| [VertexRecoParticleLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L789) | | |
 
 **Generator related (meta-)data**
 
 | | | |
 |-|-|-|
-| [GeneratorEventParameters](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L833) | | |
-| [GeneratorPdfInfo](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L850) | | |
+| [GeneratorEventParameters](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L841) | | |
+| [GeneratorPdfInfo](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L858) | | |
 
 **Interfaces**
 
 | | | |
 |-|-|-|
-| [TrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L861) | | |
+| [TrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L869) | | |
 
 The tests and examples in the `tests` directory show how to read, write, and use these types in your code.
 

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -129,7 +129,9 @@ components:
         declaration: "
           constexpr CovMatrix2f() = default;\n
           template<typename... Vs>\n
-          constexpr CovMatrix2f(Vs... v) : values{v...} {}\n
+          constexpr CovMatrix2f(Vs... v) : values{static_cast<float>(v)...} {
+            static_assert(sizeof...(v) == 3, \"CovMatrix2f requires 3 values\");
+          }\n
           constexpr CovMatrix2f(const std::array<float, 3>& v) : values(v) {}\n
           constexpr CovMatrix2f& operator=(std::array<float, 3>& v) { values = v; return *this; }\n
           bool operator==(const CovMatrix2f& v) const { return v.values == values; }\n
@@ -148,7 +150,9 @@ components:
           constexpr CovMatrix3f() = default;\n
           constexpr CovMatrix3f(const std::array<float, 6>& v) : values(v) {}\n
           template<typename... Vs>\n
-          constexpr CovMatrix3f(Vs... v) : values{v...} {}\n
+          constexpr CovMatrix3f(Vs... v) : values{static_cast<float>(v)...} {
+            static_assert(sizeof...(v) == 6, \"CovMatrix3f requires 6 values\");
+          }\n
           constexpr CovMatrix3f& operator=(std::array<float, 6>& v) { values = v; return *this; }\n
           bool operator==(const CovMatrix3f& v) const { return v.values == values; }\n
           bool operator!=(const CovMatrix3f& v) const { return v.values != values; }\n
@@ -164,7 +168,9 @@ components:
         declaration: "
           constexpr CovMatrix4f() = default;\n
           template<typename... Vs>\n
-          constexpr CovMatrix4f(Vs... v) : values{v...} {}\n
+          constexpr CovMatrix4f(Vs... v) : values{static_cast<float>(v)...} {
+            static_assert(sizeof...(v) == 10, \"CovMatrix4f requires 10 values\");
+          }\n
           constexpr CovMatrix4f(const std::array<float, 10>& v) : values(v) {}\n
           constexpr CovMatrix4f& operator=(std::array<float, 10>& v) { values = v; return *this; }\n
           bool operator==(const CovMatrix4f& v) const { return v.values == values; }\n
@@ -182,7 +188,9 @@ components:
         declaration: "
           constexpr CovMatrix6f() = default;\n
           template<typename... Vs>\n
-          constexpr CovMatrix6f(Vs... v) : values{v...} {}\n
+          constexpr CovMatrix6f(Vs... v) : values{static_cast<float>(v)...} {
+            static_assert(sizeof...(v) == 21, \"CovMatrix6f requires 21 values\");
+          }\n
           constexpr CovMatrix6f(const std::array<float, 21>& v) : values(v) {}\n
           constexpr CovMatrix6f& operator=(std::array<float, 21>& v) { values = v; return *this; }\n
           bool operator==(const CovMatrix6f& v) const { return v.values == values; }\n


### PR DESCRIPTION
currently it's possible to set only the first N elements of the matrix. I think typically this will be mostly a mistake rather than intentionally filling only the first N.

Also static_cast to float, because with older GCC and Clang this is fine, newer GCC throws a warning and newer Clang a compilation error if it's a double. It's already in the name that it's a float in case it's coming from a double (and narrowing happens).

BEGINRELEASENOTES
- Covariance matrices: Check for the size of the input for one of the constructors
  - `static_cast` the inputs to `float`

ENDRELEASENOTES