### PR TITLE
Make sure association legacy headers are truly transparent

### DIFF
--- a/include/edm4hep/MCRecoCaloAssociationCollection.h
+++ b/include/edm4hep/MCRecoCaloAssociationCollection.h
@@ -2,6 +2,8 @@
 #define EDM4HEP_MCRecoCaloAssociationCollection_H
 
 #include "edm4hep/CaloHitSimCaloHitLinkCollection.h"
+#include "edm4hep/MCRecoCaloAssociation.h"
+#include "edm4hep/MutableMCRecoCaloAssociation.h"
 
 namespace edm4hep {
 using MCRecoCaloAssociationCollection [[deprecated("use CaloHitSimCaloHitLinkCollection instead")]] =

--- a/include/edm4hep/MCRecoCaloParticleAssociationCollection.h
+++ b/include/edm4hep/MCRecoCaloParticleAssociationCollection.h
@@ -2,6 +2,8 @@
 #define EDM4HEP_MCRecoCaloParticleAssociationCollection_H
 
 #include "edm4hep/CaloHitMCParticleLinkCollection.h"
+#include "edm4hep/MCRecoCaloParticleAssociation.h"
+#include "edm4hep/MutableMCRecoCaloParticleAssociation.h"
 
 namespace edm4hep {
 using MCRecoCaloParticleAssociationCollection [[deprecated("use CaloHitMCParticleLinkCollection instead")]] =

--- a/include/edm4hep/MCRecoClusterParticleAssociationCollection.h
+++ b/include/edm4hep/MCRecoClusterParticleAssociationCollection.h
@@ -2,6 +2,8 @@
 #define EDM4HEP_MCRecoClusterParticleAssociationCollection_H
 
 #include "edm4hep/ClusterMCParticleLinkCollection.h"
+#include "edm4hep/MCRecoClusterParticleAssociation.h"
+#include "edm4hep/MutableMCRecoClusterParticleAssociation.h"
 
 namespace edm4hep {
 using MCRecoClusterParticleAssociationCollection [[deprecated("use ClusterMCParticleLinkCollection instead")]] =

--- a/include/edm4hep/MCRecoParticleAssociationCollection.h
+++ b/include/edm4hep/MCRecoParticleAssociationCollection.h
@@ -1,6 +1,8 @@
 #ifndef EDM4HEP_MCRecoParticleAssociationCollection_H
 #define EDM4HEP_MCRecoParticleAssociationCollection_H
 
+#include "edm4hep/MCRecoParticleAssociation.h"
+#include "edm4hep/MutableMCRecoParticleAssociation.h"
 #include "edm4hep/RecoMCParticleLinkCollection.h"
 
 namespace edm4hep {

--- a/include/edm4hep/MCRecoTrackParticleAssociationCollection.h
+++ b/include/edm4hep/MCRecoTrackParticleAssociationCollection.h
@@ -1,6 +1,8 @@
 #ifndef EDM4HEP_MCRecoTrackParticleAssociationCollection_H
 #define EDM4HEP_MCRecoTrackParticleAssociationCollection_H
 
+#include "edm4hep/MCRecoTrackParticleAssociation.h"
+#include "edm4hep/MutableMCRecoTrackParticleAssociation.h"
 #include "edm4hep/TrackMCParticleLinkCollection.h"
 
 namespace edm4hep {

--- a/include/edm4hep/MCRecoTrackerAssociationCollection.h
+++ b/include/edm4hep/MCRecoTrackerAssociationCollection.h
@@ -1,6 +1,8 @@
 #ifndef EDM4HEP_MCRecoTrackerAssociationCollection_H
 #define EDM4HEP_MCRecoTrackerAssociationCollection_H
 
+#include "edm4hep/MCRecoTrackerAssociation.h"
+#include "edm4hep/MutableMCRecoTrackerAssociation.h"
 #include "edm4hep/TrackerHitSimTrackerHitLinkCollection.h"
 
 namespace edm4hep {

--- a/include/edm4hep/RecoParticleVertexAssociation.h
+++ b/include/edm4hep/RecoParticleVertexAssociation.h
@@ -1,6 +1,8 @@
 #ifndef EDM4HEP_RecoParticleVertexAssociation_H
 #define EDM4HEP_RecoParticleVertexAssociation_H
 
+#include "edm4hep/MutableRecoParticleVertexAssociation.h"
+#include "edm4hep/RecoParticleVertexAssociation.h"
 #include "edm4hep/VertexRecoParticleLink.h"
 
 namespace edm4hep {


### PR DESCRIPTION

BEGINRELEASENOTES
- Include the user handle types in the `Collection.h` legacy header files such that they can truly be used transparently.

ENDRELEASENOTES