### PR TITLE
Fix assignment to non-exisitng members in createEDM4hep.py

### DIFF
--- a/scripts/createEDM4hepFile.py
+++ b/scripts/createEDM4hepFile.py
@@ -218,10 +218,10 @@ for i in range(frames):
         track.addToSubdetectorHitNumbers(next(counter))
         state = edm4hep.TrackState()
         state.location = next(counter)
-        state.d0 = next(counter)
+        state.D0 = next(counter)
         state.phi = next(counter)
         state.omega = next(counter)
-        state.z0 = next(counter)
+        state.Z0 = next(counter)
         state.tanLambda = next(counter)
         state.time = next(counter)
         state.referencePoint = edm4hep.Vector3f(

--- a/scripts/createEDM4hepFile.py
+++ b/scripts/createEDM4hepFile.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Description: Create a file with EDM4hep data using the EDM4hep python bindings
 # The purpose of the script is to use all the classes of the EDM4hep library
 # to create a file with dummy data.


### PR DESCRIPTION

BEGINRELEASENOTES
- Fixed typos in member assignment in `createEDM4hep.py`

ENDRELEASENOTES

Fixed the typos in script creating example edm4hep file.
Due to the typos a new member was created instead of updating a value of an existing one., hence incorrect values were written to the output. Originally reported on  #353.

Since earlier there were some similar issues reported (#355) I checked if there are any more typos by setting a pythonizations that forbids dynamically creating new members:

```python
import cppyy

def freeze_class(klass, name):
    def freeze_setattr(self, attr, val):
        if not attr in type(self).__dict__:
            raise AttributeError(attr)
        old_setattr(self,attr,val)

    old_setattr = klass.__setattr__ 
    klass.__setattr__ = freeze_setattr

cppyy.py.add_pythonization(freeze_class, "edm4hep")
```

which gives errors like that:

```python
Traceback (most recent call last):
  File "/home/mafila/EDM4hep/./scripts/createEDM4hepFile.py", line 234, in <module>
    state.d0 = next(counter)
  File "/home/mafila/EDM4hep/./scripts/createEDM4hepFile.py", line 8, in freeze_setattr
    raise AttributeError(attr)
AttributeError: d0
```

The only errors were for `d0` and `z0` so hopefully that was the last bug of this type