### PR TITLE
Use the Key4hepConfig flag to set the standard, compiler flags and rpath magic.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,47 +12,14 @@ SET( ${PROJECT_NAME}_VERSION  "${${PROJECT_NAME}_VERSION_MAJOR}.${${PROJECT_NAME
 find_package(podio 1.0 REQUIRED HINTS $ENV{PODIO})
 find_package(ROOT REQUIRED COMPONENTS RIO Tree Physics)
 
+include(cmake/Key4hepConfig.cmake)
+
 #--- Define basic build settings -----------------------------------------------
 # - Use GNU-style hierarchy for installing build products
 include(GNUInstallDirs)
 
-# - Define a default build type when using a single-mode tool like make/ninja
-# If you're using a build tool that supports multiple modes (Visual Studio,
-# Xcode), this setting has no effect.
-# HSF recommend RelWithDebInfo (optimized with debugging symbols) as this is
-# generally the mode used by system packaging (rpm, deb, spack, macports).
-# However, it can be overriden by passing ``-DCMAKE_BUILD_TYPE=<type>`` when
-# invoking CMake
-if(NOT CMAKE_CONFIGURATION_TYPES)
-  if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE RelWithDebInfo
-      CACHE STRING "Choose the type of build, options are: None Release MinSizeRel Debug RelWithDebInfo"
-      FORCE
-      )
-  else()
-    set(CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}"
-      CACHE STRING "Choose the type of build, options are: None Release MinSizeRel Debug RelWithDebInfo"
-      FORCE
-      )
-  endif()
-endif()
-
-# - Define the C++ Standard to use (Simplest Possible)
-set(CMAKE_CXX_STANDARD 20 CACHE STRING "")
-
-if(NOT CMAKE_CXX_STANDARD MATCHES "20|23")
-  message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD}")
-endif()
-
-message (STATUS "C++ standard: ${CMAKE_CXX_STANDARD}")
-
-option(EDM4HEP_SET_RPATH "Link libraries with built-in RPATH (run-time search path)" ON)
 include(cmake/EDM4HEPBuild.cmake)
-edm4hep_set_compiler_flags()
-edm4hep_set_rpath()
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDROP_CGAL")
-
+edm4hep_set_linker_flags()
 
 #--- Declare options -----------------------------------------------------------
 

--- a/cmake/EDM4HEPBuild.cmake
+++ b/cmake/EDM4HEPBuild.cmake
@@ -1,74 +1,12 @@
 #---------------------------------------------------------------------------------------------------
-#---edm4hep_set_rpath
+#---edm4hep_set_linker_flags
 #
-#  Set optional rpath on linux and mandatory rpath on mac
-#
-#---------------------------------------------------------------------------------------------------
-macro(edm4hep_set_rpath)
-  #  When building, don't use the install RPATH already (but later on when installing)
-  set(CMAKE_SKIP_BUILD_RPATH FALSE)         # don't skip the full RPATH for the build tree
-  set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE) # use always the build RPATH for the build tree
-  set(CMAKE_MACOSX_RPATH TRUE)              # use RPATH for MacOSX
-  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE) # point to directories outside the build tree to the install RPATH
-
-  option(USE_RUNPATH_INSTEAD_OF_RPATH "Use runpath instead of rpath (allow specifying liked libraries via LD_LIBRARY_PATH)" OFF)
-  if(USE_RUNPATH_INSTEAD_OF_RPATH)
-    set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--enable-new-dtags")
-  endif()
-
-  # Check whether to add RPATH to the installation (the build tree always has the RPATH enabled)
-  if(APPLE)
-    set(CMAKE_INSTALL_NAME_DIR "@rpath")
-    set(CMAKE_INSTALL_RPATH "@loader_path/../lib")    # self relative LIBDIR
-    # the RPATH to be used when installing, but only if it's not a system directory
-    list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
-    if("${isSystemDir}" STREQUAL "-1")
-      set(CMAKE_INSTALL_RPATH "@loader_path/../lib")
-    endif("${isSystemDir}" STREQUAL "-1")
-  elseif(EDM4HEP_SET_RPATH)
-    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${LIBDIR}") # install LIBDIR
-    # the RPATH to be used when installing, but only if it's not a system directory
-    list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
-    if("${isSystemDir}" STREQUAL "-1")
-      set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${LIBDIR}")
-    endif("${isSystemDir}" STREQUAL "-1")
-  else()
-    set(CMAKE_SKIP_INSTALL_RPATH TRUE)           # skip the full RPATH for the install tree
-  endif()
-endmacro(edm4hep_set_rpath)
-
-#---------------------------------------------------------------------------------------------------
-#---edm4hep_set_compiler_flags
-#
-#  Set compiler and linker flags
+#  Set linker flags
 #
 #---------------------------------------------------------------------------------------------------
 
-macro(edm4hep_set_compiler_flags)
+macro(edm4hep_set_linker_flags)
   include(CheckCXXCompilerFlag)
-
-  SET(COMPILER_FLAGS -fPIC -Wall -Wextra -Wpedantic -Wno-unused-variable -Wno-unused-parameter)
-
-  # AppleClang/Clang specific warning flags
-  if(CMAKE_CXX_COMPILER_ID MATCHES "^(Apple)?Clang$")
-    set ( COMPILER_FLAGS ${COMPILER_FLAGS} -Winconsistent-missing-override -Wheader-hygiene )
-  endif()
-
-  FOREACH( FLAG ${COMPILER_FLAGS} )
-    ## need to replace the minus or plus signs from the variables, because it is passed
-    ## as a macro to g++ which causes a warning about no whitespace after macro
-    ## definition
-    STRING(REPLACE "-" "_" FLAG_WORD ${FLAG} )
-    STRING(REPLACE "+" "P" FLAG_WORD ${FLAG_WORD} )
-
-    CHECK_CXX_COMPILER_FLAG( "${FLAG}" CXX_FLAG_WORKS_${FLAG_WORD} )
-    IF( ${CXX_FLAG_WORKS_${FLAG_WORD}} )
-      message( STATUS "Adding ${FLAG} to CXX_FLAGS" )
-      SET ( CMAKE_CXX_FLAGS "${FLAG} ${CMAKE_CXX_FLAGS} ")
-    ELSE()
-      message( STATUS "NOT Adding ${FLAG} to CXX_FLAGS" )
-    ENDIF()
-  ENDFOREACH()
 
   # resolve which linker we use
   execute_process(COMMAND ${CMAKE_CXX_COMPILER} -Wl,--version OUTPUT_VARIABLE stdout ERROR_QUIET)
@@ -94,4 +32,4 @@ macro(edm4hep_set_compiler_flags)
     MESSAGE( WARNING "No known linker (GNU or Apple) has been detected, pass no flags to linker" )
   endif()
 
-endmacro(edm4hep_set_compiler_flags)
+endmacro()

--- a/include/edm4hep/GeneratorToolInfo.h
+++ b/include/edm4hep/GeneratorToolInfo.h
@@ -25,11 +25,11 @@ struct GeneratorToolInfo {
 
   /// Construct a complete tool info object from all ingredients
   ///
-  /// @param name        The name of the tool
-  /// @param version     The version of the tool
-  /// @param description The brief description of the tool
-  GeneratorToolInfo(const std::string& name, const std::string& version, const std::string& description) :
-      name(name), version(version), description(description){};
+  /// @param nameTool        The name of the tool
+  /// @param versionTool     The version of the tool
+  /// @param descrTool       The brief description of the tool
+  GeneratorToolInfo(const std::string& nameTool, const std::string& versionTool, const std::string& descrTool) :
+      name(nameTool), version(versionTool), description(descrTool){};
 };
 
 namespace utils {


### PR DESCRIPTION
Several settings for Key4hep packages have been being set manually in CMakeLists.txt and they differ between different packages. A new file `Key4hepConfig.cmake` with some common settings was created (https://github.com/key4hep/key4hep-dev-utils/pull/5) and pushed to several repositories and these are the cmake changes needed to use them. 

The file `Key4hepConfig.cmake` is already in the repositories, so it doesn't need to be added. It was pushed but is not being used anywhere.

BEGINRELEASENOTES
- Use the Key4hepConfig flag to set the standard, compiler flags and rpath magic.
- For EDM4hep, the standard keeps being C++20 and the rpath is set as it was before. For the compiler flags `-Wshadow` is added on top of the existing ones.

ENDRELEASENOTES