### PR TITLE
CI: Rework workflows to make them a bit easier to maintain

### DIFF
--- a/.github/workflows/lcg_linux_with_podio.yml
+++ b/.github/workflows/lcg_linux_with_podio.yml
@@ -14,32 +14,32 @@ jobs:
               "LCG_106/x86_64-el9-gcc13-opt"]
         CXX_STANDARD: [20]
     steps:
-    - uses: actions/checkout@v3
-    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4
+      with:
+        repository: AIDASoft/podio
+        path: podio
+    - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: aidasoft/run-lcg-view@v4
       with:
         release-platform: ${{ matrix.LCG }}
         run: |
           STARTDIR=$(pwd)
           echo "::group::Build podio"
-          echo "Building podio @"$(git log -1 --format=%H)
-          git clone --depth 1 https://github.com/AIDASoft/podio
           cd podio
+          echo "Building podio @"$(git log -1 --format=%H)
           mkdir build install
           cd build
           cmake .. -DCMAKE_CXX_STANDARD=${{ matrix.CXX_STANDARD }} \
             -DENABLE_SIO=ON \
+            -DENABLE_RNTUPLE=ON \
+            -DENABLE_DATASOURCE=ON \
             -DBUILD_TESTING=OFF \
             -DCMAKE_INSTALL_PREFIX=$(pwd)/../install \
             -G Ninja
-          ninja -k0
-          ninja install
+          ninja -k0 install
           cd ..
-          export ROOT_INCLUDE_PATH=$(pwd)/install/include:$ROOT_INCLUDE_PATH:$CPATH
-          unset CPATH
-          export CMAKE_PREFIX_PATH=$(pwd)/install:$CMAKE_PREFIX_PATH
-          export LD_LIBRARY_PATH=$(pwd)/install/lib:$(pwd)/install/lib64:$LD_LIBRARY_PATH
-          export PYTHONPATH=$(pwd)/install/lib/python3$(python -c 'import sys; print(sys.version_info[1])')/site-packages:$PYTHONPATH
+          source init.sh && env.sh
           echo "::endgroup::"
           echo "::group::Build edm4hep"
           cd $STARTDIR

--- a/.github/workflows/lcg_linux_with_podio.yml
+++ b/.github/workflows/lcg_linux_with_podio.yml
@@ -36,7 +36,7 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=$(pwd)/install \
             -G Ninja -B build
           cmake --build build --target install -- -k0
-          source init.sh && env.sh
+          source init.sh && source env.sh
           echo "::endgroup::"
           echo "::group::Build edm4hep"
           cd $STARTDIR

--- a/.github/workflows/lcg_linux_with_podio.yml
+++ b/.github/workflows/lcg_linux_with_podio.yml
@@ -28,40 +28,32 @@ jobs:
           echo "::group::Build podio"
           cd podio
           echo "Building podio @"$(git log -1 --format=%H)
-          mkdir build install
-          cd build
           cmake .. -DCMAKE_CXX_STANDARD=${{ matrix.CXX_STANDARD }} \
             -DENABLE_SIO=ON \
             -DENABLE_RNTUPLE=ON \
             -DENABLE_DATASOURCE=ON \
             -DBUILD_TESTING=OFF \
-            -DCMAKE_INSTALL_PREFIX=$(pwd)/../install \
-            -G Ninja
-          ninja -k0 install
-          cd ..
+            -DCMAKE_INSTALL_PREFIX=$(pwd)/install \
+            -G Ninja -B build
+          cmake --build build --target install -- -k0
           source init.sh && env.sh
           echo "::endgroup::"
           echo "::group::Build edm4hep"
           cd $STARTDIR
           echo "Building edm4hep"
-          mkdir build install
-          cd build
           cmake .. -DCMAKE_CXX_STANDARD=${{ matrix.CXX_STANDARD }} \
-            -DCMAKE_INSTALL_PREFIX=../install \
+            -DCMAKE_INSTALL_PREFIX=$(pwd)/install \
             -DUSE_EXTERNAL_CATCH2=OFF \
-            -G Ninja
-          ninja -k0
-          ctest --output-on-failure
-          ninja install
-          cd -
+            -G Ninja -B build
+          cmake --build build -- -k0
+          ctest --test-dir build --output-on-failure
+          cmake --build build --target install
           echo "::endgroup::"
           echo "::group::Test downstream usage"
           export CMAKE_PREFIX_PATH=$PWD/install:$CMAKE_PREFIX_PATH
           cd test/downstream-project-cmake-test
-          mkdir build
-          cd build
           cmake .. -DCMAKE_CXX_STANDARD=${{ matrix.CXX_STANDARD }} \
-            -DCMAKE_INSTALL_PREFIX=../install \
-            -G Ninja
-          ninja -k0
+            -DCMAKE_INSTALL_PREFIX=$(pwd)/install \
+            -G Ninja -B build
+          cmake --build build -- -k0
           echo "::endgroup::"

--- a/.github/workflows/lcg_linux_with_podio.yml
+++ b/.github/workflows/lcg_linux_with_podio.yml
@@ -28,7 +28,7 @@ jobs:
           echo "::group::Build podio"
           cd podio
           echo "Building podio @"$(git log -1 --format=%H)
-          cmake .. -DCMAKE_CXX_STANDARD=${{ matrix.CXX_STANDARD }} \
+          cmake -DCMAKE_CXX_STANDARD=${{ matrix.CXX_STANDARD }} \
             -DENABLE_SIO=ON \
             -DENABLE_RNTUPLE=ON \
             -DENABLE_DATASOURCE=ON \
@@ -41,7 +41,7 @@ jobs:
           echo "::group::Build edm4hep"
           cd $STARTDIR
           echo "Building edm4hep"
-          cmake .. -DCMAKE_CXX_STANDARD=${{ matrix.CXX_STANDARD }} \
+          cmake -DCMAKE_CXX_STANDARD=${{ matrix.CXX_STANDARD }} \
             -DCMAKE_INSTALL_PREFIX=$(pwd)/install \
             -DUSE_EXTERNAL_CATCH2=OFF \
             -G Ninja -B build
@@ -52,7 +52,7 @@ jobs:
           echo "::group::Test downstream usage"
           export CMAKE_PREFIX_PATH=$PWD/install:$CMAKE_PREFIX_PATH
           cd test/downstream-project-cmake-test
-          cmake .. -DCMAKE_CXX_STANDARD=${{ matrix.CXX_STANDARD }} \
+          cmake -DCMAKE_CXX_STANDARD=${{ matrix.CXX_STANDARD }} \
             -DCMAKE_INSTALL_PREFIX=$(pwd)/install \
             -G Ninja -B build
           cmake --build build -- -k0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,10 +20,10 @@ jobs:
           echo "::group::Build podio"
           cd podio
           echo "Building podio @"$(git log -1 --format=%H)
-          cmake .. -DCMAKE_CXX_STANDARD=20 \
+          cmake -DCMAKE_CXX_STANDARD=20 \
             -DENABLE_SIO=ON \
             -DBUILD_TESTING=OFF \
-            -DCMAKE_INSTALL_PREFIX=$(pwd)install \
+            -DCMAKE_INSTALL_PREFIX=$(pwd)/install \
             -G Ninja -B build
           cmake --build build --target install
           source init.sh && source env.sh
@@ -33,7 +33,7 @@ jobs:
           export PYTHONPATH=$(python -m site --user-site):$PYTHONPATH
           export PATH=/root/.local/bin:$PATH
           pip install argparse --user
-          cmake .. -DENABLE_SIO=ON \
+          cmake -DENABLE_SIO=ON \
             -DCMAKE_CXX_STANDARD=20 \
             -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror "\
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,46 +6,39 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4
+      with:
+        repository: AIDASoft/podio
+        path: podio
+    - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: aidasoft/run-lcg-view@v4
       with:
         release-platform: LCG_104/x86_64-el9-clang16-opt
         run: |
           STARTDIR=$(pwd)
           echo "::group::Build podio"
-          echo "Building podio @"$(git log -1 --format=%H)
-          git clone --depth 1 https://github.com/AIDASoft/podio
           cd podio
-          mkdir build install
-          cd build
+          echo "Building podio @"$(git log -1 --format=%H)
           cmake .. -DCMAKE_CXX_STANDARD=20 \
             -DENABLE_SIO=ON \
             -DBUILD_TESTING=OFF \
-            -DCMAKE_INSTALL_PREFIX=$(pwd)/../install \
-            -G Ninja
-          ninja -k0
-          ninja install
-          cd ..
-          export ROOT_INCLUDE_PATH=$(pwd)/install/include:$ROOT_INCLUDE_PATH:$CPATH
-          unset CPATH
-          export CMAKE_PREFIX_PATH=$(pwd)/install:$CMAKE_PREFIX_PATH
-          export LD_LIBRARY_PATH=$(pwd)/install/lib:$(pwd)/install/lib64:$LD_LIBRARY_PATH
+            -DCMAKE_INSTALL_PREFIX=$(pwd)/install \
+            -G Ninja -B build
+          cmake --build build --target install
+          source init.sh && env.sh
           echo "::endgroup::"
           echo "::group::Run pre-commit"
           cd $STARTDIR
           export PYTHONPATH=$(python -m site --user-site):$PYTHONPATH
           export PATH=/root/.local/bin:$PATH
           pip install argparse --user
-          mkdir build
-          cd build
           cmake .. -DENABLE_SIO=ON \
             -DCMAKE_CXX_STANDARD=20 \
             -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror "\
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-            -DUSE_EXTERNAL_CATCH2=OFF
-          ln -s $(pwd)/compile_commands.json ../
-          cd ..
+            -DUSE_EXTERNAL_CATCH2=OFF -B build
+          ln -s $(pwd)/build/compile_commands.json ./compile_commands.json
           pip install pre-commit --user
           pre-commit run --show-diff-on-failure \
             --color=always \

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -30,9 +30,9 @@ jobs:
           echo "::endgroup::"
           echo "::group::Run pre-commit"
           cd $STARTDIR
-          export PYTHONPATH=$(python -m site --user-site):$PYTHONPATH
-          export PATH=/root/.local/bin:$PATH
-          pip install argparse --user
+          python3 -m venv /root/pre-commit-venv
+          source /root/pre-commit-venv/bin/activate
+          pip install pre-commit
           cmake -DENABLE_SIO=ON \
             -DCMAKE_CXX_STANDARD=20 \
             -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror "\

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -23,10 +23,10 @@ jobs:
           cmake .. -DCMAKE_CXX_STANDARD=20 \
             -DENABLE_SIO=ON \
             -DBUILD_TESTING=OFF \
-            -DCMAKE_INSTALL_PREFIX=$(pwd)/install \
+            -DCMAKE_INSTALL_PREFIX=$(pwd)install \
             -G Ninja -B build
           cmake --build build --target install
-          source init.sh && env.sh
+          source init.sh && source env.sh
           echo "::endgroup::"
           echo "::group::Run pre-commit"
           cd $STARTDIR

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -39,7 +39,6 @@ jobs:
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
             -DUSE_EXTERNAL_CATCH2=OFF -B build
           ln -s $(pwd)/build/compile_commands.json ./compile_commands.json
-          pip install pre-commit --user
           pre-commit run --show-diff-on-failure \
             --color=always \
             --all-files


### PR DESCRIPTION
BEGINRELEASENOTES
- CI: Update versions of github actions where appropriate
- CI: simplify workflows that build podio and EDM4hep by using cmake commands to invoke the build tool
- CI: Enable more features from podio for building EDM4hep on top of
  - Also fix a buggy printout that states the commit of podio that was used for building

ENDRELEASENOTES