### PR TITLE
Inject the EDM4hep version into the metadata that are stored by podio

### DIFF
--- a/edm4hep/CMakeLists.txt
+++ b/edm4hep/CMakeLists.txt
@@ -4,7 +4,9 @@ set(extra_code extra_code/CovMatrixCommon.ipp)
 # For now unconditionally generate all the code that is supported by the
 # installed podio
 PODIO_GENERATE_DATAMODEL(edm4hep ../edm4hep.yaml headers sources
-  IO_BACKEND_HANDLERS ${PODIO_IO_HANDLERS} DEPENDS ${extra_code}
+  IO_BACKEND_HANDLERS ${PODIO_IO_HANDLERS}
+  DEPENDS ${extra_code}
+  VERSION ${${PROJECT_NAME}_VERSION}
 )
 
 PODIO_ADD_DATAMODEL_CORE_LIB(edm4hep "${headers}" "${sources}")


### PR DESCRIPTION

BEGINRELEASENOTES
- Inject the EDM4hep version into the metadata that are stored by podio

ENDRELEASENOTES

Technically this also requires a bump in the minimal podio version, but we need a podio tag first for that. 