### PR TITLE
Add missing attributes for python package

### DIFF
--- a/python/edm4hep/__init__.py
+++ b/python/edm4hep/__init__.py
@@ -27,5 +27,12 @@ from ROOT import edm4hep
 # Make TAB completion work for utils
 setattr(edm4hep, 'utils', edm4hep.utils)
 
+# set package attributes for edm4hep
+edm4hep.__version__ = __version__
+edm4hep.__name__ = __name__
+edm4hep.__spec__ = __spec__
+edm4hep.__path__ = __path__
+edm4hep.__file__ = __file__
+
 # Make `import edm4hep` work
 sys.modules['edm4hep'] = edm4hep

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -117,5 +117,12 @@ if(HepMC3_FOUND AND HepPDT_FOUND )
   )
 endif()
 
+add_test(NAME py_test_module COMMAND python ${CMAKE_CURRENT_LIST_DIR}/test_module.py)
+set_test_env(py_test_module)
+set_property(TEST py_test_module APPEND PROPERTY ENVIRONMENT
+    ${ENVIRONMENT}
+    PYTHONPATH=${PROJECT_SOURCE_DIR}/python:$ENV{PYTHONPATH}
+)
+
 add_subdirectory(utils)
 add_subdirectory(tools)

--- a/test/test_module.py
+++ b/test/test_module.py
@@ -1,0 +1,8 @@
+import edm4hep
+
+assert edm4hep.__version__
+assert edm4hep.__name__ == "edm4hep"
+assert edm4hep.__spec__
+assert edm4hep.__path__
+assert edm4hep.__file__
+assert "utils" in dir(edm4hep)

--- a/test/test_module.py
+++ b/test/test_module.py
@@ -1,8 +1,29 @@
-import edm4hep
+#!/usr/bin/env python3
 
-assert edm4hep.__version__
-assert edm4hep.__name__ == "edm4hep"
-assert edm4hep.__spec__
-assert edm4hep.__path__
-assert edm4hep.__file__
+"""Check the attributes of edm4hep package"""
+
+import edm4hep
+from pathlib import Path
+from ROOT import gInterpreter
+
+if gInterpreter.LoadFile("edm4hep/EDM4hepVersion.h") != 0:
+    raise ImportError("Error while loading file edm4hep/EDM4hepVersion.h")
+
+# __version__
+version = edm4hep.version.build_version
+assert edm4hep.__version__ == f"{version.major}.{version.minor}.{version.patch}"
+# __name__
+name = "edm4hep"
+assert edm4hep.__name__ == name
+# __file__
+expected_origin = str(Path(__file__).parent.parent / "python" / "edm4hep" / "__init__.py")
+assert edm4hep.__file__ == expected_origin
+# __path__
+expected_path = [str(Path(expected_origin).parent)]
+assert edm4hep.__path__ == expected_path
+# __spec__
+assert edm4hep.__spec__.name == name
+assert edm4hep.__spec__.origin == expected_origin
+assert edm4hep.__spec__.submodule_search_locations == expected_path
+# utils
 assert "utils" in dir(edm4hep)

--- a/test/test_module.py
+++ b/test/test_module.py
@@ -3,8 +3,8 @@
 """Check the attributes of edm4hep package"""
 
 import edm4hep
-from pathlib import Path
 from ROOT import gInterpreter
+from importlib.util import find_spec
 
 if gInterpreter.LoadFile("edm4hep/EDM4hepVersion.h") != 0:
     raise ImportError("Error while loading file edm4hep/EDM4hepVersion.h")
@@ -12,18 +12,15 @@ if gInterpreter.LoadFile("edm4hep/EDM4hepVersion.h") != 0:
 # __version__
 version = edm4hep.version.build_version
 assert edm4hep.__version__ == f"{version.major}.{version.minor}.{version.patch}"
-# __name__
+
+# import attributes
 name = "edm4hep"
+expected_spec = find_spec(name)
 assert edm4hep.__name__ == name
-# __file__
-expected_origin = str(Path(__file__).parent.parent / "python" / "edm4hep" / "__init__.py")
-assert edm4hep.__file__ == expected_origin
-# __path__
-expected_path = [str(Path(expected_origin).parent)]
-assert edm4hep.__path__ == expected_path
-# __spec__
-assert edm4hep.__spec__.name == name
-assert edm4hep.__spec__.origin == expected_origin
-assert edm4hep.__spec__.submodule_search_locations == expected_path
+assert edm4hep.__name__ == expected_spec.name
+assert edm4hep.__spec__ == expected_spec
+assert edm4hep.__path__ == expected_spec.submodule_search_locations
+assert edm4hep.__file__ == expected_spec.origin
+
 # utils
 assert "utils" in dir(edm4hep)


### PR DESCRIPTION
BEGINRELEASENOTES
- Added missing attributes for python package

ENDRELEASENOTES

The package attributes from the import system were missing since the `edm4hep` is rebound to the `edm4hep` submodule created with ROOT/cppyy. Similarly `__version__` was set in the `__init__.py` but then lost

Having missing attributes shouldn't be a problem as we didn't experience it yet. But I think there was an intention to have `edm4hep.__version__` available

Import system [docs](https://docs.python.org/3/reference/import.html#import-related-module-attributes)