### PR TITLE
Use PROJECT_BINARY_DIR instead of CMAKE_BINARY_DIR to always locate the test files

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,14 +22,14 @@ set_tests_properties(create_complete_file_rntuple PROPERTIES
   SKIP_REGULAR_EXPRESSION "The RNTuple writer from podio is not available but was requested"
 )
 
-add_test(NAME check_complete_file COMMAND pytest --inputfile=${CMAKE_BINARY_DIR}/test/edm4hep_example.root -v)
+add_test(NAME check_complete_file COMMAND pytest --inputfile=${PROJECT_BINARY_DIR}/test/edm4hep_example.root -v)
 set_test_env(check_complete_file)
 set_tests_properties(
   check_complete_file
   PROPERTIES
    DEPENDS create_complete_file
 )
-add_test(NAME check_complete_file_rntuple COMMAND pytest --inputfile=${CMAKE_BINARY_DIR}/test/edm4hep_example_rntuple.root -v)
+add_test(NAME check_complete_file_rntuple COMMAND pytest --inputfile=${PROJECT_BINARY_DIR}/test/edm4hep_example_rntuple.root -v)
 set_test_env(check_complete_file_rntuple)
 set_tests_properties(
   check_complete_file_rntuple


### PR DESCRIPTION
Introduced in https://github.com/key4hep/EDM4hep/pull/361, `CMAKE_BINARY_DIR` won't work if EDM4hep is built from another project.

BEGINRELEASENOTES
- Use PROJECT_BINARY_DIR instead of CMAKE_BINARY_DIR to always locate the test files

ENDRELEASENOTES