### PR TITLE
Skip the full file check if the rntuple file has not been produced

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,6 +35,7 @@ set_tests_properties(
   check_complete_file_rntuple
   PROPERTIES
    DEPENDS create_complete_file_rntuple
+   SKIP_REGULAR_EXPRESSION "collected 0 items / 1 skipped"
 )
 
 set_tests_properties(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,8 +1,18 @@
 #!/usr/bin/env python3
 """pytest config module to make passing of input file name possible"""
 
+"""The pytest options after configuration"""
+options = None
+
 
 def pytest_addoption(parser):
     """Hook to add an inputfile argument to pytest for checking EDM4hep file
     contents"""
     parser.addoption("--inputfile", action="store")
+
+
+def pytest_configure(config):
+    """This is a slighty hacky solution to make the pytest configuration
+    available in test modules outside of fixtures"""
+    global options
+    options = config.option

--- a/test/test_EDM4hepFile.py
+++ b/test/test_EDM4hepFile.py
@@ -3,15 +3,25 @@
 created by scripts/createEDM4hepFile.py has the expected contents
 """
 
+import os
 import podio
 import edm4hep
 import pytest
 from itertools import count
 
+from conftest import options
+
 # For now simply copy these from createEDM4hepFile.py
 FRAMES = 3
 VECTORSIZE = 5
 COUNT_START = 42  # Starting point for the counters
+
+# Skip the test if an rntuple file has not been produced
+if "rntuple" in options.inputfile and not os.path.isfile(options.inputfile):
+    pytest.skip(
+        "Skipping rntuple reading tests, because input is not produced",
+        allow_module_level=True,
+    )
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION

BEGINRELEASENOTES
- Skip the check for the full file in case the RNTuple has not been produce (e.g. if podio hasn't been built with RNTuple support)

ENDRELEASENOTES

This is a slightly hackish solution that leverages pytests capabilities to skip tests rather than failing them. Unfortunately it returns a non-zero exit code in that case, so we need the `SKIP_REGULAR_EXPRESSION` (which we can now make a bit more narrow). This works around the same issue as https://github.com/AIDASoft/podio/pull/677 but entirely within EDM4hep.

I tried first with cmake features, but neither [`REQUIRED_FILES`](https://cmake.org/cmake/help/latest/prop_test/REQUIRED_FILES.html) nor [`FIXTURES_REQUIRED`](https://cmake.org/cmake/help/latest/prop_test/FIXTURES_REQUIRED.html#prop_test:FIXTURES_REQUIRED) can be made to work at the moment, as both of them mark the test suite as failed if they are used to *not run* a test. See these discussions: [first](https://gitlab.kitware.com/cmake/cmake/-/issues/17980) [second](https://gitlab.kitware.com/cmake/cmake/-/issues/26008)