### PR TITLE
Relax the requirement for the HepMC3 version

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -104,7 +104,7 @@ IF(TARGET ROOT::ROOTDataFrame)
 endif()
 
 
-find_package(HepMC3 3.3)
+find_package(HepMC3)
 find_package(HepPDT)
 
 if(HepMC3_FOUND AND HepPDT_FOUND )


### PR DESCRIPTION
Introduced in https://github.com/key4hep/EDM4hep/pull/367, it shouldn't be necessary to require any version of HepMC3, see        https://github.com/key4hep/EDM4hep/commit/a98fad09172cf88e14eb7daa4ad37cca2d786819#r146821010

BEGINRELEASENOTES
- Relax the requirement for the HepMC3 version

ENDRELEASENOTES