### PR TITLE
Find nlohmann_json downstream if EDM4hep has support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,8 @@ find_package(ROOT REQUIRED COMPONENTS RIO Tree Physics)
 
 option(EDM4HEP_WITH_JSON "Whether or not to build EDM4HEP with JSON support (and edm4hep2json)" ON)
 if (EDM4HEP_WITH_JSON)
- find_package(nlohmann_json 3.10.5 REQUIRED)
+ set(EDM4HEP_NLOHMANN_JSON_VERSION 3.10.5)
+ find_package(nlohmann_json ${EDM4HEP_NLOHMANN_JSON_VERSION} REQUIRED)
 endif()
 
 include(cmake/Key4hepConfig.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,11 @@ SET( ${PROJECT_NAME}_VERSION  "${${PROJECT_NAME}_VERSION_MAJOR}.${${PROJECT_NAME
 find_package(podio 1.1 REQUIRED HINTS $ENV{PODIO})
 find_package(ROOT REQUIRED COMPONENTS RIO Tree Physics)
 
+option(EDM4HEP_WITH_JSON "Whether or not to build EDM4HEP with JSON support (and edm4hep2json)" ON)
+if (EDM4HEP_WITH_JSON)
+ find_package(nlohmann_json 3.10.5 REQUIRED)
+endif()
+
 include(cmake/Key4hepConfig.cmake)
 
 #--- Define basic build settings -----------------------------------------------
@@ -63,7 +68,6 @@ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE
               ${CMAKE_CURRENT_SOURCE_DIR}/NOTICE
               DESTINATION ${CMAKE_INSTALL_DOCDIR})
 
-find_package(nlohmann_json 3.10.5)
 
 add_subdirectory(edm4hep)
 add_subdirectory(utils)

--- a/cmake/EDM4HEPConfig.cmake.in
+++ b/cmake/EDM4HEPConfig.cmake.in
@@ -16,7 +16,7 @@ find_dependency(podio REQUIRED)
 
 set(EDM4HEP_WITH_JSON @EDM4HEP_WITH_JSON@)
 if (EDM4HEP_WITH_JSON)
-  find_dependency(nlohmann_json 3.10.5 REQUIRED)
+  find_dependency(nlohmann_json @EDM4HEP_NLOHMANN_JSON_VERSION@ REQUIRED)
 endif()
 
 # - Include the targets file to create the imported targets that a client can

--- a/cmake/EDM4HEPConfig.cmake.in
+++ b/cmake/EDM4HEPConfig.cmake.in
@@ -14,6 +14,11 @@ set_and_check(EDM4HEP_DATA_DIR "@PACKAGE_CMAKE_INSTALL_DATADIR@/edm4hep")
 include(CMakeFindDependencyMacro)
 find_dependency(podio REQUIRED)
 
+set(EDM4HEP_WITH_JSON @nlohmann_json_FOUND@)
+if (EDM4HEP_WITH_JSON)
+  find_dependency(nlohmann_json 3.10.5 REQUIRED)
+endif()
+
 # - Include the targets file to create the imported targets that a client can
 # link to (libraries) or execute (programs)
 include("${CMAKE_CURRENT_LIST_DIR}/EDM4HEPTargets.cmake")

--- a/cmake/EDM4HEPConfig.cmake.in
+++ b/cmake/EDM4HEPConfig.cmake.in
@@ -14,7 +14,7 @@ set_and_check(EDM4HEP_DATA_DIR "@PACKAGE_CMAKE_INSTALL_DATADIR@/edm4hep")
 include(CMakeFindDependencyMacro)
 find_dependency(podio REQUIRED)
 
-set(EDM4HEP_WITH_JSON @nlohmann_json_FOUND@)
+set(EDM4HEP_WITH_JSON @EDM4HEP_WITH_JSON@)
 if (EDM4HEP_WITH_JSON)
   find_dependency(nlohmann_json 3.10.5 REQUIRED)
 endif()

--- a/edm4hep/CMakeLists.txt
+++ b/edm4hep/CMakeLists.txt
@@ -19,7 +19,7 @@ add_library(EDM4HEP::edm4hep ALIAS edm4hep)
 file(GLOB_RECURSE top_headers ${PROJECT_SOURCE_DIR}/include/*.h)
 target_sources(edm4hep PUBLIC FILE_SET headers TYPE HEADERS BASE_DIRS ${PROJECT_SOURCE_DIR}/include FILES ${top_headers})
 
-if (nlohmann_json_FOUND)
+if (EDM4HEP_WITH_JSON)
   target_compile_definitions(edm4hep PUBLIC PODIO_JSON_OUTPUT)
   target_link_libraries(edm4hep PUBLIC nlohmann_json::nlohmann_json)
 endif()

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,6 +1,6 @@
 list( APPEND CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" )
 
-if (nlohmann_json_FOUND)
+if (EDM4HEP_WITH_JSON)
   add_executable(edm4hep2json src/edm4hep2json.cxx)
 
   set(EDM4HEP_SET_RPATH TRUE)


### PR DESCRIPTION
BEGINRELEASENOTES
- Add an `EDM4HEP_WITH_JSON` cmake option (default `ON`) to be explicit about whether we want to build EDM4hep with JSON support or not.
  - Properly propagate this to downstream packages.
  - If set to `OFF` the `edm4hep2json` executable will not be built.

ENDRELEASENOTES