### PR TITLE
Make sure to only run tests with compatible root versions

### DIFF
--- a/test/backwards_compat/CMakeLists.txt
+++ b/test/backwards_compat/CMakeLists.txt
@@ -2,14 +2,26 @@ ExternalData_Add_Test(backward_compat_tests
   NAME backwards_compat_v00-99 COMMAND pytest -v --inputfile=DATA{${CMAKE_CURRENT_SOURCE_DIR}/input_files/edm4hep_example_v00-99-01_podio_v01-01.root})
 set_test_env(backwards_compat_v00-99)
 
-ExternalData_Add_Test(backward_compat_tests
-  NAME backwards_compat_rntuple_v00-99 COMMAND pytest -v --inputfile=DATA{${CMAKE_CURRENT_SOURCE_DIR}/input_files/edm4hep_example_rntuple_v00-99-01_podio_v01-01.root})
-set_test_env(backwards_compat_rntuple_v00-99)
-
 set_tests_properties(
   backwards_compat_v00-99
-  backwards_compat_rntuple_v00-99
 
   PROPERTIES
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test
 )
+
+
+if (ROOT_VERSION VERSION_LESS 6.33)
+  # This input file has been written with RNTuple RC2 which is only present up
+  # to the 6.32 release series. Trying to read this with a newer version of ROOT
+  # doesn't work
+  ExternalData_Add_Test(backward_compat_tests
+    NAME backwards_compat_rntuple_v00-99 COMMAND pytest -v --inputfile=DATA{${CMAKE_CURRENT_SOURCE_DIR}/input_files/edm4hep_example_rntuple_v00-99-01_podio_v01-01.root})
+  set_test_env(backwards_compat_rntuple_v00-99)
+
+  set_tests_properties(
+    backwards_compat_rntuple_v00-99
+
+    PROPERTIES
+      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test
+  )
+endif()


### PR DESCRIPTION

BEGINRELEASENOTES
- Make sure to only run backwards compatibility tests if we have a suitable version of ROOT to still read the RC2 RNTuples stored in the files.

ENDRELEASENOTES

Necessary to make the full CI suite pass again for https://github.com/AIDASoft/podio/pull/702