### PR TITLE
Make the PIDHandler class non-copyable

### DIFF
--- a/utils/include/edm4hep/utils/ParticleIDUtils.h
+++ b/utils/include/edm4hep/utils/ParticleIDUtils.h
@@ -55,8 +55,8 @@ class PIDHandler {
 public:
   PIDHandler() = default;
   ~PIDHandler() = default;
-  PIDHandler(const PIDHandler&) = default;
-  PIDHandler& operator=(const PIDHandler&) = default;
+  PIDHandler(const PIDHandler&) = delete;
+  PIDHandler& operator=(const PIDHandler&) = delete;
   PIDHandler(PIDHandler&&) = default;
   PIDHandler& operator=(PIDHandler&&) = default;
 

--- a/utils/include/edm4hep/utils/ParticleIDUtils.h
+++ b/utils/include/edm4hep/utils/ParticleIDUtils.h
@@ -55,6 +55,7 @@ class PIDHandler {
 public:
   PIDHandler() = default;
   ~PIDHandler() = default;
+  // Copies are not allowed to avoid copying the internal maps
   PIDHandler(const PIDHandler&) = delete;
   PIDHandler& operator=(const PIDHandler&) = delete;
   PIDHandler(PIDHandler&&) = default;


### PR DESCRIPTION
BEGINRELEASENOTES
- Make the PIDHandler class non-copyable

ENDRELEASENOTES

Sounds like a bad idea to copy all these maps, vector of strings, strings...