### PR TITLE
install old schemas libraries

### DIFF
--- a/edm4hep/CMakeLists.txt
+++ b/edm4hep/CMakeLists.txt
@@ -32,10 +32,12 @@ target_include_directories(edm4hepOldSchemas PRIVATE
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/edm4hep/schema_evolution/include>
 )
 target_link_libraries(edm4hepOldSchemas PUBLIC podio::podio EDM4HEP::edm4hep)
+add_library(EDM4HEP::oldSchemas ALIAS edm4hepOldSchemas)
 
 PODIO_ADD_ROOT_IO_DICT(edm4hepOldSchemasDict edm4hepOldSchemas ${PROJECT_SOURCE_DIR}/edm4hep/schema_evolution/include/edm4hep/schema_evolution/OldLinkData.h schema_evolution/src/selection.xml)
+add_library(EDM4HEP::oldSchemasDict ALIAS edm4hepOldSchemasDict)
 
-list(APPEND EDM4HEP_INSTALL_LIBS edm4hep edm4hepDict)
+list(APPEND EDM4HEP_INSTALL_LIBS edm4hep edm4hepDict edm4hepOldSchemas edm4hepOldSchemasDict)
 
 PODIO_ADD_SIO_IO_BLOCKS(edm4hep "${headers}" "${sources}")
 IF(TARGET edm4hepSioBlocks)


### PR DESCRIPTION

BEGINRELEASENOTES
- Install oldSchemas library and dictionary

ENDRELEASENOTES

The oldSchemas library added in #373 wasn't added for installation, while being expected to be installed by python bindings:

```txt
  File "/cvmfs/sw-nightlies.hsf.org/key4hep/releases/2024-12-19/x86_64-almalinux9-gcc14.2.0-opt/edm4hep/d651cd6792eb29808c18f742280508735f040269_develop-45e6w4/lib/python3.11/site-packages/edm4hep/__init__.py", line 30, in <module>
    raise RuntimeError("Failed to load edm4hep legacy schemas library")
RuntimeError: Failed to load edm4hep legacy schemas library

```