### PR TITLE
update doxygen files to 1.11

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1,4 +1,4 @@
-# Doxyfile 1.8.6
+# Doxyfile 1.11.0
 
 # This file describes the settings to be used by the documentation system
 # doxygen (www.doxygen.org) for a project.
@@ -12,16 +12,26 @@
 # For lists, items can also be appended using:
 # TAG += value [value, ...]
 # Values that contain spaces should be placed between quotes (\" \").
+#
+# Note:
+#
+# Use doxygen to compare the used configuration file with the template
+# configuration file:
+# doxygen -x [configFile]
+# Use doxygen to compare the used configuration file with the template
+# configuration file without replacing the environment variables or CMake type
+# replacement variables:
+# doxygen -x_noenv [configFile]
 
 #---------------------------------------------------------------------------
 # Project related configuration options
 #---------------------------------------------------------------------------
 
-# This tag specifies the encoding used for all characters in the config file
-# that follow. The default is UTF-8 which is also the encoding used for all text
-# before the first occurrence of this tag. Doxygen uses libiconv (or the iconv
-# built into libc) for the transcoding. See http://www.gnu.org/software/libiconv
-# for the list of possible encodings.
+# This tag specifies the encoding used for all characters in the configuration
+# file that follow. The default is UTF-8 which is also the encoding used for all
+# text before the first occurrence of this tag. Doxygen uses libiconv (or the
+# iconv built into libc) for the transcoding. See
+# https://www.gnu.org/software/libiconv/ for the list of possible encodings.
 # The default value is: UTF-8.
 
 DOXYFILE_ENCODING      = UTF-8
@@ -32,7 +42,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "EDM4hep"
+PROJECT_NAME           = EDM4hep
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version
@@ -46,12 +56,18 @@ PROJECT_NUMBER         = @EDM4HEP_VERSION@
 
 PROJECT_BRIEF          =
 
-# With the PROJECT_LOGO tag one can specify an logo or icon that is included in
-# the documentation. The maximum height of the logo should not exceed 55 pixels
-# and the maximum width should not exceed 200 pixels. Doxygen will copy the logo
-# to the output directory.
+# With the PROJECT_LOGO tag one can specify a logo or an icon that is included
+# in the documentation. The maximum height of the logo should not exceed 55
+# pixels and the maximum width should not exceed 200 pixels. Doxygen will copy
+# the logo to the output directory.
 
 PROJECT_LOGO           =
+
+# With the PROJECT_ICON tag one can specify an icon that is included in the tabs
+# when the HTML document is shown. Doxygen will copy the logo to the output
+# directory.
+
+PROJECT_ICON           =
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute) path
 # into which the generated documentation will be written. If a relative path is
@@ -60,39 +76,59 @@ PROJECT_LOGO           =
 
 OUTPUT_DIRECTORY       = @PROJECT_BINARY_DIR@/doxygen
 
-# If the CREATE_SUBDIRS tag is set to YES, then doxygen will create 4096 sub-
-# directories (in 2 levels) under the output directory of each output format and
-# will distribute the generated files over these directories. Enabling this
+# If the CREATE_SUBDIRS tag is set to YES then doxygen will create up to 4096
+# sub-directories (in 2 levels) under the output directory of each output format
+# and will distribute the generated files over these directories. Enabling this
 # option can be useful when feeding doxygen a huge amount of source files, where
 # putting all generated files in the same directory would otherwise causes
-# performance problems for the file system.
+# performance problems for the file system. Adapt CREATE_SUBDIRS_LEVEL to
+# control the number of sub-directories.
 # The default value is: NO.
 
 CREATE_SUBDIRS         = NO
 
+# Controls the number of sub-directories that will be created when
+# CREATE_SUBDIRS tag is set to YES. Level 0 represents 16 directories, and every
+# level increment doubles the number of directories, resulting in 4096
+# directories at level 8 which is the default and also the maximum value. The
+# sub-directories are organized in 2 levels, the first level always has a fixed
+# number of 16 directories.
+# Minimum value: 0, maximum value: 8, default value: 8.
+# This tag requires that the tag CREATE_SUBDIRS is set to YES.
+
+CREATE_SUBDIRS_LEVEL   = 8
+
+# If the ALLOW_UNICODE_NAMES tag is set to YES, doxygen will allow non-ASCII
+# characters to appear in the names of generated files. If set to NO, non-ASCII
+# characters will be escaped, for example _xE3_x81_x84 will be used for Unicode
+# U+3044.
+# The default value is: NO.
+
+ALLOW_UNICODE_NAMES    = NO
+
 # The OUTPUT_LANGUAGE tag is used to specify the language in which all
 # documentation generated by doxygen is written. Doxygen will use this
 # information to generate all constant output in the proper language.
-# Possible values are: Afrikaans, Arabic, Armenian, Brazilian, Catalan, Chinese,
-# Chinese-Traditional, Croatian, Czech, Danish, Dutch, English (United States),
-# Esperanto, Farsi (Persian), Finnish, French, German, Greek, Hungarian,
-# Indonesian, Italian, Japanese, Japanese-en (Japanese with English messages),
-# Korean, Korean-en (Korean with English messages), Latvian, Lithuanian,
-# Macedonian, Norwegian, Persian (Farsi), Polish, Portuguese, Romanian, Russian,
-# Serbian, Serbian-Cyrillic, Slovak, Slovene, Spanish, Swedish, Turkish,
-# Ukrainian and Vietnamese.
+# Possible values are: Afrikaans, Arabic, Armenian, Brazilian, Bulgarian,
+# Catalan, Chinese, Chinese-Traditional, Croatian, Czech, Danish, Dutch, English
+# (United States), Esperanto, Farsi (Persian), Finnish, French, German, Greek,
+# Hindi, Hungarian, Indonesian, Italian, Japanese, Japanese-en (Japanese with
+# English messages), Korean, Korean-en (Korean with English messages), Latvian,
+# Lithuanian, Macedonian, Norwegian, Persian (Farsi), Polish, Portuguese,
+# Romanian, Russian, Serbian, Serbian-Cyrillic, Slovak, Slovene, Spanish,
+# Swedish, Turkish, Ukrainian and Vietnamese.
 # The default value is: English.
 
 OUTPUT_LANGUAGE        = English
 
-# If the BRIEF_MEMBER_DESC tag is set to YES doxygen will include brief member
+# If the BRIEF_MEMBER_DESC tag is set to YES, doxygen will include brief member
 # descriptions after the members that are listed in the file and class
 # documentation (similar to Javadoc). Set to NO to disable this.
 # The default value is: YES.
 
 BRIEF_MEMBER_DESC      = YES
 
-# If the REPEAT_BRIEF tag is set to YES doxygen will prepend the brief
+# If the REPEAT_BRIEF tag is set to YES, doxygen will prepend the brief
 # description of a member or function before the detailed description
 #
 # Note: If both HIDE_UNDOC_MEMBERS and BRIEF_MEMBER_DESC are set to NO, the
@@ -127,7 +163,7 @@ ALWAYS_DETAILED_SEC    = NO
 
 INLINE_INHERITED_MEMB  = NO
 
-# If the FULL_PATH_NAMES tag is set to YES doxygen will prepend the full path
+# If the FULL_PATH_NAMES tag is set to YES, doxygen will prepend the full path
 # before files name in the file list and in the header files. If set to NO the
 # shortest path that makes the file name unique will be used
 # The default value is: YES.
@@ -160,7 +196,6 @@ STRIP_FROM_INC_PATH    = @PROJECT_SOURCE_DIR@/include \
                          @PROJECT_SOURCE_DIR@/utils/include \
                          @PROJECT_SOURCE_DIR@/edm4hep
 
-
 # If the SHORT_NAMES tag is set to YES, doxygen will generate much shorter (but
 # less readable) file names. This can be useful is your file systems doesn't
 # support long names like on DOS, Mac, or CD-ROM.
@@ -176,6 +211,16 @@ SHORT_NAMES            = NO
 # The default value is: NO.
 
 JAVADOC_AUTOBRIEF      = YES
+
+# If the JAVADOC_BANNER tag is set to YES then doxygen will interpret a line
+# such as
+# /***************
+# as being the beginning of a Javadoc-style comment "banner". If set to NO, the
+# Javadoc-style will behave just like regular comments and it will not be
+# interpreted by doxygen.
+# The default value is: NO.
+
+JAVADOC_BANNER         = NO
 
 # If the QT_AUTOBRIEF tag is set to YES then doxygen will interpret the first
 # line (until the first dot) of a Qt-style comment as the brief description. If
@@ -197,15 +242,23 @@ QT_AUTOBRIEF           = YES
 
 MULTILINE_CPP_IS_BRIEF = NO
 
+# By default Python docstrings are displayed as preformatted text and doxygen's
+# special commands cannot be used. By setting PYTHON_DOCSTRING to NO the
+# doxygen's special commands can be used and the contents of the docstring
+# documentation blocks is shown as doxygen documentation.
+# The default value is: YES.
+
+PYTHON_DOCSTRING       = YES
+
 # If the INHERIT_DOCS tag is set to YES then an undocumented member inherits the
 # documentation from any documented member that it re-implements.
 # The default value is: YES.
 
 INHERIT_DOCS           = YES
 
-# If the SEPARATE_MEMBER_PAGES tag is set to YES, then doxygen will produce a
-# new page for each member. If set to NO, the documentation of a member will be
-# part of the file/class/namespace that contains it.
+# If the SEPARATE_MEMBER_PAGES tag is set to YES then doxygen will produce a new
+# page for each member. If set to NO, the documentation of a member will be part
+# of the file/class/namespace that contains it.
 # The default value is: NO.
 
 SEPARATE_MEMBER_PAGES  = NO
@@ -220,19 +273,18 @@ TAB_SIZE               = 4
 # the documentation. An alias has the form:
 # name=value
 # For example adding
-# "sideeffect=@par Side Effects:\n"
+# "sideeffect=@par Side Effects:^^"
 # will allow you to put the command \sideeffect (or @sideeffect) in the
 # documentation, which will result in a user-defined paragraph with heading
-# "Side Effects:". You can put \n's in the value part of an alias to insert
-# newlines.
+# "Side Effects:". Note that you cannot put \n's in the value part of an alias
+# to insert newlines (in the resulting output). You can put ^^ in the value part
+# of an alias to insert a newline as if a physical newline was in the original
+# file. When you need a literal { or } or , in the value part of an alias you
+# have to escape them by means of a backslash (\), this can lead to conflicts
+# with the commands \{ and \} for these it is advised to use the version @{ and
+# @} or use a double escape (\\{ and \\})
 
 ALIASES                = "FIXME=\xrefitem fixmes \"Fix-Me\" \"Fix-Me's\""
-
-# This tag can be used to specify a number of word-keyword mappings (TCL only).
-# A mapping has the form "name=value". For example adding "class=itcl::class"
-# will allow you to use the command class in the itcl::class meaning.
-
-TCL_SUBST              =
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For
@@ -262,25 +314,43 @@ OPTIMIZE_FOR_FORTRAN   = NO
 
 OPTIMIZE_OUTPUT_VHDL   = NO
 
+# Set the OPTIMIZE_OUTPUT_SLICE tag to YES if your project consists of Slice
+# sources only. Doxygen will then generate output that is more tailored for that
+# language. For instance, namespaces will be presented as modules, types will be
+# separated into more groups, etc.
+# The default value is: NO.
+
+OPTIMIZE_OUTPUT_SLICE  = NO
+
 # Doxygen selects the parser to use depending on the extension of the files it
 # parses. With this tag you can assign which parser to use for a given
 # extension. Doxygen has a built-in mapping, but you can override or extend it
 # using this tag. The format is ext=language, where ext is a file extension, and
-# language is one of the parsers supported by doxygen: IDL, Java, Javascript,
-# C#, C, C++, D, PHP, Objective-C, Python, Fortran, VHDL. For instance to make
-# doxygen treat .inc files as Fortran files (default is PHP), and .f files as C
-# (default is Fortran), use: inc=Fortran f=C.
+# language is one of the parsers supported by doxygen: IDL, Java, JavaScript,
+# Csharp (C#), C, C++, Lex, D, PHP, md (Markdown), Objective-C, Python, Slice,
+# VHDL, Fortran (fixed format Fortran: FortranFixed, free formatted Fortran:
+# FortranFree, unknown formatted Fortran: Fortran. In the later case the parser
+# tries to guess whether the code is fixed or free formatted code, this is the
+# default for Fortran type files). For instance to make doxygen treat .inc files
+# as Fortran files (default is PHP), and .f files as C (default is Fortran),
+# use: inc=Fortran f=C.
 #
-# Note For files without extension you can use no_extension as a placeholder.
+# Note: For files without extension you can use no_extension as a placeholder.
 #
 # Note that for custom extensions you also need to set FILE_PATTERNS otherwise
-# the files are not read by doxygen.
+# the files are not read by doxygen. When specifying no_extension you should add
+# * to the FILE_PATTERNS.
+#
+# Note see also the list of default file extension mappings.
 
-EXTENSION_MAPPING      = h=C++ icpp=C++ icc=C++ inl=C++
+EXTENSION_MAPPING      = h=C++ \
+                         icpp=C++ \
+                         icc=C++ \
+                         inl=C++
 
 # If the MARKDOWN_SUPPORT tag is enabled then doxygen pre-processes all comments
 # according to the Markdown format, which allows for more readable
-# documentation. See http://daringfireball.net/projects/markdown/ for details.
+# documentation. See https://daringfireball.net/projects/markdown/ for details.
 # The output of markdown processing is further processed by doxygen, so you can
 # mix doxygen, HTML, and XML commands with Markdown formatting. Disable only in
 # case of backward compatibilities issues.
@@ -288,10 +358,30 @@ EXTENSION_MAPPING      = h=C++ icpp=C++ icc=C++ inl=C++
 
 MARKDOWN_SUPPORT       = YES
 
+# When the TOC_INCLUDE_HEADINGS tag is set to a non-zero value, all headings up
+# to that level are automatically included in the table of contents, even if
+# they do not have an id attribute.
+# Note: This feature currently applies only to Markdown headings.
+# Minimum value: 0, maximum value: 99, default value: 6.
+# This tag requires that the tag MARKDOWN_SUPPORT is set to YES.
+
+TOC_INCLUDE_HEADINGS   = 6
+
+# The MARKDOWN_ID_STYLE tag can be used to specify the algorithm used to
+# generate identifiers for the Markdown headings. Note: Every identifier is
+# unique.
+# Possible values are: DOXYGEN use a fixed 'autotoc_md' string followed by a
+# sequence number starting at 0 and GITHUB use the lower case version of title
+# with any whitespace replaced by '-' and punctuation characters removed.
+# The default value is: DOXYGEN.
+# This tag requires that the tag MARKDOWN_SUPPORT is set to YES.
+
+MARKDOWN_ID_STYLE      = DOXYGEN
+
 # When enabled doxygen tries to link words that correspond to documented
 # classes, or namespaces to their corresponding documentation. Such a link can
-# be prevented in individual cases by by putting a % sign in front of the word
-# or globally by setting AUTOLINK_SUPPORT to NO.
+# be prevented in individual cases by putting a % sign in front of the word or
+# globally by setting AUTOLINK_SUPPORT to NO.
 # The default value is: YES.
 
 AUTOLINK_SUPPORT       = YES
@@ -300,8 +390,8 @@ AUTOLINK_SUPPORT       = YES
 # to include (a tag file for) the STL sources as input, then you should set this
 # tag to YES in order to let doxygen match functions declarations and
 # definitions whose arguments contain STL classes (e.g. func(std::string);
-# versus func(std::string) {}). This also make the inheritance and collaboration
-# diagrams that involve STL classes more complete and accurate.
+# versus func(std::string) {}). This also makes the inheritance and
+# collaboration diagrams that involve STL classes more complete and accurate.
 # The default value is: NO.
 
 BUILTIN_STL_SUPPORT    = YES
@@ -313,9 +403,9 @@ BUILTIN_STL_SUPPORT    = YES
 CPP_CLI_SUPPORT        = NO
 
 # Set the SIP_SUPPORT tag to YES if your project consists of sip (see:
-# http://www.riverbankcomputing.co.uk/software/sip/intro) sources only. Doxygen
-# will parse them like normal C++ but will assume all classes use public instead
-# of private inheritance when no explicit protection keyword is present.
+# https://www.riverbankcomputing.com/software) sources only. Doxygen will parse
+# them like normal C++ but will assume all classes use public instead of private
+# inheritance when no explicit protection keyword is present.
 # The default value is: NO.
 
 SIP_SUPPORT            = NO
@@ -331,12 +421,19 @@ SIP_SUPPORT            = NO
 IDL_PROPERTY_SUPPORT   = YES
 
 # If member grouping is used in the documentation and the DISTRIBUTE_GROUP_DOC
-# tag is set to YES, then doxygen will reuse the documentation of the first
+# tag is set to YES then doxygen will reuse the documentation of the first
 # member in the group (if any) for the other members of the group. By default
 # all members of a group must be documented explicitly.
 # The default value is: NO.
 
 DISTRIBUTE_GROUP_DOC   = NO
+
+# If one adds a struct or class to a group and this option is enabled, then also
+# any nested class or struct is added to the same group. By default this option
+# is disabled and one has to add nested compounds explicitly via \ingroup.
+# The default value is: NO.
+
+GROUP_NESTED_COMPOUNDS = NO
 
 # Set the SUBGROUPING tag to YES to allow class member groups of the same type
 # (for instance a group of public functions) to be put as a subgroup of that
@@ -392,11 +489,32 @@ TYPEDEF_HIDES_STRUCT   = NO
 
 LOOKUP_CACHE_SIZE      = 0
 
+# The NUM_PROC_THREADS specifies the number of threads doxygen is allowed to use
+# during processing. When set to 0 doxygen will based this on the number of
+# cores available in the system. You can set it explicitly to a value larger
+# than 0 to get more control over the balance between CPU load and processing
+# speed. At this moment only the input processing can be done using multiple
+# threads. Since this is still an experimental feature the default is set to 1,
+# which effectively disables parallel processing. Please report any issues you
+# encounter. Generating dot graphs in parallel is controlled by the
+# DOT_NUM_THREADS setting.
+# Minimum value: 0, maximum value: 32, default value: 1.
+
+NUM_PROC_THREADS       = 1
+
+# If the TIMESTAMP tag is set different from NO then each generated page will
+# contain the date or date and time when the page was generated. Setting this to
+# NO can help when comparing the output of multiple runs.
+# Possible values are: YES, NO, DATETIME and DATE.
+# The default value is: NO.
+
+TIMESTAMP              = YES
+
 #---------------------------------------------------------------------------
 # Build related configuration options
 #---------------------------------------------------------------------------
 
-# If the EXTRACT_ALL tag is set to YES doxygen will assume all entities in
+# If the EXTRACT_ALL tag is set to YES, doxygen will assume all entities in
 # documentation are documented, even if no documentation was available. Private
 # class members and static file members will be hidden unless the
 # EXTRACT_PRIVATE respectively EXTRACT_STATIC tags are set to YES.
@@ -406,35 +524,41 @@ LOOKUP_CACHE_SIZE      = 0
 
 EXTRACT_ALL            = YES
 
-# If the EXTRACT_PRIVATE tag is set to YES all private members of a class will
+# If the EXTRACT_PRIVATE tag is set to YES, all private members of a class will
 # be included in the documentation.
 # The default value is: NO.
 
 EXTRACT_PRIVATE        = YES
 
-# If the EXTRACT_PACKAGE tag is set to YES all members with package or internal
+# If the EXTRACT_PRIV_VIRTUAL tag is set to YES, documented private virtual
+# methods of a class will be included in the documentation.
+# The default value is: NO.
+
+EXTRACT_PRIV_VIRTUAL   = NO
+
+# If the EXTRACT_PACKAGE tag is set to YES, all members with package or internal
 # scope will be included in the documentation.
 # The default value is: NO.
 
 EXTRACT_PACKAGE        = NO
 
-# If the EXTRACT_STATIC tag is set to YES all static members of a file will be
+# If the EXTRACT_STATIC tag is set to YES, all static members of a file will be
 # included in the documentation.
 # The default value is: NO.
 
 EXTRACT_STATIC         = NO
 
-# If the EXTRACT_LOCAL_CLASSES tag is set to YES classes (and structs) defined
-# locally in source files will be included in the documentation. If set to NO
+# If the EXTRACT_LOCAL_CLASSES tag is set to YES, classes (and structs) defined
+# locally in source files will be included in the documentation. If set to NO,
 # only classes defined in header files are included. Does not have any effect
 # for Java sources.
 # The default value is: YES.
 
 EXTRACT_LOCAL_CLASSES  = YES
 
-# This flag is only useful for Objective-C code. When set to YES local methods,
+# This flag is only useful for Objective-C code. If set to YES, local methods,
 # which are defined in the implementation section but not in the interface are
-# included in the documentation. If set to NO only methods in the interface are
+# included in the documentation. If set to NO, only methods in the interface are
 # included.
 # The default value is: NO.
 
@@ -449,6 +573,13 @@ EXTRACT_LOCAL_METHODS  = NO
 
 EXTRACT_ANON_NSPACES   = NO
 
+# If this flag is set to YES, the name of an unnamed parameter in a declaration
+# will be determined by the corresponding definition. By default unnamed
+# parameters remain unnamed in the output.
+# The default value is: YES.
+
+RESOLVE_UNNAMED_PARAMS = YES
+
 # If the HIDE_UNDOC_MEMBERS tag is set to YES, doxygen will hide all
 # undocumented members inside documented classes or files. If set to NO these
 # members will be included in the various overviews, but no documentation
@@ -459,21 +590,22 @@ HIDE_UNDOC_MEMBERS     = NO
 
 # If the HIDE_UNDOC_CLASSES tag is set to YES, doxygen will hide all
 # undocumented classes that are normally visible in the class hierarchy. If set
-# to NO these classes will be included in the various overviews. This option has
-# no effect if EXTRACT_ALL is enabled.
+# to NO, these classes will be included in the various overviews. This option
+# will also hide undocumented C++ concepts if enabled. This option has no effect
+# if EXTRACT_ALL is enabled.
 # The default value is: NO.
 
 HIDE_UNDOC_CLASSES     = NO
 
 # If the HIDE_FRIEND_COMPOUNDS tag is set to YES, doxygen will hide all friend
-# (class|struct|union) declarations. If set to NO these declarations will be
-# included in the documentation.
+# declarations. If set to NO, these declarations will be included in the
+# documentation.
 # The default value is: NO.
 
 HIDE_FRIEND_COMPOUNDS  = NO
 
 # If the HIDE_IN_BODY_DOCS tag is set to YES, doxygen will hide any
-# documentation blocks found inside the body of a function. If set to NO these
+# documentation blocks found inside the body of a function. If set to NO, these
 # blocks will be appended to the function's detailed documentation block.
 # The default value is: NO.
 
@@ -486,21 +618,42 @@ HIDE_IN_BODY_DOCS      = NO
 
 INTERNAL_DOCS          = NO
 
-# If the CASE_SENSE_NAMES tag is set to NO then doxygen will only generate file
-# names in lower-case letters. If set to YES upper-case letters are also
-# allowed. This is useful if you have classes or files whose names only differ
-# in case and if your file system supports case sensitive file names. Windows
-# and Mac users are advised to set this option to NO.
-# The default value is: system dependent.
+# With the correct setting of option CASE_SENSE_NAMES doxygen will better be
+# able to match the capabilities of the underlying filesystem. In case the
+# filesystem is case sensitive (i.e. it supports files in the same directory
+# whose names only differ in casing), the option must be set to YES to properly
+# deal with such files in case they appear in the input. For filesystems that
+# are not case sensitive the option should be set to NO to properly deal with
+# output files written for symbols that only differ in casing, such as for two
+# classes, one named CLASS and the other named Class, and to also support
+# references to files without having to specify the exact matching casing. On
+# Windows (including Cygwin) and MacOS, users should typically set this option
+# to NO, whereas on Linux or other Unix flavors it should typically be set to
+# YES.
+# Possible values are: SYSTEM, NO and YES.
+# The default value is: SYSTEM.
 
 CASE_SENSE_NAMES       = NO
 
 # If the HIDE_SCOPE_NAMES tag is set to NO then doxygen will show members with
-# their full class and namespace scopes in the documentation. If set to YES the
+# their full class and namespace scopes in the documentation. If set to YES, the
 # scope will be hidden.
 # The default value is: NO.
 
 HIDE_SCOPE_NAMES       = NO
+
+# If the HIDE_COMPOUND_REFERENCE tag is set to NO (default) then doxygen will
+# append additional text to a page's title, such as Class Reference. If set to
+# YES the compound reference will be hidden.
+# The default value is: NO.
+
+HIDE_COMPOUND_REFERENCE= NO
+
+# If the SHOW_HEADERFILE tag is set to YES then the documentation for a class
+# will show which file needs to be included to use the class.
+# The default value is: YES.
+
+SHOW_HEADERFILE        = YES
 
 # If the SHOW_INCLUDE_FILES tag is set to YES then doxygen will put a list of
 # the files that are included by a file in the documentation of that file.
@@ -529,14 +682,14 @@ INLINE_INFO            = YES
 
 # If the SORT_MEMBER_DOCS tag is set to YES then doxygen will sort the
 # (detailed) documentation of file and class members alphabetically by member
-# name. If set to NO the members will appear in declaration order.
+# name. If set to NO, the members will appear in declaration order.
 # The default value is: YES.
 
 SORT_MEMBER_DOCS       = YES
 
 # If the SORT_BRIEF_DOCS tag is set to YES then doxygen will sort the brief
 # descriptions of file, namespace and class members alphabetically by member
-# name. If set to NO the members will appear in declaration order. Note that
+# name. If set to NO, the members will appear in declaration order. Note that
 # this will also influence the order of the classes in the class list.
 # The default value is: NO.
 
@@ -581,27 +734,25 @@ SORT_BY_SCOPE_NAME     = NO
 
 STRICT_PROTO_MATCHING  = NO
 
-# The GENERATE_TODOLIST tag can be used to enable ( YES) or disable ( NO) the
-# todo list. This list is created by putting \todo commands in the
-# documentation.
+# The GENERATE_TODOLIST tag can be used to enable (YES) or disable (NO) the todo
+# list. This list is created by putting \todo commands in the documentation.
 # The default value is: YES.
 
 GENERATE_TODOLIST      = YES
 
-# The GENERATE_TESTLIST tag can be used to enable ( YES) or disable ( NO) the
-# test list. This list is created by putting \test commands in the
-# documentation.
+# The GENERATE_TESTLIST tag can be used to enable (YES) or disable (NO) the test
+# list. This list is created by putting \test commands in the documentation.
 # The default value is: YES.
 
 GENERATE_TESTLIST      = YES
 
-# The GENERATE_BUGLIST tag can be used to enable ( YES) or disable ( NO) the bug
+# The GENERATE_BUGLIST tag can be used to enable (YES) or disable (NO) the bug
 # list. This list is created by putting \bug commands in the documentation.
 # The default value is: YES.
 
 GENERATE_BUGLIST       = YES
 
-# The GENERATE_DEPRECATEDLIST tag can be used to enable ( YES) or disable ( NO)
+# The GENERATE_DEPRECATEDLIST tag can be used to enable (YES) or disable (NO)
 # the deprecated list. This list is created by putting \deprecated commands in
 # the documentation.
 # The default value is: YES.
@@ -626,8 +777,8 @@ ENABLED_SECTIONS       =
 MAX_INITIALIZER_LINES  = 30
 
 # Set the SHOW_USED_FILES tag to NO to disable the list of files generated at
-# the bottom of the documentation of classes and structs. If set to YES the list
-# will mention the files that were used to generate the documentation.
+# the bottom of the documentation of classes and structs. If set to YES, the
+# list will mention the files that were used to generate the documentation.
 # The default value is: YES.
 
 SHOW_USED_FILES        = YES
@@ -661,7 +812,8 @@ FILE_VERSION_FILTER    =
 # output files in an output format independent way. To create the layout file
 # that represents doxygen's defaults, run doxygen with the -l option. You can
 # optionally specify a file name after the option, if omitted DoxygenLayout.xml
-# will be used as the name of the layout file.
+# will be used as the name of the layout file. See also section "Changing the
+# layout of pages" for information.
 #
 # Note that if you run doxygen from a directory containing a file called
 # DoxygenLayout.xml, doxygen will parse it automatically even if the LAYOUT_FILE
@@ -672,11 +824,10 @@ LAYOUT_FILE            =
 # The CITE_BIB_FILES tag can be used to specify one or more bib files containing
 # the reference definitions. This must be a list of .bib files. The .bib
 # extension is automatically appended if omitted. This requires the bibtex tool
-# to be installed. See also http://en.wikipedia.org/wiki/BibTeX for more info.
+# to be installed. See also https://en.wikipedia.org/wiki/BibTeX for more info.
 # For LaTeX the style of the bibliography can be controlled using
 # LATEX_BIB_STYLE. To use this feature you need bibtex and perl available in the
-# search path. Do not use file names with spaces, bibtex cannot handle them. See
-# also \cite for info how to create references.
+# search path. See also \cite for info how to create references.
 
 CITE_BIB_FILES         =
 
@@ -692,7 +843,7 @@ CITE_BIB_FILES         =
 QUIET                  = NO
 
 # The WARNINGS tag can be used to turn on/off the warning messages that are
-# generated to standard error ( stderr) by doxygen. If WARNINGS is set to YES
+# generated to standard error (stderr) by doxygen. If WARNINGS is set to YES
 # this implies that the warnings are on.
 #
 # Tip: Turn warnings on while writing the documentation.
@@ -700,7 +851,7 @@ QUIET                  = NO
 
 WARNINGS               = YES
 
-# If the WARN_IF_UNDOCUMENTED tag is set to YES, then doxygen will generate
+# If the WARN_IF_UNDOCUMENTED tag is set to YES then doxygen will generate
 # warnings for undocumented members. If EXTRACT_ALL is set to YES then this flag
 # will automatically be disabled.
 # The default value is: YES.
@@ -708,20 +859,53 @@ WARNINGS               = YES
 WARN_IF_UNDOCUMENTED   = YES
 
 # If the WARN_IF_DOC_ERROR tag is set to YES, doxygen will generate warnings for
-# potential errors in the documentation, such as not documenting some parameters
-# in a documented function, or documenting parameters that don't exist or using
-# markup commands wrongly.
+# potential errors in the documentation, such as documenting some parameters in
+# a documented function twice, or documenting parameters that don't exist or
+# using markup commands wrongly.
 # The default value is: YES.
 
 WARN_IF_DOC_ERROR      = YES
 
+# If WARN_IF_INCOMPLETE_DOC is set to YES, doxygen will warn about incomplete
+# function parameter documentation. If set to NO, doxygen will accept that some
+# parameters have no documentation without warning.
+# The default value is: YES.
+
+WARN_IF_INCOMPLETE_DOC = YES
+
 # This WARN_NO_PARAMDOC option can be enabled to get warnings for functions that
 # are documented, but have no documentation for their parameters or return
-# value. If set to NO doxygen will only warn about wrong or incomplete parameter
-# documentation, but not about the absence of documentation.
+# value. If set to NO, doxygen will only warn about wrong parameter
+# documentation, but not about the absence of documentation. If EXTRACT_ALL is
+# set to YES then this flag will automatically be disabled. See also
+# WARN_IF_INCOMPLETE_DOC
 # The default value is: NO.
 
 WARN_NO_PARAMDOC       = NO
+
+# If WARN_IF_UNDOC_ENUM_VAL option is set to YES, doxygen will warn about
+# undocumented enumeration values. If set to NO, doxygen will accept
+# undocumented enumeration values. If EXTRACT_ALL is set to YES then this flag
+# will automatically be disabled.
+# The default value is: NO.
+
+WARN_IF_UNDOC_ENUM_VAL = NO
+
+# If the WARN_AS_ERROR tag is set to YES then doxygen will immediately stop when
+# a warning is encountered. If the WARN_AS_ERROR tag is set to FAIL_ON_WARNINGS
+# then doxygen will continue running as if WARN_AS_ERROR tag is set to NO, but
+# at the end of the doxygen process doxygen will return with a non-zero status.
+# If the WARN_AS_ERROR tag is set to FAIL_ON_WARNINGS_PRINT then doxygen behaves
+# like FAIL_ON_WARNINGS but in case no WARN_LOGFILE is defined doxygen will not
+# write the warning messages in between other messages but write them at the end
+# of a run, in case a WARN_LOGFILE is defined the warning messages will be
+# besides being in the defined file also be shown at the end of a run, unless
+# the WARN_LOGFILE is defined as - i.e. standard output (stdout) in that case
+# the behavior will remain as with the setting FAIL_ON_WARNINGS.
+# Possible values are: NO, YES, FAIL_ON_WARNINGS and FAIL_ON_WARNINGS_PRINT.
+# The default value is: NO.
+
+WARN_AS_ERROR          = NO
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which
@@ -729,13 +913,27 @@ WARN_NO_PARAMDOC       = NO
 # and the warning text. Optionally the format may contain $version, which will
 # be replaced by the version of the file (if it could be obtained via
 # FILE_VERSION_FILTER)
+# See also: WARN_LINE_FORMAT
 # The default value is: $file:$line: $text.
 
 WARN_FORMAT            = "$file:$line: $text"
 
+# In the $text part of the WARN_FORMAT command it is possible that a reference
+# to a more specific place is given. To make it easier to jump to this place
+# (outside of doxygen) the user can define a custom "cut" / "paste" string.
+# Example:
+# WARN_LINE_FORMAT = "'vi $file +$line'"
+# See also: WARN_FORMAT
+# The default value is: at line $line of file $file.
+
+WARN_LINE_FORMAT       = "at line $line of file $file"
+
 # The WARN_LOGFILE tag can be used to specify a file to which warning and error
 # messages should be written. If left blank the output is written to standard
-# error (stderr).
+# error (stderr). In case the file specified cannot be opened for writing the
+# warning and error messages are written to standard error. When as file - is
+# specified the warning and error messages are written to standard output
+# (stdout).
 
 WARN_LOGFILE           = @PROJECT_BINARY_DIR@/doxygen-warnings.log
 
@@ -746,7 +944,7 @@ WARN_LOGFILE           = @PROJECT_BINARY_DIR@/doxygen-warnings.log
 # The INPUT tag is used to specify the files and/or directories that contain
 # documented source files. You may enter file names like myfile.cpp or
 # directories like /usr/src/myproject. Separate the files or directories with
-# spaces.
+# spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = @PROJECT_SOURCE_DIR@/edm4hep \
@@ -758,27 +956,60 @@ INPUT                  = @PROJECT_SOURCE_DIR@/edm4hep \
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
 # libiconv (or the iconv built into libc) for the transcoding. See the libiconv
-# documentation (see: http://www.gnu.org/software/libiconv) for the list of
-# possible encodings.
+# documentation (see:
+# https://www.gnu.org/software/libiconv/) for the list of possible encodings.
+# See also: INPUT_FILE_ENCODING
 # The default value is: UTF-8.
 
 INPUT_ENCODING         = UTF-8
 
+# This tag can be used to specify the character encoding of the source files
+# that doxygen parses The INPUT_FILE_ENCODING tag can be used to specify
+# character encoding on a per file pattern basis. Doxygen will compare the file
+# name with each pattern and apply the encoding instead of the default
+# INPUT_ENCODING) if there is a match. The character encodings are a list of the
+# form: pattern=encoding (like *.php=ISO-8859-1).
+# See also: INPUT_ENCODING for further information on supported encodings.
+
+INPUT_FILE_ENCODING    =
+
 # If the value of the INPUT tag contains directories, you can use the
 # FILE_PATTERNS tag to specify one or more wildcard patterns (like *.cpp and
-# *.h) to filter out the source-files in the directories. If left blank the
-# following patterns are tested:*.c, *.cc, *.cxx, *.cpp, *.c++, *.java, *.ii,
-# *.ixx, *.ipp, *.i++, *.inl, *.idl, *.ddl, *.odl, *.h, *.hh, *.hxx, *.hpp,
-# *.h++, *.cs, *.d, *.php, *.php4, *.php5, *.phtml, *.inc, *.m, *.markdown,
-# *.md, *.mm, *.dox, *.py, *.f90, *.f, *.for, *.tcl, *.vhd, *.vhdl, *.ucf,
-# *.qsf, *.as and *.js.
+# *.h) to filter out the source-files in the directories.
+#
+# Note that for custom extensions or not directly supported extensions you also
+# need to set EXTENSION_MAPPING for the extension otherwise the files are not
+# read by doxygen.
+#
+# Note the list of default checked file patterns might differ from the list of
+# default file extension mappings.
+#
+# If left blank the following patterns are tested:*.c, *.cc, *.cxx, *.cxxm,
+# *.cpp, *.cppm, *.ccm, *.c++, *.c++m, *.java, *.ii, *.ixx, *.ipp, *.i++, *.inl,
+# *.idl, *.ddl, *.odl, *.h, *.hh, *.hxx, *.hpp, *.h++, *.ixx, *.l, *.cs, *.d,
+# *.php, *.php4, *.php5, *.phtml, *.inc, *.m, *.markdown, *.md, *.mm, *.dox (to
+# be provided as doxygen C comment), *.py, *.pyw, *.f90, *.f95, *.f03, *.f08,
+# *.f18, *.f, *.for, *.vhd, *.vhdl, *.ucf, *.qsf and *.ice.
 
-FILE_PATTERNS          = *.c *.cc *.cxx *.cpp *.c++
-FILE_PATTERNS         += *.inl *.icpp *.icc
-FILE_PATTERNS         += *.h *.hh *.hxx *.hpp *.h++
-FILE_PATTERNS         += *.py
-FILE_PATTERNS         += *.f90 *.f *.for
-FILE_PATTERNS         += *.dox *.md
+FILE_PATTERNS          = *.c \
+                         *.cc \
+                         *.cxx \
+                         *.cpp \
+                         *.c++ \
+                         *.inl \
+                         *.icpp \
+                         *.icc \
+                         *.h \
+                         *.hh \
+                         *.hxx \
+                         *.hpp \
+                         *.h++ \
+                         *.py \
+                         *.f90 \
+                         *.f \
+                         *.for \
+                         *.dox \
+                         *.md
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.
@@ -793,7 +1024,8 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = @PROJECT_BINARY_DIR@ @CMAKE_INSTALL_PREFIX@
+EXCLUDE                = @PROJECT_BINARY_DIR@ \
+                         @CMAKE_INSTALL_PREFIX@
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
@@ -809,18 +1041,19 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       = */podio/* */test/* */tests/*
-EXCLUDE_PATTERNS      += */dict/* */cmake/* */scripts/*
-EXCLUDE_PATTERNS      += */edm4hep/src/*
+EXCLUDE_PATTERNS       = */podio/* \
+                         */test/* \
+                         */tests/* \
+                         */dict/* \
+                         */cmake/* \
+                         */scripts/* \
+                         */edm4hep/src/*
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the
 # output. The symbol name can be a fully qualified name, a word, or if the
 # wildcard * is used, a substring. Examples: ANamespace, AClass,
-# AClass::ANamespace, ANamespace::*Test
-#
-# Note that the wildcards are matched against the file with absolute path, so to
-# exclude all test directories use the pattern */test/*
+# ANamespace::AClass, ANamespace::*Test
 
 EXCLUDE_SYMBOLS        = podio
 
@@ -864,6 +1097,15 @@ IMAGE_PATH             = @PROJECT_SOURCE_DIR@
 # Note that the filter must not add or remove lines; it is applied before the
 # code is scanned, but not when the output code is generated. If lines are added
 # or removed, the anchors will not be placed correctly.
+#
+# Note that doxygen will use the data processed and written to standard output
+# for further processing, therefore nothing else, like debug statements or used
+# commands (so in case of a Windows batch file always use @echo OFF), should be
+# written to standard output.
+#
+# Note that for custom extensions or not directly supported extensions you also
+# need to set EXTENSION_MAPPING for the extension otherwise the files are not
+# properly processed by doxygen.
 
 INPUT_FILTER           =
 
@@ -873,11 +1115,15 @@ INPUT_FILTER           =
 # (like *.cpp=my_cpp_filter). See INPUT_FILTER for further information on how
 # filters are used. If the FILTER_PATTERNS tag is empty or if none of the
 # patterns match the file name, INPUT_FILTER is applied.
+#
+# Note that for custom extensions or not directly supported extensions you also
+# need to set EXTENSION_MAPPING for the extension otherwise the files are not
+# properly processed by doxygen.
 
 FILTER_PATTERNS        =
 
 # If the FILTER_SOURCE_FILES tag is set to YES, the input filter (if set using
-# INPUT_FILTER ) will also be used to filter the input files that are used for
+# INPUT_FILTER) will also be used to filter the input files that are used for
 # producing the source files to browse (i.e. when SOURCE_BROWSER is set to YES).
 # The default value is: NO.
 
@@ -898,6 +1144,15 @@ FILTER_SOURCE_PATTERNS =
 
 USE_MDFILE_AS_MAINPAGE = README.md
 
+# The Fortran standard specifies that for fixed formatted Fortran code all
+# characters from position 72 are to be considered as comment. A common
+# extension is to allow longer lines before the automatic comment starts. The
+# setting FORTRAN_COMMENT_AFTER will also make it possible that longer lines can
+# be processed before the automatic comment starts.
+# Minimum value: 7, maximum value: 10000, default value: 72.
+
+FORTRAN_COMMENT_AFTER  = 72
+
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing
 #---------------------------------------------------------------------------
@@ -912,7 +1167,8 @@ USE_MDFILE_AS_MAINPAGE = README.md
 SOURCE_BROWSER         = NO
 
 # Setting the INLINE_SOURCES tag to YES will include the body of functions,
-# classes and enums directly into the documentation.
+# multi-line macros, enums or list initialized variables directly into the
+# documentation.
 # The default value is: NO.
 
 INLINE_SOURCES         = NO
@@ -925,7 +1181,7 @@ INLINE_SOURCES         = NO
 STRIP_CODE_COMMENTS    = YES
 
 # If the REFERENCED_BY_RELATION tag is set to YES then for each documented
-# function all documented functions referencing it will be listed.
+# entity all documented functions referencing it will be listed.
 # The default value is: NO.
 
 REFERENCED_BY_RELATION = NO
@@ -937,7 +1193,7 @@ REFERENCED_BY_RELATION = NO
 REFERENCES_RELATION    = NO
 
 # If the REFERENCES_LINK_SOURCE tag is set to YES and SOURCE_BROWSER tag is set
-# to YES, then the hyperlinks from functions in REFERENCES_RELATION and
+# to YES then the hyperlinks from functions in REFERENCES_RELATION and
 # REFERENCED_BY_RELATION lists will link to the source code. Otherwise they will
 # link to the documentation.
 # The default value is: YES.
@@ -957,12 +1213,12 @@ SOURCE_TOOLTIPS        = YES
 # If the USE_HTAGS tag is set to YES then the references to source code will
 # point to the HTML generated by the htags(1) tool instead of doxygen built-in
 # source browser. The htags tool is part of GNU's global source tagging system
-# (see http://www.gnu.org/software/global/global.html). You will need version
+# (see https://www.gnu.org/software/global/global.html). You will need version
 # 4.8.6 or higher.
 #
 # To use it do the following:
 # - Install the latest version of global
-# - Enable SOURCE_BROWSER and USE_HTAGS in the config file
+# - Enable SOURCE_BROWSER and USE_HTAGS in the configuration file
 # - Make sure the INPUT points to the root of the source tree
 # - Run doxygen as normal
 #
@@ -995,17 +1251,11 @@ VERBATIM_HEADERS       = YES
 
 ALPHABETICAL_INDEX     = YES
 
-# The COLS_IN_ALPHA_INDEX tag can be used to specify the number of columns in
-# which the alphabetical index list will be split.
-# Minimum value: 1, maximum value: 20, default value: 5.
-# This tag requires that the tag ALPHABETICAL_INDEX is set to YES.
-
-COLS_IN_ALPHA_INDEX    = 3
-
-# In case all classes in a project start with a common prefix, all classes will
-# be put under the same header in the alphabetical index. The IGNORE_PREFIX tag
-# can be used to specify a prefix (or a list of prefixes) that should be ignored
-# while generating the index headers.
+# The IGNORE_PREFIX tag can be used to specify a prefix (or a list of prefixes)
+# that should be ignored while generating the index headers. The IGNORE_PREFIX
+# tag works for classes, function and member names. The entity will be placed in
+# the alphabetical list under the first letter of the entity name that remains
+# after removing the prefix.
 # This tag requires that the tag ALPHABETICAL_INDEX is set to YES.
 
 IGNORE_PREFIX          =
@@ -1014,7 +1264,7 @@ IGNORE_PREFIX          =
 # Configuration options related to the HTML output
 #---------------------------------------------------------------------------
 
-# If the GENERATE_HTML tag is set to YES doxygen will generate HTML output
+# If the GENERATE_HTML tag is set to YES, doxygen will generate HTML output
 # The default value is: YES.
 
 GENERATE_HTML          = YES
@@ -1076,13 +1326,20 @@ HTML_FOOTER            = @CMAKE_CURRENT_SOURCE_DIR@/doc/edm4hep_footer.html
 
 HTML_STYLESHEET        =
 
-# The HTML_EXTRA_STYLESHEET tag can be used to specify an additional user-
-# defined cascading style sheet that is included after the standard style sheets
+# The HTML_EXTRA_STYLESHEET tag can be used to specify additional user-defined
+# cascading style sheets that are included after the standard style sheets
 # created by doxygen. Using this option one can overrule certain style aspects.
 # This is preferred over using HTML_STYLESHEET since it does not replace the
-# standard style sheet and is therefor more robust against future updates.
-# Doxygen will copy the style sheet file to the output directory. For an example
-# see the documentation.
+# standard style sheet and is therefore more robust against future updates.
+# Doxygen will copy the style sheet files to the output directory.
+# Note: The order of the extra style sheet files is of importance (e.g. the last
+# style sheet in the list overrules the setting of the previous ones in the
+# list).
+# Note: Since the styling of scrollbars can currently not be overruled in
+# Webkit/Chromium, the styling will be left out of the default doxygen.css if
+# one or more extra stylesheets have been specified. So if scrollbar
+# customization is desired it has to be added explicitly. For an example see the
+# documentation.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
 HTML_EXTRA_STYLESHEET  = @CMAKE_CURRENT_SOURCE_DIR@/doc/edm4hep_stylesheet.css
@@ -1097,10 +1354,23 @@ HTML_EXTRA_STYLESHEET  = @CMAKE_CURRENT_SOURCE_DIR@/doc/edm4hep_stylesheet.css
 
 HTML_EXTRA_FILES       = @DOXYGEN_HTML_EXTRA_FILES@
 
+# The HTML_COLORSTYLE tag can be used to specify if the generated HTML output
+# should be rendered with a dark or light theme.
+# Possible values are: LIGHT always generates light mode output, DARK always
+# generates dark mode output, AUTO_LIGHT automatically sets the mode according
+# to the user preference, uses light mode if no preference is set (the default),
+# AUTO_DARK automatically sets the mode according to the user preference, uses
+# dark mode if no preference is set and TOGGLE allows a user to switch between
+# light and dark mode via a button.
+# The default value is: AUTO_LIGHT.
+# This tag requires that the tag GENERATE_HTML is set to YES.
+
+HTML_COLORSTYLE        = AUTO_LIGHT
+
 # The HTML_COLORSTYLE_HUE tag controls the color of the HTML output. Doxygen
-# will adjust the colors in the stylesheet and background images according to
-# this color. Hue is specified as an angle on a colorwheel, see
-# http://en.wikipedia.org/wiki/Hue for more information. For instance the value
+# will adjust the colors in the style sheet and background images according to
+# this color. Hue is specified as an angle on a color-wheel, see
+# https://en.wikipedia.org/wiki/Hue for more information. For instance the value
 # 0 represents red, 60 is yellow, 120 is green, 180 is cyan, 240 is blue, 300
 # purple, and 360 is red again.
 # Minimum value: 0, maximum value: 359, default value: 220.
@@ -1109,7 +1379,7 @@ HTML_EXTRA_FILES       = @DOXYGEN_HTML_EXTRA_FILES@
 HTML_COLORSTYLE_HUE    = 220
 
 # The HTML_COLORSTYLE_SAT tag controls the purity (or saturation) of the colors
-# in the HTML output. For a value of 0 the output will use grayscales only. A
+# in the HTML output. For a value of 0 the output will use gray-scales only. A
 # value of 255 will produce the most vivid colors.
 # Minimum value: 0, maximum value: 255, default value: 100.
 # This tag requires that the tag GENERATE_HTML is set to YES.
@@ -1127,13 +1397,16 @@ HTML_COLORSTYLE_SAT    = 30
 
 HTML_COLORSTYLE_GAMMA  = 106
 
-# If the HTML_TIMESTAMP tag is set to YES then the footer of each generated HTML
-# page will contain the date and time when the page was generated. Setting this
-# to NO can help when comparing the output of multiple runs.
+# If the HTML_DYNAMIC_MENUS tag is set to YES then the generated HTML
+# documentation will contain a main index with vertical navigation menus that
+# are dynamically created via JavaScript. If disabled, the navigation index will
+# consists of multiple levels of tabs that are statically embedded in every HTML
+# page. Disable this option to support browsers that do not have JavaScript,
+# like the Qt help browser.
 # The default value is: YES.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_TIMESTAMP         = YES
+HTML_DYNAMIC_MENUS     = YES
 
 # If the HTML_DYNAMIC_SECTIONS tag is set to YES then the generated HTML
 # documentation will contain sections that can be hidden and shown after the
@@ -1142,6 +1415,33 @@ HTML_TIMESTAMP         = YES
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
 HTML_DYNAMIC_SECTIONS  = NO
+
+# If the HTML_CODE_FOLDING tag is set to YES then classes and functions can be
+# dynamically folded and expanded in the generated HTML source code.
+# The default value is: YES.
+# This tag requires that the tag GENERATE_HTML is set to YES.
+
+HTML_CODE_FOLDING      = YES
+
+# If the HTML_COPY_CLIPBOARD tag is set to YES then doxygen will show an icon in
+# the top right corner of code and text fragments that allows the user to copy
+# its content to the clipboard. Note this only works if supported by the browser
+# and the web page is served via a secure context (see:
+# https://www.w3.org/TR/secure-contexts/), i.e. using the https: or file:
+# protocol.
+# The default value is: YES.
+# This tag requires that the tag GENERATE_HTML is set to YES.
+
+HTML_COPY_CLIPBOARD    = YES
+
+# Doxygen stores a couple of settings persistently in the browser (via e.g.
+# cookies). By default these settings apply to all HTML pages generated by
+# doxygen across all projects. The HTML_PROJECT_COOKIE tag can be used to store
+# the settings under a project specific key, such that the user preferences will
+# be stored separately.
+# This tag requires that the tag GENERATE_HTML is set to YES.
+
+HTML_PROJECT_COOKIE    =
 
 # With HTML_INDEX_NUM_ENTRIES one can control the preferred number of entries
 # shown in the various tree structured indices initially; the user can expand
@@ -1158,13 +1458,14 @@ HTML_INDEX_NUM_ENTRIES = 100
 
 # If the GENERATE_DOCSET tag is set to YES, additional index files will be
 # generated that can be used as input for Apple's Xcode 3 integrated development
-# environment (see: http://developer.apple.com/tools/xcode/), introduced with
-# OSX 10.5 (Leopard). To create a documentation set, doxygen will generate a
-# Makefile in the HTML output directory. Running make will produce the docset in
-# that directory and running make install will install the docset in
+# environment (see:
+# https://developer.apple.com/xcode/), introduced with OSX 10.5 (Leopard). To
+# create a documentation set, doxygen will generate a Makefile in the HTML
+# output directory. Running make will produce the docset in that directory and
+# running make install will install the docset in
 # ~/Library/Developer/Shared/Documentation/DocSets so that Xcode will find it at
-# startup. See http://developer.apple.com/tools/creatingdocsetswithdoxygen.html
-# for more information.
+# startup. See https://developer.apple.com/library/archive/featuredarticles/Doxy
+# genXcode/_index.html for more information.
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
@@ -1177,6 +1478,13 @@ GENERATE_DOCSET        = NO
 # This tag requires that the tag GENERATE_DOCSET is set to YES.
 
 DOCSET_FEEDNAME        = "Doxygen generated docs"
+
+# This tag determines the URL of the docset feed. A documentation feed provides
+# an umbrella under which multiple documentation sets from a single provider
+# (such as a company or product suite) can be grouped.
+# This tag requires that the tag GENERATE_DOCSET is set to YES.
+
+DOCSET_FEEDURL         =
 
 # This tag specifies a string that should uniquely identify the documentation
 # set bundle. This should be a reverse domain-name style string, e.g.
@@ -1203,8 +1511,12 @@ DOCSET_PUBLISHER_NAME  = Publisher
 # If the GENERATE_HTMLHELP tag is set to YES then doxygen generates three
 # additional HTML index files: index.hhp, index.hhc, and index.hhk. The
 # index.hhp is a project file that can be read by Microsoft's HTML Help Workshop
-# (see: http://www.microsoft.com/en-us/download/details.aspx?id=21138) on
-# Windows.
+# on Windows. In the beginning of 2021 Microsoft took the original page, with
+# a.o. the download links, offline the HTML help workshop was already many years
+# in maintenance mode). You can download the HTML help workshop from the web
+# archives at Installation executable (see:
+# http://web.archive.org/web/20160201063255/http://download.microsoft.com/downlo
+# ad/0/A/9/0A939EF6-E31C-430F-A3DF-DFAE7960D564/htmlhelp.exe).
 #
 # The HTML Help Workshop contains a compiler that can convert all HTML output
 # generated by doxygen into a single compiled HTML file (.chm). Compiled HTML
@@ -1226,28 +1538,29 @@ GENERATE_HTMLHELP      = NO
 CHM_FILE               =
 
 # The HHC_LOCATION tag can be used to specify the location (absolute path
-# including file name) of the HTML help compiler ( hhc.exe). If non-empty
+# including file name) of the HTML help compiler (hhc.exe). If non-empty,
 # doxygen will try to run the HTML help compiler on the generated index.hhp.
 # The file has to be specified with full path.
 # This tag requires that the tag GENERATE_HTMLHELP is set to YES.
 
 HHC_LOCATION           =
 
-# The GENERATE_CHI flag controls if a separate .chi index file is generated (
-# YES) or that it should be included in the master .chm file ( NO).
+# The GENERATE_CHI flag controls if a separate .chi index file is generated
+# (YES) or that it should be included in the main .chm file (NO).
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTMLHELP is set to YES.
 
 GENERATE_CHI           = NO
 
-# The CHM_INDEX_ENCODING is used to encode HtmlHelp index ( hhk), content ( hhc)
+# The CHM_INDEX_ENCODING is used to encode HtmlHelp index (hhk), content (hhc)
 # and project file content.
 # This tag requires that the tag GENERATE_HTMLHELP is set to YES.
 
 CHM_INDEX_ENCODING     =
 
-# The BINARY_TOC flag controls whether a binary table of contents is generated (
-# YES) or a normal table of contents ( NO) in the .chm file.
+# The BINARY_TOC flag controls whether a binary table of contents is generated
+# (YES) or a normal table of contents (NO) in the .chm file. Furthermore it
+# enables the Previous and Next buttons.
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTMLHELP is set to YES.
 
@@ -1259,6 +1572,16 @@ BINARY_TOC             = NO
 # This tag requires that the tag GENERATE_HTMLHELP is set to YES.
 
 TOC_EXPAND             = NO
+
+# The SITEMAP_URL tag is used to specify the full URL of the place where the
+# generated documentation will be placed on the server by the user during the
+# deployment of the documentation. The generated sitemap is called sitemap.xml
+# and placed on the directory specified by HTML_OUTPUT. In case no SITEMAP_URL
+# is specified no sitemap is generated. For information about the sitemap
+# protocol see https://www.sitemaps.org
+# This tag requires that the tag GENERATE_HTML is set to YES.
+
+SITEMAP_URL            =
 
 # If the GENERATE_QHP tag is set to YES and both QHP_NAMESPACE and
 # QHP_VIRTUAL_FOLDER are set, an additional index file will be generated that
@@ -1278,7 +1601,8 @@ QCH_FILE               =
 
 # The QHP_NAMESPACE tag specifies the namespace to use when generating Qt Help
 # Project output. For more information please see Qt Help Project / Namespace
-# (see: http://qt-project.org/doc/qt-4.8/qthelpproject.html#namespace).
+# (see:
+# https://doc.qt.io/archives/qt-4.8/qthelpproject.html#namespace).
 # The default value is: org.doxygen.Project.
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
@@ -1286,8 +1610,8 @@ QHP_NAMESPACE          = org.doxygen.Project
 
 # The QHP_VIRTUAL_FOLDER tag specifies the namespace to use when generating Qt
 # Help Project output. For more information please see Qt Help Project / Virtual
-# Folders (see: http://qt-project.org/doc/qt-4.8/qthelpproject.html#virtual-
-# folders).
+# Folders (see:
+# https://doc.qt.io/archives/qt-4.8/qthelpproject.html#virtual-folders).
 # The default value is: doc.
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
@@ -1295,30 +1619,30 @@ QHP_VIRTUAL_FOLDER     = doc
 
 # If the QHP_CUST_FILTER_NAME tag is set, it specifies the name of a custom
 # filter to add. For more information please see Qt Help Project / Custom
-# Filters (see: http://qt-project.org/doc/qt-4.8/qthelpproject.html#custom-
-# filters).
+# Filters (see:
+# https://doc.qt.io/archives/qt-4.8/qthelpproject.html#custom-filters).
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
 QHP_CUST_FILTER_NAME   =
 
 # The QHP_CUST_FILTER_ATTRS tag specifies the list of the attributes of the
 # custom filter to add. For more information please see Qt Help Project / Custom
-# Filters (see: http://qt-project.org/doc/qt-4.8/qthelpproject.html#custom-
-# filters).
+# Filters (see:
+# https://doc.qt.io/archives/qt-4.8/qthelpproject.html#custom-filters).
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
 QHP_CUST_FILTER_ATTRS  =
 
 # The QHP_SECT_FILTER_ATTRS tag specifies the list of the attributes this
 # project's filter section matches. Qt Help Project / Filter Attributes (see:
-# http://qt-project.org/doc/qt-4.8/qthelpproject.html#filter-attributes).
+# https://doc.qt.io/archives/qt-4.8/qthelpproject.html#filter-attributes).
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
 QHP_SECT_FILTER_ATTRS  =
 
-# The QHG_LOCATION tag can be used to specify the location of Qt's
-# qhelpgenerator. If non-empty doxygen will try to run qhelpgenerator on the
-# generated .qhp file.
+# The QHG_LOCATION tag can be used to specify the location (absolute path
+# including file name) of Qt's qhelpgenerator. If non-empty doxygen will try to
+# run qhelpgenerator on the generated .qhp file.
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
 QHG_LOCATION           =
@@ -1360,16 +1684,28 @@ DISABLE_INDEX          = NO
 # index structure (just like the one that is generated for HTML Help). For this
 # to work a browser that supports JavaScript, DHTML, CSS and frames is required
 # (i.e. any modern browser). Windows users are probably better off using the
-# HTML help feature. Via custom stylesheets (see HTML_EXTRA_STYLESHEET) one can
-# further fine-tune the look of the index. As an example, the default style
-# sheet generated by doxygen has an example that shows how to put an image at
-# the root of the tree instead of the PROJECT_NAME. Since the tree basically has
-# the same information as the tab index, you could consider setting
-# DISABLE_INDEX to YES when enabling this option.
+# HTML help feature. Via custom style sheets (see HTML_EXTRA_STYLESHEET) one can
+# further fine tune the look of the index (see "Fine-tuning the output"). As an
+# example, the default style sheet generated by doxygen has an example that
+# shows how to put an image at the root of the tree instead of the PROJECT_NAME.
+# Since the tree basically has the same information as the tab index, you could
+# consider setting DISABLE_INDEX to YES when enabling this option.
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
 GENERATE_TREEVIEW      = NO
+
+# When both GENERATE_TREEVIEW and DISABLE_INDEX are set to YES, then the
+# FULL_SIDEBAR option determines if the side bar is limited to only the treeview
+# area (value NO) or if it should extend to the full height of the window (value
+# YES). Setting this to YES gives a layout similar to
+# https://docs.readthedocs.io with more room for contents, but less room for the
+# project logo, title, and description. If either GENERATE_TREEVIEW or
+# DISABLE_INDEX is set to NO, this option has no effect.
+# The default value is: NO.
+# This tag requires that the tag GENERATE_HTML is set to YES.
+
+FULL_SIDEBAR           = NO
 
 # The ENUM_VALUES_PER_LINE tag can be used to set the number of enum values that
 # doxygen will group on one line in the generated HTML documentation.
@@ -1388,12 +1724,30 @@ ENUM_VALUES_PER_LINE   = 4
 
 TREEVIEW_WIDTH         = 250
 
-# When the EXT_LINKS_IN_WINDOW option is set to YES doxygen will open links to
+# If the EXT_LINKS_IN_WINDOW option is set to YES, doxygen will open links to
 # external symbols imported via tag files in a separate window.
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
 EXT_LINKS_IN_WINDOW    = NO
+
+# If the OBFUSCATE_EMAILS tag is set to YES, doxygen will obfuscate email
+# addresses.
+# The default value is: YES.
+# This tag requires that the tag GENERATE_HTML is set to YES.
+
+OBFUSCATE_EMAILS       = YES
+
+# If the HTML_FORMULA_FORMAT option is set to svg, doxygen will use the pdf2svg
+# tool (see https://github.com/dawbarton/pdf2svg) or inkscape (see
+# https://inkscape.org) to generate formulas as SVG images instead of PNGs for
+# the HTML output. These images will generally look nicer at scaled resolutions.
+# Possible values are: png (the default) and svg (looks nicer but requires the
+# pdf2svg or inkscape tool).
+# The default value is: png.
+# This tag requires that the tag GENERATE_HTML is set to YES.
+
+HTML_FORMULA_FORMAT    = png
 
 # Use this tag to change the font size of LaTeX formulas included as images in
 # the HTML documentation. When you change the font size after a successful
@@ -1404,20 +1758,15 @@ EXT_LINKS_IN_WINDOW    = NO
 
 FORMULA_FONTSIZE       = 10
 
-# Use the FORMULA_TRANPARENT tag to determine whether or not the images
-# generated for formulas are transparent PNGs. Transparent PNGs are not
-# supported properly for IE 6.0, but are supported on all modern browsers.
-#
-# Note that when changing this option you need to delete any form_*.png files in
-# the HTML output directory before the changes have effect.
-# The default value is: YES.
-# This tag requires that the tag GENERATE_HTML is set to YES.
+# The FORMULA_MACROFILE can contain LaTeX \newcommand and \renewcommand commands
+# to create new LaTeX commands to be used in formulas as building blocks. See
+# the section "Including formulas" for details.
 
-FORMULA_TRANSPARENT    = YES
+FORMULA_MACROFILE      =
 
 # Enable the USE_MATHJAX option to render LaTeX formulas using MathJax (see
-# http://www.mathjax.org) which uses client side Javascript for the rendering
-# instead of using prerendered bitmaps. Use this if you do not have LaTeX
+# https://www.mathjax.org) which uses client side JavaScript for the rendering
+# instead of using pre-rendered bitmaps. Use this if you do not have LaTeX
 # installed or if you want to formulas look prettier in the HTML output. When
 # enabled you may also need to install MathJax separately and configure the path
 # to it using the MATHJAX_RELPATH option.
@@ -1426,11 +1775,29 @@ FORMULA_TRANSPARENT    = YES
 
 USE_MATHJAX            = YES
 
+# With MATHJAX_VERSION it is possible to specify the MathJax version to be used.
+# Note that the different versions of MathJax have different requirements with
+# regards to the different settings, so it is possible that also other MathJax
+# settings have to be changed when switching between the different MathJax
+# versions.
+# Possible values are: MathJax_2 and MathJax_3.
+# The default value is: MathJax_2.
+# This tag requires that the tag USE_MATHJAX is set to YES.
+
+MATHJAX_VERSION        = MathJax_2
+
 # When MathJax is enabled you can set the default output format to be used for
-# the MathJax output. See the MathJax site (see:
-# http://docs.mathjax.org/en/latest/output.html) for more details.
+# the MathJax output. For more details about the output format see MathJax
+# version 2 (see:
+# http://docs.mathjax.org/en/v2.7-latest/output.html) and MathJax version 3
+# (see:
+# http://docs.mathjax.org/en/latest/web/components/output.html).
 # Possible values are: HTML-CSS (which is slower, but has the best
-# compatibility), NativeMML (i.e. MathML) and SVG.
+# compatibility. This is the name for Mathjax version 2, for MathJax version 3
+# this will be translated into chtml), NativeMML (i.e. MathML. Only supported
+# for MathJax 2. For MathJax version 3 chtml will be used instead.), chtml (This
+# is the name for Mathjax version 3, for MathJax version 2 this will be
+# translated into HTML-CSS) and SVG.
 # The default value is: HTML-CSS.
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
@@ -1443,22 +1810,29 @@ MATHJAX_FORMAT         = HTML-CSS
 # MATHJAX_RELPATH should be ../mathjax. The default value points to the MathJax
 # Content Delivery Network so you can quickly see the result without installing
 # MathJax. However, it is strongly recommended to install a local copy of
-# MathJax from http://www.mathjax.org before deployment.
-# The default value is: http://cdn.mathjax.org/mathjax/latest.
+# MathJax from https://www.mathjax.org before deployment. The default value is:
+# - in case of MathJax version 2: https://cdn.jsdelivr.net/npm/mathjax@2
+# - in case of MathJax version 3: https://cdn.jsdelivr.net/npm/mathjax@3
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
 MATHJAX_RELPATH        = @MATHJAX_RELPATH@
 
 # The MATHJAX_EXTENSIONS tag can be used to specify one or more MathJax
 # extension names that should be enabled during MathJax rendering. For example
+# for MathJax version 2 (see
+# https://docs.mathjax.org/en/v2.7-latest/tex.html#tex-and-latex-extensions):
 # MATHJAX_EXTENSIONS = TeX/AMSmath TeX/AMSsymbols
+# For example for MathJax version 3 (see
+# http://docs.mathjax.org/en/latest/input/tex/extensions/index.html):
+# MATHJAX_EXTENSIONS = ams
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
 MATHJAX_EXTENSIONS     =
 
 # The MATHJAX_CODEFILE tag can be used to specify a file with javascript pieces
 # of code that will be used on startup of the MathJax code. See the MathJax site
-# (see: http://docs.mathjax.org/en/latest/output.html) for more details. For an
+# (see:
+# http://docs.mathjax.org/en/v2.7-latest/output.html) for more details. For an
 # example see the documentation.
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
@@ -1486,12 +1860,12 @@ MATHJAX_CODEFILE       =
 SEARCHENGINE           = YES
 
 # When the SERVER_BASED_SEARCH tag is enabled the search engine will be
-# implemented using a web server instead of a web client using Javascript. There
-# are two flavours of web server based searching depending on the
-# EXTERNAL_SEARCH setting. When disabled, doxygen will generate a PHP script for
-# searching and an index file used by the script. When EXTERNAL_SEARCH is
-# enabled the indexing and searching needs to be provided by external tools. See
-# the section "External Indexing and Searching" for details.
+# implemented using a web server instead of a web client using JavaScript. There
+# are two flavors of web server based searching depending on the EXTERNAL_SEARCH
+# setting. When disabled, doxygen will generate a PHP script for searching and
+# an index file used by the script. When EXTERNAL_SEARCH is enabled the indexing
+# and searching needs to be provided by external tools. See the section
+# "External Indexing and Searching" for details.
 # The default value is: NO.
 # This tag requires that the tag SEARCHENGINE is set to YES.
 
@@ -1503,9 +1877,10 @@ SERVER_BASED_SEARCH    = NO
 # external search engine pointed to by the SEARCHENGINE_URL option to obtain the
 # search results.
 #
-# Doxygen ships with an example indexer ( doxyindexer) and search engine
+# Doxygen ships with an example indexer (doxyindexer) and search engine
 # (doxysearch.cgi) which are based on the open source search engine library
-# Xapian (see: http://xapian.org/).
+# Xapian (see:
+# https://xapian.org/).
 #
 # See the section "External Indexing and Searching" for details.
 # The default value is: NO.
@@ -1516,10 +1891,11 @@ EXTERNAL_SEARCH        = NO
 # The SEARCHENGINE_URL should point to a search engine hosted by a web server
 # which will return the search results when EXTERNAL_SEARCH is enabled.
 #
-# Doxygen ships with an example indexer ( doxyindexer) and search engine
+# Doxygen ships with an example indexer (doxyindexer) and search engine
 # (doxysearch.cgi) which are based on the open source search engine library
-# Xapian (see: http://xapian.org/). See the section "External Indexing and
-# Searching" for details.
+# Xapian (see:
+# https://xapian.org/). See the section "External Indexing and Searching" for
+# details.
 # This tag requires that the tag SEARCHENGINE is set to YES.
 
 SEARCHENGINE_URL       =
@@ -1554,7 +1930,7 @@ EXTRA_SEARCH_MAPPINGS  =
 # Configuration options related to the LaTeX output
 #---------------------------------------------------------------------------
 
-# If the GENERATE_LATEX tag is set to YES doxygen will generate LaTeX output.
+# If the GENERATE_LATEX tag is set to YES, doxygen will generate LaTeX output.
 # The default value is: YES.
 
 GENERATE_LATEX         = NO
@@ -1570,22 +1946,36 @@ LATEX_OUTPUT           = latex
 # The LATEX_CMD_NAME tag can be used to specify the LaTeX command name to be
 # invoked.
 #
-# Note that when enabling USE_PDFLATEX this option is only used for generating
-# bitmaps for formulas in the HTML output, but not in the Makefile that is
-# written to the output directory.
-# The default file is: latex.
+# Note that when not enabling USE_PDFLATEX the default is latex when enabling
+# USE_PDFLATEX the default is pdflatex and when in the later case latex is
+# chosen this is overwritten by pdflatex. For specific output languages the
+# default can have been set differently, this depends on the implementation of
+# the output language.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
 LATEX_CMD_NAME         = latex
 
 # The MAKEINDEX_CMD_NAME tag can be used to specify the command name to generate
 # index for LaTeX.
+# Note: This tag is used in the Makefile / make.bat.
+# See also: LATEX_MAKEINDEX_CMD for the part in the generated output file
+# (.tex).
 # The default file is: makeindex.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
 MAKEINDEX_CMD_NAME     = makeindex
 
-# If the COMPACT_LATEX tag is set to YES doxygen generates more compact LaTeX
+# The LATEX_MAKEINDEX_CMD tag can be used to specify the command name to
+# generate index for LaTeX. In case there is no backslash (\) as first character
+# it will be automatically added in the LaTeX code.
+# Note: This tag is used in the generated output file (.tex).
+# See also: MAKEINDEX_CMD_NAME for the part in the Makefile / make.bat.
+# The default value is: makeindex.
+# This tag requires that the tag GENERATE_LATEX is set to YES.
+
+LATEX_MAKEINDEX_CMD    = makeindex
+
+# If the COMPACT_LATEX tag is set to YES, doxygen generates more compact LaTeX
 # documents. This may be useful for small projects and may help to save some
 # trees in general.
 # The default value is: NO.
@@ -1603,38 +1993,56 @@ COMPACT_LATEX          = NO
 PAPER_TYPE             = a4
 
 # The EXTRA_PACKAGES tag can be used to specify one or more LaTeX package names
-# that should be included in the LaTeX output. To get the times font for
-# instance you can specify
-# EXTRA_PACKAGES=times
+# that should be included in the LaTeX output. The package can be specified just
+# by its name or with the correct syntax as to be used with the LaTeX
+# \usepackage command. To get the times font for instance you can specify :
+# EXTRA_PACKAGES=times or EXTRA_PACKAGES={times}
+# To use the option intlimits with the amsmath package you can specify:
+# EXTRA_PACKAGES=[intlimits]{amsmath}
 # If left blank no extra packages will be included.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
 EXTRA_PACKAGES         =
 
-# The LATEX_HEADER tag can be used to specify a personal LaTeX header for the
-# generated LaTeX document. The header should contain everything until the first
-# chapter. If it is left blank doxygen will generate a standard header. See
-# section "Doxygen usage" for information on how to let doxygen write the
-# default header to a separate file.
+# The LATEX_HEADER tag can be used to specify a user-defined LaTeX header for
+# the generated LaTeX document. The header should contain everything until the
+# first chapter. If it is left blank doxygen will generate a standard header. It
+# is highly recommended to start with a default header using
+# doxygen -w latex new_header.tex new_footer.tex new_stylesheet.sty
+# and then modify the file new_header.tex. See also section "Doxygen usage" for
+# information on how to generate the default header that doxygen normally uses.
 #
-# Note: Only use a user-defined header if you know what you are doing! The
-# following commands have a special meaning inside the header: $title,
-# $datetime, $date, $doxygenversion, $projectname, $projectnumber. Doxygen will
-# replace them by respectively the title of the page, the current date and time,
-# only the current date, the version number of doxygen, the project name (see
-# PROJECT_NAME), or the project number (see PROJECT_NUMBER).
+# Note: Only use a user-defined header if you know what you are doing!
+# Note: The header is subject to change so you typically have to regenerate the
+# default header when upgrading to a newer version of doxygen. The following
+# commands have a special meaning inside the header (and footer): For a
+# description of the possible markers and block names see the documentation.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
 LATEX_HEADER           =
 
-# The LATEX_FOOTER tag can be used to specify a personal LaTeX footer for the
-# generated LaTeX document. The footer should contain everything after the last
-# chapter. If it is left blank doxygen will generate a standard footer.
-#
-# Note: Only use a user-defined footer if you know what you are doing!
+# The LATEX_FOOTER tag can be used to specify a user-defined LaTeX footer for
+# the generated LaTeX document. The footer should contain everything after the
+# last chapter. If it is left blank doxygen will generate a standard footer. See
+# LATEX_HEADER for more information on how to generate a default footer and what
+# special commands can be used inside the footer. See also section "Doxygen
+# usage" for information on how to generate the default footer that doxygen
+# normally uses. Note: Only use a user-defined footer if you know what you are
+# doing!
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
 LATEX_FOOTER           =
+
+# The LATEX_EXTRA_STYLESHEET tag can be used to specify additional user-defined
+# LaTeX style sheets that are included after the standard style sheets created
+# by doxygen. Using this option one can overrule certain style aspects. Doxygen
+# will copy the style sheet files to the output directory.
+# Note: The order of the extra style sheet files is of importance (e.g. the last
+# style sheet in the list overrules the setting of the previous ones in the
+# list).
+# This tag requires that the tag GENERATE_LATEX is set to YES.
+
+LATEX_EXTRA_STYLESHEET =
 
 # The LATEX_EXTRA_FILES tag can be used to specify one or more extra images or
 # other source files which should be copied to the LATEX_OUTPUT output
@@ -1653,18 +2061,26 @@ LATEX_EXTRA_FILES      =
 
 PDF_HYPERLINKS         = YES
 
-# If the LATEX_PDFLATEX tag is set to YES, doxygen will use pdflatex to generate
-# the PDF file directly from the LaTeX files. Set this option to YES to get a
-# higher quality PDF documentation.
+# If the USE_PDFLATEX tag is set to YES, doxygen will use the engine as
+# specified with LATEX_CMD_NAME to generate the PDF file directly from the LaTeX
+# files. Set this option to YES, to get a higher quality PDF documentation.
+#
+# See also section LATEX_CMD_NAME for selecting the engine.
 # The default value is: YES.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
 USE_PDFLATEX           = YES
 
-# If the LATEX_BATCHMODE tag is set to YES, doxygen will add the \batchmode
-# command to the generated LaTeX files. This will instruct LaTeX to keep running
-# if errors occur, instead of asking the user for help. This option is also used
-# when generating formulas in HTML.
+# The LATEX_BATCHMODE tag signals the behavior of LaTeX in case of an error.
+# Possible values are: NO same as ERROR_STOP, YES same as BATCH, BATCH In batch
+# mode nothing is printed on the terminal, errors are scrolled as if <return> is
+# hit at every error; missing files that TeX tries to input or request from
+# keyboard input (\read on a not open input stream) cause the job to abort,
+# NON_STOP In nonstop mode the diagnostic message will appear on the terminal,
+# but there is no possibility of user interaction just like in batch mode,
+# SCROLL In scroll mode, TeX will stop only for missing files to input or if
+# keyboard input is necessary and ERROR_STOP In errorstop mode, TeX will stop at
+# each error, asking for user intervention.
 # The default value is: NO.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
@@ -1677,29 +2093,27 @@ LATEX_BATCHMODE        = NO
 
 LATEX_HIDE_INDICES     = NO
 
-# If the LATEX_SOURCE_CODE tag is set to YES then doxygen will include source
-# code with syntax highlighting in the LaTeX output.
-#
-# Note that which sources are shown also depends on other settings such as
-# SOURCE_BROWSER.
-# The default value is: NO.
-# This tag requires that the tag GENERATE_LATEX is set to YES.
-
-LATEX_SOURCE_CODE      = NO
-
 # The LATEX_BIB_STYLE tag can be used to specify the style to use for the
 # bibliography, e.g. plainnat, or ieeetr. See
-# http://en.wikipedia.org/wiki/BibTeX and \cite for more info.
+# https://en.wikipedia.org/wiki/BibTeX and \cite for more info.
 # The default value is: plain.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
 LATEX_BIB_STYLE        = plain
 
+# The LATEX_EMOJI_DIRECTORY tag is used to specify the (relative or absolute)
+# path from which the emoji images will be read. If a relative path is entered,
+# it will be relative to the LATEX_OUTPUT directory. If left blank the
+# LATEX_OUTPUT directory will be used.
+# This tag requires that the tag GENERATE_LATEX is set to YES.
+
+LATEX_EMOJI_DIRECTORY  =
+
 #---------------------------------------------------------------------------
 # Configuration options related to the RTF output
 #---------------------------------------------------------------------------
 
-# If the GENERATE_RTF tag is set to YES doxygen will generate RTF output. The
+# If the GENERATE_RTF tag is set to YES, doxygen will generate RTF output. The
 # RTF output is optimized for Word 97 and may not look too pretty with other RTF
 # readers/editors.
 # The default value is: NO.
@@ -1714,7 +2128,7 @@ GENERATE_RTF           = NO
 
 RTF_OUTPUT             = rtf
 
-# If the COMPACT_RTF tag is set to YES doxygen generates more compact RTF
+# If the COMPACT_RTF tag is set to YES, doxygen generates more compact RTF
 # documents. This may be useful for small projects and may help to save some
 # trees in general.
 # The default value is: NO.
@@ -1734,9 +2148,9 @@ COMPACT_RTF            = NO
 
 RTF_HYPERLINKS         = NO
 
-# Load stylesheet definitions from file. Syntax is similar to doxygen's config
-# file, i.e. a series of assignments. You only have to provide replacements,
-# missing definitions are set to their default value.
+# Load stylesheet definitions from file. Syntax is similar to doxygen's
+# configuration file, i.e. a series of assignments. You only have to provide
+# replacements, missing definitions are set to their default value.
 #
 # See also section "Doxygen usage" for information on how to generate the
 # default style sheet that doxygen normally uses.
@@ -1745,17 +2159,25 @@ RTF_HYPERLINKS         = NO
 RTF_STYLESHEET_FILE    =
 
 # Set optional variables used in the generation of an RTF document. Syntax is
-# similar to doxygen's config file. A template extensions file can be generated
-# using doxygen -e rtf extensionFile.
+# similar to doxygen's configuration file. A template extensions file can be
+# generated using doxygen -e rtf extensionFile.
 # This tag requires that the tag GENERATE_RTF is set to YES.
 
 RTF_EXTENSIONS_FILE    =
+
+# The RTF_EXTRA_FILES tag can be used to specify one or more extra images or
+# other source files which should be copied to the RTF_OUTPUT output directory.
+# Note that the files will be copied as-is; there are no commands or markers
+# available.
+# This tag requires that the tag GENERATE_RTF is set to YES.
+
+RTF_EXTRA_FILES        =
 
 #---------------------------------------------------------------------------
 # Configuration options related to the man page output
 #---------------------------------------------------------------------------
 
-# If the GENERATE_MAN tag is set to YES doxygen will generate man pages for
+# If the GENERATE_MAN tag is set to YES, doxygen will generate man pages for
 # classes and files.
 # The default value is: NO.
 
@@ -1779,6 +2201,13 @@ MAN_OUTPUT             = man
 
 MAN_EXTENSION          = .3
 
+# The MAN_SUBDIR tag determines the name of the directory created within
+# MAN_OUTPUT in which the man pages are placed. If defaults to man followed by
+# MAN_EXTENSION with the initial . removed.
+# This tag requires that the tag GENERATE_MAN is set to YES.
+
+MAN_SUBDIR             =
+
 # If the MAN_LINKS tag is set to YES and doxygen generates man output, then it
 # will generate one additional man file for each entity documented in the real
 # man page(s). These additional files only source the real man page, but without
@@ -1792,7 +2221,7 @@ MAN_LINKS              = NO
 # Configuration options related to the XML output
 #---------------------------------------------------------------------------
 
-# If the GENERATE_XML tag is set to YES doxygen will generate an XML file that
+# If the GENERATE_XML tag is set to YES, doxygen will generate an XML file that
 # captures the structure of the code including all documentation.
 # The default value is: NO.
 
@@ -1806,19 +2235,7 @@ GENERATE_XML           = NO
 
 XML_OUTPUT             = xml
 
-# The XML_SCHEMA tag can be used to specify a XML schema, which can be used by a
-# validating XML parser to check the syntax of the XML files.
-# This tag requires that the tag GENERATE_XML is set to YES.
-
-XML_SCHEMA             =
-
-# The XML_DTD tag can be used to specify a XML DTD, which can be used by a
-# validating XML parser to check the syntax of the XML files.
-# This tag requires that the tag GENERATE_XML is set to YES.
-
-XML_DTD                =
-
-# If the XML_PROGRAMLISTING tag is set to YES doxygen will dump the program
+# If the XML_PROGRAMLISTING tag is set to YES, doxygen will dump the program
 # listings (including syntax highlighting and cross-referencing information) to
 # the XML output. Note that enabling this will significantly increase the size
 # of the XML output.
@@ -1827,11 +2244,18 @@ XML_DTD                =
 
 XML_PROGRAMLISTING     = YES
 
+# If the XML_NS_MEMB_FILE_SCOPE tag is set to YES, doxygen will include
+# namespace members in file scope as well, matching the HTML output.
+# The default value is: NO.
+# This tag requires that the tag GENERATE_XML is set to YES.
+
+XML_NS_MEMB_FILE_SCOPE = NO
+
 #---------------------------------------------------------------------------
 # Configuration options related to the DOCBOOK output
 #---------------------------------------------------------------------------
 
-# If the GENERATE_DOCBOOK tag is set to YES doxygen will generate Docbook files
+# If the GENERATE_DOCBOOK tag is set to YES, doxygen will generate Docbook files
 # that can be used to generate PDF.
 # The default value is: NO.
 
@@ -1849,19 +2273,45 @@ DOCBOOK_OUTPUT         = docbook
 # Configuration options for the AutoGen Definitions output
 #---------------------------------------------------------------------------
 
-# If the GENERATE_AUTOGEN_DEF tag is set to YES doxygen will generate an AutoGen
-# Definitions (see http://autogen.sf.net) file that captures the structure of
-# the code including all documentation. Note that this feature is still
-# experimental and incomplete at the moment.
+# If the GENERATE_AUTOGEN_DEF tag is set to YES, doxygen will generate an
+# AutoGen Definitions (see https://autogen.sourceforge.net/) file that captures
+# the structure of the code including all documentation. Note that this feature
+# is still experimental and incomplete at the moment.
 # The default value is: NO.
 
 GENERATE_AUTOGEN_DEF   = NO
 
 #---------------------------------------------------------------------------
+# Configuration options related to Sqlite3 output
+#---------------------------------------------------------------------------
+
+# If the GENERATE_SQLITE3 tag is set to YES doxygen will generate a Sqlite3
+# database with symbols found by doxygen stored in tables.
+# The default value is: NO.
+
+GENERATE_SQLITE3       = NO
+
+# The SQLITE3_OUTPUT tag is used to specify where the Sqlite3 database will be
+# put. If a relative path is entered the value of OUTPUT_DIRECTORY will be put
+# in front of it.
+# The default directory is: sqlite3.
+# This tag requires that the tag GENERATE_SQLITE3 is set to YES.
+
+SQLITE3_OUTPUT         = sqlite3
+
+# The SQLITE3_RECREATE_DB tag is set to YES, the existing doxygen_sqlite3.db
+# database file will be recreated with each doxygen run. If set to NO, doxygen
+# will warn if a database file is already found and not modify it.
+# The default value is: YES.
+# This tag requires that the tag GENERATE_SQLITE3 is set to YES.
+
+SQLITE3_RECREATE_DB    = YES
+
+#---------------------------------------------------------------------------
 # Configuration options related to the Perl module output
 #---------------------------------------------------------------------------
 
-# If the GENERATE_PERLMOD tag is set to YES doxygen will generate a Perl module
+# If the GENERATE_PERLMOD tag is set to YES, doxygen will generate a Perl module
 # file that captures the structure of the code including all documentation.
 #
 # Note that this feature is still experimental and incomplete at the moment.
@@ -1869,7 +2319,7 @@ GENERATE_AUTOGEN_DEF   = NO
 
 GENERATE_PERLMOD       = NO
 
-# If the PERLMOD_LATEX tag is set to YES doxygen will generate the necessary
+# If the PERLMOD_LATEX tag is set to YES, doxygen will generate the necessary
 # Makefile rules, Perl scripts and LaTeX code to be able to generate PDF and DVI
 # output from the Perl module output.
 # The default value is: NO.
@@ -1877,9 +2327,9 @@ GENERATE_PERLMOD       = NO
 
 PERLMOD_LATEX          = NO
 
-# If the PERLMOD_PRETTY tag is set to YES the Perl module output will be nicely
+# If the PERLMOD_PRETTY tag is set to YES, the Perl module output will be nicely
 # formatted so it can be parsed by a human reader. This is useful if you want to
-# understand what is going on. On the other hand, if this tag is set to NO the
+# understand what is going on. On the other hand, if this tag is set to NO, the
 # size of the Perl module output will be much smaller and Perl will parse it
 # just the same.
 # The default value is: YES.
@@ -1899,14 +2349,14 @@ PERLMOD_MAKEVAR_PREFIX =
 # Configuration options related to the preprocessor
 #---------------------------------------------------------------------------
 
-# If the ENABLE_PREPROCESSING tag is set to YES doxygen will evaluate all
+# If the ENABLE_PREPROCESSING tag is set to YES, doxygen will evaluate all
 # C-preprocessor directives found in the sources and include files.
 # The default value is: YES.
 
 ENABLE_PREPROCESSING   = YES
 
-# If the MACRO_EXPANSION tag is set to YES doxygen will expand all macro names
-# in the source code. If set to NO only conditional compilation will be
+# If the MACRO_EXPANSION tag is set to YES, doxygen will expand all macro names
+# in the source code. If set to NO, only conditional compilation will be
 # performed. Macro expansion can be done in a controlled way by setting
 # EXPAND_ONLY_PREDEF to YES.
 # The default value is: NO.
@@ -1922,7 +2372,7 @@ MACRO_EXPANSION        = NO
 
 EXPAND_ONLY_PREDEF     = NO
 
-# If the SEARCH_INCLUDES tag is set to YES the includes files in the
+# If the SEARCH_INCLUDES tag is set to YES, the include files in the
 # INCLUDE_PATH will be searched if a #include is found.
 # The default value is: YES.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
@@ -1931,7 +2381,8 @@ SEARCH_INCLUDES        = YES
 
 # The INCLUDE_PATH tag can be used to specify one or more directories that
 # contain include files that are not input files but should be processed by the
-# preprocessor.
+# preprocessor. Note that the INCLUDE_PATH is not recursive, so the setting of
+# RECURSIVE has no effect here.
 # This tag requires that the tag SEARCH_INCLUDES is set to YES.
 
 INCLUDE_PATH           =
@@ -1964,9 +2415,9 @@ PREDEFINED             =
 EXPAND_AS_DEFINED      =
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES then doxygen's preprocessor will
-# remove all refrences to function-like macros that are alone on a line, have an
-# all uppercase name, and do not end with a semicolon. Such function macros are
-# typically used for boiler-plate code, and will confuse the parser if not
+# remove all references to function-like macros that are alone on a line, have
+# an all uppercase name, and do not end with a semicolon. Such function macros
+# are typically used for boiler-plate code, and will confuse the parser if not
 # removed.
 # The default value is: YES.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
@@ -1986,7 +2437,7 @@ SKIP_FUNCTION_MACROS   = YES
 # where loc1 and loc2 can be relative or absolute paths or URLs. See the
 # section "Linking to external documentation" for more information about the use
 # of tag files.
-# Note: Each tag file must have an unique name (where the name does NOT include
+# Note: Each tag file must have a unique name (where the name does NOT include
 # the path). If a tag file is not located in the directory in which doxygen is
 # run, you must also specify the path to the tagfile here.
 
@@ -1998,62 +2449,32 @@ TAGFILES               =
 
 GENERATE_TAGFILE       =
 
-# If the ALLEXTERNALS tag is set to YES all external class will be listed in the
-# class index. If set to NO only the inherited external classes will be listed.
+# If the ALLEXTERNALS tag is set to YES, all external classes and namespaces
+# will be listed in the class and namespace index. If set to NO, only the
+# inherited external classes will be listed.
 # The default value is: NO.
 
 ALLEXTERNALS           = NO
 
-# If the EXTERNAL_GROUPS tag is set to YES all external groups will be listed in
-# the modules index. If set to NO, only the current project's groups will be
+# If the EXTERNAL_GROUPS tag is set to YES, all external groups will be listed
+# in the topic index. If set to NO, only the current project's groups will be
 # listed.
 # The default value is: YES.
 
 EXTERNAL_GROUPS        = YES
 
-# If the EXTERNAL_PAGES tag is set to YES all external pages will be listed in
+# If the EXTERNAL_PAGES tag is set to YES, all external pages will be listed in
 # the related pages index. If set to NO, only the current project's pages will
 # be listed.
 # The default value is: YES.
 
 EXTERNAL_PAGES         = YES
 
-# The PERL_PATH should be the absolute path and name of the perl script
-# interpreter (i.e. the result of 'which perl').
-# The default file (with absolute path) is: /usr/bin/perl.
-
-PERL_PATH              = /usr/bin/perl
-
 #---------------------------------------------------------------------------
-# Configuration options related to the dot tool
+# Configuration options related to diagram generator tools
 #---------------------------------------------------------------------------
 
-# If the CLASS_DIAGRAMS tag is set to YES doxygen will generate a class diagram
-# (in HTML and LaTeX) for classes with base or super classes. Setting the tag to
-# NO turns the diagrams off. Note that this option also works with HAVE_DOT
-# disabled, but it is recommended to install and use dot, since it yields more
-# powerful graphs.
-# The default value is: YES.
-
-CLASS_DIAGRAMS         = YES
-
-# You can define message sequence charts within doxygen comments using the \msc
-# command. Doxygen will then run the mscgen tool (see:
-# http://www.mcternan.me.uk/mscgen/)) to produce the chart and insert it in the
-# documentation. The MSCGEN_PATH tag allows you to specify the directory where
-# the mscgen tool resides. If left empty the tool is assumed to be found in the
-# default search path.
-
-MSCGEN_PATH            =
-
-# You can include diagrams made with dia in doxygen documentation. Doxygen will
-# then run dia to produce the diagram and insert it in the documentation. The
-# DIA_PATH tag allows you to specify the directory where the dia binary resides.
-# If left empty dia is assumed to be found in the default search path.
-
-DIA_PATH               =
-
-# If set to YES, the inheritance and collaboration graphs will hide inheritance
+# If set to YES the inheritance and collaboration graphs will hide inheritance
 # and usage relations if the target is undocumented or is not a class.
 # The default value is: YES.
 
@@ -2061,7 +2482,7 @@ HIDE_UNDOC_RELATIONS   = YES
 
 # If you set the HAVE_DOT tag to YES then doxygen will assume the dot tool is
 # available from the path. This tool is part of Graphviz (see:
-# http://www.graphviz.org/), a graph visualization toolkit from AT&T and Lucent
+# https://www.graphviz.org/), a graph visualization toolkit from AT&T and Lucent
 # Bell Labs. The other options in this section have no effect if this option is
 # set to NO
 # The default value is: NO.
@@ -2078,55 +2499,83 @@ HAVE_DOT               = YES
 
 DOT_NUM_THREADS        = 0
 
-# When you want a differently looking font n the dot files that doxygen
-# generates you can specify the font name using DOT_FONTNAME. You need to make
-# sure dot is able to find the font, which can be done by putting it in a
-# standard location or by setting the DOTFONTPATH environment variable or by
-# setting DOT_FONTPATH to the directory containing the font.
-# The default value is: Helvetica.
+# DOT_COMMON_ATTR is common attributes for nodes, edges and labels of
+# subgraphs. When you want a differently looking font in the dot files that
+# doxygen generates you can specify fontname, fontcolor and fontsize attributes.
+# For details please see <a href=https://graphviz.org/doc/info/attrs.html>Node,
+# Edge and Graph Attributes specification</a> You need to make sure dot is able
+# to find the font, which can be done by putting it in a standard location or by
+# setting the DOTFONTPATH environment variable or by setting DOT_FONTPATH to the
+# directory containing the font. Default graphviz fontsize is 14.
+# The default value is: fontname=Helvetica,fontsize=10.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_FONTNAME           = Helvetica
+DOT_COMMON_ATTR        = "fontname=Helvetica,fontsize=10"
 
-# The DOT_FONTSIZE tag can be used to set the size (in points) of the font of
-# dot graphs.
-# Minimum value: 4, maximum value: 24, default value: 10.
+# DOT_EDGE_ATTR is concatenated with DOT_COMMON_ATTR. For elegant style you can
+# add 'arrowhead=open, arrowtail=open, arrowsize=0.5'. <a
+# href=https://graphviz.org/doc/info/arrows.html>Complete documentation about
+# arrows shapes.</a>
+# The default value is: labelfontname=Helvetica,labelfontsize=10.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_FONTSIZE           = 10
+DOT_EDGE_ATTR          = "labelfontname=Helvetica,labelfontsize=10"
 
-# By default doxygen will tell dot to use the default font as specified with
-# DOT_FONTNAME. If you specify a different font using DOT_FONTNAME you can set
-# the path where dot can find it using this tag.
+# DOT_NODE_ATTR is concatenated with DOT_COMMON_ATTR. For view without boxes
+# around nodes set 'shape=plain' or 'shape=plaintext' <a
+# href=https://www.graphviz.org/doc/info/shapes.html>Shapes specification</a>
+# The default value is: shape=box,height=0.2,width=0.4.
+# This tag requires that the tag HAVE_DOT is set to YES.
+
+DOT_NODE_ATTR          = "shape=box,height=0.2,width=0.4"
+
+# You can set the path where dot can find font specified with fontname in
+# DOT_COMMON_ATTR and others dot attributes.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
 DOT_FONTPATH           =
 
-# If the CLASS_GRAPH tag is set to YES then doxygen will generate a graph for
-# each documented class showing the direct and indirect inheritance relations.
-# Setting this tag to YES will force the CLASS_DIAGRAMS tag to NO.
+# If the CLASS_GRAPH tag is set to YES or GRAPH or BUILTIN then doxygen will
+# generate a graph for each documented class showing the direct and indirect
+# inheritance relations. In case the CLASS_GRAPH tag is set to YES or GRAPH and
+# HAVE_DOT is enabled as well, then dot will be used to draw the graph. In case
+# the CLASS_GRAPH tag is set to YES and HAVE_DOT is disabled or if the
+# CLASS_GRAPH tag is set to BUILTIN, then the built-in generator will be used.
+# If the CLASS_GRAPH tag is set to TEXT the direct and indirect inheritance
+# relations will be shown as texts / links. Explicit enabling an inheritance
+# graph or choosing a different representation for an inheritance graph of a
+# specific class, can be accomplished by means of the command \inheritancegraph.
+# Disabling an inheritance graph can be accomplished by means of the command
+# \hideinheritancegraph.
+# Possible values are: NO, YES, TEXT, GRAPH and BUILTIN.
 # The default value is: YES.
-# This tag requires that the tag HAVE_DOT is set to YES.
 
 CLASS_GRAPH            = YES
 
 # If the COLLABORATION_GRAPH tag is set to YES then doxygen will generate a
 # graph for each documented class showing the direct and indirect implementation
 # dependencies (inheritance, containment, and class references variables) of the
-# class with other documented classes.
+# class with other documented classes. Explicit enabling a collaboration graph,
+# when COLLABORATION_GRAPH is set to NO, can be accomplished by means of the
+# command \collaborationgraph. Disabling a collaboration graph can be
+# accomplished by means of the command \hidecollaborationgraph.
 # The default value is: YES.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
 COLLABORATION_GRAPH    = YES
 
 # If the GROUP_GRAPHS tag is set to YES then doxygen will generate a graph for
-# groups, showing the direct groups dependencies.
+# groups, showing the direct groups dependencies. Explicit enabling a group
+# dependency graph, when GROUP_GRAPHS is set to NO, can be accomplished by means
+# of the command \groupgraph. Disabling a directory graph can be accomplished by
+# means of the command \hidegroupgraph. See also the chapter Grouping in the
+# manual.
 # The default value is: YES.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
 GROUP_GRAPHS           = YES
 
-# If the UML_LOOK tag is set to YES doxygen will generate inheritance and
+# If the UML_LOOK tag is set to YES, doxygen will generate inheritance and
 # collaboration diagrams in a style similar to the OMG's Unified Modeling
 # Language.
 # The default value is: NO.
@@ -2143,9 +2592,31 @@ UML_LOOK               = NO
 # but if the number exceeds 15, the total amount of fields shown is limited to
 # 10.
 # Minimum value: 0, maximum value: 100, default value: 10.
-# This tag requires that the tag HAVE_DOT is set to YES.
+# This tag requires that the tag UML_LOOK is set to YES.
 
 UML_LIMIT_NUM_FIELDS   = 10
+
+# If the DOT_UML_DETAILS tag is set to NO, doxygen will show attributes and
+# methods without types and arguments in the UML graphs. If the DOT_UML_DETAILS
+# tag is set to YES, doxygen will add type and arguments for attributes and
+# methods in the UML graphs. If the DOT_UML_DETAILS tag is set to NONE, doxygen
+# will not generate fields with class member information in the UML graphs. The
+# class diagrams will look similar to the default class diagrams but using UML
+# notation for the relationships.
+# Possible values are: NO, YES and NONE.
+# The default value is: NO.
+# This tag requires that the tag UML_LOOK is set to YES.
+
+DOT_UML_DETAILS        = NO
+
+# The DOT_WRAP_THRESHOLD tag can be used to set the maximum number of characters
+# to display on a single line. If the actual line length exceeds this threshold
+# significantly it will be wrapped across multiple lines. Some heuristics are
+# applied to avoid ugly line breaks.
+# Minimum value: 0, maximum value: 1000, default value: 17.
+# This tag requires that the tag HAVE_DOT is set to YES.
+
+DOT_WRAP_THRESHOLD     = 17
 
 # If the TEMPLATE_RELATIONS tag is set to YES then the inheritance and
 # collaboration graphs will show the relations between templates and their
@@ -2158,7 +2629,9 @@ TEMPLATE_RELATIONS     = NO
 # If the INCLUDE_GRAPH, ENABLE_PREPROCESSING and SEARCH_INCLUDES tags are set to
 # YES then doxygen will generate a graph for each documented file showing the
 # direct and indirect include dependencies of the file with other documented
-# files.
+# files. Explicit enabling an include graph, when INCLUDE_GRAPH is is set to NO,
+# can be accomplished by means of the command \includegraph. Disabling an
+# include graph can be accomplished by means of the command \hideincludegraph.
 # The default value is: YES.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
@@ -2167,7 +2640,10 @@ INCLUDE_GRAPH          = YES
 # If the INCLUDED_BY_GRAPH, ENABLE_PREPROCESSING and SEARCH_INCLUDES tags are
 # set to YES then doxygen will generate a graph for each documented file showing
 # the direct and indirect include dependencies of the file with other documented
-# files.
+# files. Explicit enabling an included by graph, when INCLUDED_BY_GRAPH is set
+# to NO, can be accomplished by means of the command \includedbygraph. Disabling
+# an included by graph can be accomplished by means of the command
+# \hideincludedbygraph.
 # The default value is: YES.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
@@ -2178,7 +2654,8 @@ INCLUDED_BY_GRAPH      = YES
 #
 # Note that enabling this option will significantly increase the time of a run.
 # So in most cases it will be better to enable call graphs for selected
-# functions only using the \callgraph command.
+# functions only using the \callgraph command. Disabling a call graph can be
+# accomplished by means of the command \hidecallgraph.
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
@@ -2189,7 +2666,8 @@ CALL_GRAPH             = NO
 #
 # Note that enabling this option will significantly increase the time of a run.
 # So in most cases it will be better to enable caller graphs for selected
-# functions only using the \callergraph command.
+# functions only using the \callergraph command. Disabling a caller graph can be
+# accomplished by means of the command \hidecallergraph.
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
@@ -2205,18 +2683,32 @@ GRAPHICAL_HIERARCHY    = YES
 # If the DIRECTORY_GRAPH tag is set to YES then doxygen will show the
 # dependencies a directory has on other directories in a graphical way. The
 # dependency relations are determined by the #include relations between the
-# files in the directories.
+# files in the directories. Explicit enabling a directory graph, when
+# DIRECTORY_GRAPH is set to NO, can be accomplished by means of the command
+# \directorygraph. Disabling a directory graph can be accomplished by means of
+# the command \hidedirectorygraph.
 # The default value is: YES.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
 DIRECTORY_GRAPH        = YES
 
+# The DIR_GRAPH_MAX_DEPTH tag can be used to limit the maximum number of levels
+# of child directories generated in directory dependency graphs by dot.
+# Minimum value: 1, maximum value: 25, default value: 1.
+# This tag requires that the tag DIRECTORY_GRAPH is set to YES.
+
+DIR_GRAPH_MAX_DEPTH    = 1
+
 # The DOT_IMAGE_FORMAT tag can be used to set the image format of the images
-# generated by dot.
+# generated by dot. For an explanation of the image formats see the section
+# output formats in the documentation of the dot tool (Graphviz (see:
+# https://www.graphviz.org/)).
 # Note: If you choose svg you need to set HTML_FILE_EXTENSION to xhtml in order
 # to make the SVG files visible in IE 9+ (other browsers do not have this
 # requirement).
-# Possible values are: png, jpg, gif and svg.
+# Possible values are: png, jpg, gif, svg, png:gd, png:gd:gd, png:cairo,
+# png:cairo:gd, png:cairo:cairo, png:cairo:gdiplus, png:gdiplus and
+# png:gdiplus:gdiplus.
 # The default value is: png.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
@@ -2247,11 +2739,12 @@ DOT_PATH               =
 
 DOTFILE_DIRS           =
 
-# The MSCFILE_DIRS tag can be used to specify one or more directories that
-# contain msc files that are included in the documentation (see the \mscfile
-# command).
+# You can include diagrams made with dia in doxygen documentation. Doxygen will
+# then run dia to produce the diagram and insert it in the documentation. The
+# DIA_PATH tag allows you to specify the directory where the dia binary resides.
+# If left empty dia is assumed to be found in the default search path.
 
-MSCFILE_DIRS           =
+DIA_PATH               =
 
 # The DIAFILE_DIRS tag can be used to specify one or more directories that
 # contain dia files that are included in the documentation (see the \diafile
@@ -2259,10 +2752,28 @@ MSCFILE_DIRS           =
 
 DIAFILE_DIRS           =
 
+# When using plantuml, the PLANTUML_JAR_PATH tag should be used to specify the
+# path where java can find the plantuml.jar file or to the filename of jar file
+# to be used. If left blank, it is assumed PlantUML is not used or called during
+# a preprocessing step. Doxygen will generate a warning when it encounters a
+# \startuml command in this case and will not generate output for the diagram.
+
+PLANTUML_JAR_PATH      =
+
+# When using plantuml, the PLANTUML_CFG_FILE tag can be used to specify a
+# configuration file for plantuml.
+
+PLANTUML_CFG_FILE      =
+
+# When using plantuml, the specified paths are searched for files specified by
+# the !include statement in a plantuml block.
+
+PLANTUML_INCLUDE_PATH  =
+
 # The DOT_GRAPH_MAX_NODES tag can be used to set the maximum number of nodes
 # that will be shown in the graph. If the number of nodes in a graph becomes
 # larger than this value, doxygen will truncate the graph, which is visualized
-# by representing a node as a red box. Note that doxygen if the number of direct
+# by representing a node as a red box. Note that if the number of direct
 # children of the root node in a graph is already larger than
 # DOT_GRAPH_MAX_NODES then the graph will not be shown at all. Also note that
 # the size of a graph can be further restricted by MAX_DOT_GRAPH_DEPTH.
@@ -2283,19 +2794,7 @@ DOT_GRAPH_MAX_NODES    = 50
 
 MAX_DOT_GRAPH_DEPTH    = 0
 
-# Set the DOT_TRANSPARENT tag to YES to generate images with a transparent
-# background. This is disabled by default, because dot on Windows does not seem
-# to support this out of the box.
-#
-# Warning: Depending on the platform used, enabling this option may lead to
-# badly anti-aliased labels on the edges of a graph (i.e. they become hard to
-# read).
-# The default value is: NO.
-# This tag requires that the tag HAVE_DOT is set to YES.
-
-DOT_TRANSPARENT        = NO
-
-# Set the DOT_MULTI_TARGETS tag to YES allow dot to generate multiple output
+# Set the DOT_MULTI_TARGETS tag to YES to allow dot to generate multiple output
 # files in one run (i.e. multiple -o and -T options on the command line). This
 # makes dot run faster, but since only newer versions of dot (>1.8.10) support
 # this, this feature is disabled by default.
@@ -2307,14 +2806,34 @@ DOT_MULTI_TARGETS      = YES
 # If the GENERATE_LEGEND tag is set to YES doxygen will generate a legend page
 # explaining the meaning of the various boxes and arrows in the dot generated
 # graphs.
+# Note: This tag requires that UML_LOOK isn't set, i.e. the doxygen internal
+# graphical representation for inheritance and collaboration diagrams is used.
 # The default value is: YES.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
 GENERATE_LEGEND        = YES
 
-# If the DOT_CLEANUP tag is set to YES doxygen will remove the intermediate dot
+# If the DOT_CLEANUP tag is set to YES, doxygen will remove the intermediate
 # files that are used to generate the various graphs.
+#
+# Note: This setting is not only used for dot files but also for msc temporary
+# files.
 # The default value is: YES.
-# This tag requires that the tag HAVE_DOT is set to YES.
 
 DOT_CLEANUP            = YES
+
+# You can define message sequence charts within doxygen comments using the \msc
+# command. If the MSCGEN_TOOL tag is left empty (the default), then doxygen will
+# use a built-in version of mscgen tool to produce the charts. Alternatively,
+# the MSCGEN_TOOL tag can also specify the name an external tool. For instance,
+# specifying prog as the value, doxygen will call the tool as prog -T
+# <outfile_format> -o <outputfile> <inputfile>. The external tool should support
+# output file formats "png", "eps", "svg", and "ismap".
+
+MSCGEN_TOOL            =
+
+# The MSCFILE_DIRS tag can be used to specify one or more directories that
+# contain msc files that are included in the documentation (see the \mscfile
+# command).
+
+MSCFILE_DIRS           =

--- a/doc/edm4hep_footer.html
+++ b/doc/edm4hep_footer.html
@@ -1,21 +1,22 @@
-<!-- HTML footer for doxygen 1.8.15-->
+<!-- HTML footer for doxygen 1.11.0-->
 <!-- start footer part -->
 <!--BEGIN GENERATE_TREEVIEW-->
 <div id="nav-path" class="navpath"><!-- id is needed for treeview function! -->
   <ul>
     $navpath
     <li class="footer">$generatedby
-    <a href="http://www.doxygen.org/index.html">
-    <img class="footer" src="$relpath^doxygen.png" alt="doxygen"/></a> $doxygenversion </li>
+    <a href="https://www.doxygen.org/index.html">
+    <img class="footer" src="$relpath^doxygen.svg" width="104" height="31" alt="doxygen"/></a> $doxygenversion </li>
   </ul>
 </div>
 <!--END GENERATE_TREEVIEW-->
 <!--BEGIN !GENERATE_TREEVIEW-->
 <hr class="footer"/><address class="footer"><small>
-$generatedby &#160;<a href="http://www.doxygen.org/index.html">
-<img class="footer" src="$relpath^doxygen.png" alt="doxygen"/>
+$generatedby&#160;<a href="https://www.doxygen.org/index.html">
+<img class="footer" src="$relpath^doxygen.svg" width="104" height="31" alt="doxygen"/>
 </a> $doxygenversion
 </small></address>
+</div><!-- doc-content -->
 <!--END !GENERATE_TREEVIEW-->
 </body>
 </html>

--- a/doc/edm4hep_header.html
+++ b/doc/edm4hep_header.html
@@ -1,54 +1,78 @@
-<!-- HTML header for doxygen 1.8.15-->
+<!-- HTML header for doxygen 1.11.0-->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="$langISO">
 <head>
 <meta http-equiv="Content-Type" content="text/xhtml;charset=UTF-8"/>
-<meta http-equiv="X-UA-Compatible" content="IE=9"/>
+<meta http-equiv="X-UA-Compatible" content="IE=11"/>
 <meta name="generator" content="Doxygen $doxygenversion"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <!--BEGIN PROJECT_NAME--><title>$projectname: $title</title><!--END PROJECT_NAME-->
 <!--BEGIN !PROJECT_NAME--><title>$title</title><!--END !PROJECT_NAME-->
+<!--BEGIN PROJECT_ICON-->
+<link rel="icon" href="$relpath^$projecticon" type="image/x-icon" />
+<!--END PROJECT_ICON-->
 <link href="$relpath^tabs.css" rel="stylesheet" type="text/css"/>
+<!--BEGIN DISABLE_INDEX-->
+  <!--BEGIN FULL_SIDEBAR-->
+<script type="text/javascript">var page_layout=1;</script>
+  <!--END FULL_SIDEBAR-->
+<!--END DISABLE_INDEX-->
 <script type="text/javascript" src="$relpath^jquery.js"></script>
 <script type="text/javascript" src="$relpath^dynsections.js"></script>
+<!--BEGIN COPY_CLIPBOARD-->
+<script type="text/javascript" src="$relpath^clipboard.js"></script>
+<!--END COPY_CLIPBOARD-->
 $treeview
 $search
 $mathjax
+$darkmode
 <link href="$relpath^$stylesheet" rel="stylesheet" type="text/css" />
 $extrastylesheet
 </head>
 <body>
+<!--BEGIN DISABLE_INDEX-->
+  <!--BEGIN FULL_SIDEBAR-->
+<div id="side-nav" class="ui-resizable side-nav-resizable"><!-- do not remove this div, it is closed by doxygen! -->
+  <!--END FULL_SIDEBAR-->
+<!--END DISABLE_INDEX-->
+
 <div id="top"><!-- do not remove this div, it is closed by doxygen! -->
 
 <!--BEGIN TITLEAREA-->
 <div id="titlearea">
 <table cellspacing="0" cellpadding="0">
  <tbody>
- <tr style="height: 56px;">
+ <tr id="projectrow">
   <!--BEGIN PROJECT_LOGO-->
-  <td id="projectlogo"><img alt="Logo" src="$relpath^$projectlogo"/></td>
+  <td id="projectlogo"><img alt="Logo" src="$relpath^$projectlogo"$logosize/></td>
   <!--END PROJECT_LOGO-->
   <!--BEGIN PROJECT_NAME-->
-  <td id="projectalign" style="padding-left: 0.5em;">
-   <div id="projectname">$projectname
-   <!--BEGIN PROJECT_NUMBER-->&#160;<span id="projectnumber">$projectnumber</span><!--END PROJECT_NUMBER-->
+  <td id="projectalign">
+   <div id="projectname">$projectname<!--BEGIN PROJECT_NUMBER--><span id="projectnumber">&#160;$projectnumber</span><!--END PROJECT_NUMBER-->
    </div>
    <!--BEGIN PROJECT_BRIEF--><div id="projectbrief">$projectbrief</div><!--END PROJECT_BRIEF-->
   </td>
   <!--END PROJECT_NAME-->
   <!--BEGIN !PROJECT_NAME-->
    <!--BEGIN PROJECT_BRIEF-->
-    <td style="padding-left: 0.5em;">
+    <td>
     <div id="projectbrief">$projectbrief</div>
     </td>
    <!--END PROJECT_BRIEF-->
   <!--END !PROJECT_NAME-->
   <!--BEGIN DISABLE_INDEX-->
    <!--BEGIN SEARCHENGINE-->
-   <td>$searchbox</td>
+     <!--BEGIN !FULL_SIDEBAR-->
+    <td>$searchbox</td>
+     <!--END !FULL_SIDEBAR-->
    <!--END SEARCHENGINE-->
   <!--END DISABLE_INDEX-->
  </tr>
+  <!--BEGIN SEARCHENGINE-->
+   <!--BEGIN FULL_SIDEBAR-->
+   <tr><td colspan="2">$searchbox</td></tr>
+   <!--END FULL_SIDEBAR-->
+  <!--END SEARCHENGINE-->
  </tbody>
 </table>
 </div>

--- a/doc/edm4hep_stylesheet.css
+++ b/doc/edm4hep_stylesheet.css
@@ -1,1764 +1,2244 @@
-/* The standard CSS for doxygen 1.8.15 */
-
-body, table, div, p, dl {
-	font: 400 14px/22px Roboto,sans-serif;
-}
-
-p.reference, p.definition {
-	font: 400 14px/22px Roboto,sans-serif;
-}
-
-/* @group Heading Levels */
-
-h1.groupheader {
-	font-size: 150%;
-}
-
-.title {
-	font: 400 14px/28px Roboto,sans-serif;
-	font-size: 150%;
-	font-weight: bold;
-	margin: 10px 2px;
-}
-
-h2.groupheader {
-	border-bottom: 1px solid #879ECB;
-	color: #354C7B;
-	font-size: 150%;
-	font-weight: normal;
-	margin-top: 1.75em;
-	padding-top: 8px;
-	padding-bottom: 4px;
-	width: 100%;
-}
-
-h3.groupheader {
-	font-size: 100%;
-}
-
-h1, h2, h3, h4, h5, h6 {
-	-webkit-transition: text-shadow 0.5s linear;
-	-moz-transition: text-shadow 0.5s linear;
-	-ms-transition: text-shadow 0.5s linear;
-	-o-transition: text-shadow 0.5s linear;
-	transition: text-shadow 0.5s linear;
-	margin-right: 15px;
-}
-
-h1.glow, h2.glow, h3.glow, h4.glow, h5.glow, h6.glow {
-	text-shadow: 0 0 15px cyan;
-}
-
-dt {
-	font-weight: bold;
-}
-
-div.multicol {
-	-moz-column-gap: 1em;
-	-webkit-column-gap: 1em;
-	-moz-column-count: 3;
-	-webkit-column-count: 3;
-}
-
-p.startli, p.startdd {
-	margin-top: 2px;
-}
-
-p.starttd {
-	margin-top: 0px;
-}
-
-p.endli {
-	margin-bottom: 0px;
-}
-
-p.enddd {
-	margin-bottom: 4px;
-}
-
-p.endtd {
-	margin-bottom: 2px;
-}
-
-p.interli {
-}
-
-p.interdd {
-}
-
-p.intertd {
-}
-
-/* @end */
-
-caption {
-	font-weight: bold;
-}
-
-span.legend {
-        font-size: 70%;
-        text-align: center;
-}
-
-h3.version {
-        font-size: 90%;
-        text-align: center;
-}
-
-div.qindex, div.navtab{
-	background-color: #EBEFF6;
-	border: 1px solid #A3B4D7;
-	text-align: center;
-}
-
-div.qindex, div.navpath {
-	width: 100%;
-	line-height: 140%;
-}
-
-div.navtab {
-	margin-right: 15px;
-}
-
-/* @group Link Styling */
-
-a {
-	color: #3D578C;
-	font-weight: normal;
-	text-decoration: none;
-}
-
-.contents a:visited {
-	color: #4665A2;
-}
-
-a:hover {
-	text-decoration: underline;
-}
-
-a.qindex {
-	font-weight: bold;
-}
-
-a.qindexHL {
-	font-weight: bold;
-	background-color: #9CAFD4;
-	color: #FFFFFF;
-	border: 1px double #869DCA;
-}
-
-.contents a.qindexHL:visited {
-        color: #FFFFFF;
-}
-
-a.el {
-	font-weight: bold;
-}
-
-a.elRef {
-}
-
-a.code, a.code:visited, a.line, a.line:visited {
-	color: #4665A2;
-}
-
-a.codeRef, a.codeRef:visited, a.lineRef, a.lineRef:visited {
-	color: #4665A2;
-}
-
-/* @end */
-
-dl.el {
-	margin-left: -1cm;
-}
-
-ul {
-  overflow: hidden; /*Fixed: list item bullets overlap floating elements*/
-}
-
-#side-nav ul {
-  overflow: visible; /* reset ul rule for scroll bar in GENERATE_TREEVIEW window */
-}
-
-#main-nav ul {
-  overflow: visible; /* reset ul rule for the navigation bar drop down lists */
-}
-
-.fragment {
-  text-align: left;
-  direction: ltr;
-  overflow-x: auto; /*Fixed: fragment lines overlap floating elements*/
-  overflow-y: hidden;
-}
-
-pre.fragment {
-        border: 1px solid #C4CFE5;
-        background-color: #FBFCFD;
-        padding: 4px 6px;
-        margin: 4px 8px 4px 2px;
-        overflow: auto;
-        word-wrap: break-word;
-        font-size:  9pt;
-        line-height: 125%;
-        font-family: monospace, fixed;
-        font-size: 105%;
-}
-
-div.fragment {
-  padding: 0 0 1px 0; /*Fixed: last line underline overlap border*/
-  margin: 4px 8px 4px 2px;
-	background-color: #FBFCFD;
-	border: 1px solid #C4CFE5;
-}
-
-div.line {
-	font-family: monospace, fixed;
-        font-size: 13px;
-	min-height: 13px;
-	line-height: 1.0;
-	text-wrap: unrestricted;
-	white-space: -moz-pre-wrap; /* Moz */
-	white-space: -pre-wrap;     /* Opera 4-6 */
-	white-space: -o-pre-wrap;   /* Opera 7 */
-	white-space: pre-wrap;      /* CSS3  */
-	word-wrap: break-word;      /* IE 5.5+ */
-	text-indent: -53px;
-	padding-left: 53px;
-	padding-bottom: 0px;
-	margin: 0px;
-	-webkit-transition-property: background-color, box-shadow;
-	-webkit-transition-duration: 0.5s;
-	-moz-transition-property: background-color, box-shadow;
-	-moz-transition-duration: 0.5s;
-	-ms-transition-property: background-color, box-shadow;
-	-ms-transition-duration: 0.5s;
-	-o-transition-property: background-color, box-shadow;
-	-o-transition-duration: 0.5s;
-	transition-property: background-color, box-shadow;
-	transition-duration: 0.5s;
-}
-
-div.line:after {
-    content:"\000A";
-    white-space: pre;
-}
-
-div.line.glow {
-	background-color: cyan;
-	box-shadow: 0 0 10px cyan;
-}
-
-
-span.lineno {
-	padding-right: 4px;
-	text-align: right;
-	border-right: 2px solid #0F0;
-	background-color: #E8E8E8;
-        white-space: pre;
-}
-span.lineno a {
-	background-color: #D8D8D8;
-}
-
-span.lineno a:hover {
-	background-color: #C8C8C8;
-}
-
-.lineno {
-	-webkit-touch-callout: none;
-	-webkit-user-select: none;
-	-khtml-user-select: none;
-	-moz-user-select: none;
-	-ms-user-select: none;
-	user-select: none;
-}
-
-div.ah, span.ah {
-	background-color: black;
-	font-weight: bold;
-	color: #FFFFFF;
-	margin-bottom: 3px;
-	margin-top: 3px;
-	padding: 0.2em;
-	border: solid thin #333;
-	border-radius: 0.5em;
-	-webkit-border-radius: .5em;
-	-moz-border-radius: .5em;
-	box-shadow: 2px 2px 3px #999;
-	-webkit-box-shadow: 2px 2px 3px #999;
-	-moz-box-shadow: rgba(0, 0, 0, 0.15) 2px 2px 2px;
-	background-image: -webkit-gradient(linear, left top, left bottom, from(#eee), to(#000),color-stop(0.3, #444));
-	background-image: -moz-linear-gradient(center top, #eee 0%, #444 40%, #000 110%);
-}
-
-div.classindex ul {
-        list-style: none;
-        padding-left: 0;
-}
-
-div.classindex span.ai {
-        display: inline-block;
-}
-
-div.groupHeader {
-	margin-left: 16px;
-	margin-top: 12px;
-	font-weight: bold;
-}
-
-div.groupText {
-	margin-left: 16px;
-	font-style: italic;
-}
-
-body {
-	background-color: white;
-	color: black;
-        margin: 0;
-}
-
-div.contents {
-	margin-top: 10px;
-	margin-left: 12px;
-	margin-right: 8px;
-}
-
-td.indexkey {
-	background-color: #EBEFF6;
-	font-weight: bold;
-	border: 1px solid #C4CFE5;
-	margin: 2px 0px 2px 0;
-	padding: 2px 10px;
-        white-space: nowrap;
-        vertical-align: top;
-}
-
-td.indexvalue {
-	background-color: #EBEFF6;
-	border: 1px solid #C4CFE5;
-	padding: 2px 10px;
-	margin: 2px 0px;
-}
-
-tr.memlist {
-	background-color: #EEF1F7;
-}
-
-p.formulaDsp {
-	text-align: center;
-}
-
-img.formulaDsp {
-
-}
-
-img.formulaInl, img.inline {
-	vertical-align: middle;
-}
-
-div.center {
-	text-align: center;
-        margin-top: 0px;
-        margin-bottom: 0px;
-        padding: 0px;
-}
-
-div.center img {
-	border: 0px;
-}
-
-address.footer {
-	text-align: right;
-	padding-right: 12px;
-}
-
-img.footer {
-	border: 0px;
-	vertical-align: middle;
-}
-
-/* @group Code Colorization */
-
-span.keyword {
-	color: #008000
-}
-
-span.keywordtype {
-	color: #604020
-}
-
-span.keywordflow {
-	color: #e08000
-}
-
-span.comment {
-	color: #800000
-}
-
-span.preprocessor {
-	color: #806020
-}
-
-span.stringliteral {
-	color: #002080
-}
-
-span.charliteral {
-	color: #008080
-}
-
-span.vhdldigit {
-	color: #ff00ff
-}
-
-span.vhdlchar {
-	color: #000000
-}
-
-span.vhdlkeyword {
-	color: #700070
-}
-
-span.vhdllogic {
-	color: #ff0000
-}
-
-blockquote {
-        background-color: #F7F8FB;
-        border-left: 2px solid #9CAFD4;
-        margin: 0 24px 0 4px;
-        padding: 0 12px 0 16px;
-}
-
-blockquote.DocNodeRTL {
-   border-left: 0;
-   border-right: 2px solid #9CAFD4;
-   margin: 0 4px 0 24px;
-   padding: 0 16px 0 12px;
-}
-
-/* @end */
-
-/*
-.search {
-	color: #003399;
-	font-weight: bold;
-}
-
-form.search {
-	margin-bottom: 0px;
-	margin-top: 0px;
-}
-
-input.search {
-	font-size: 75%;
-	color: #000080;
-	font-weight: normal;
-	background-color: #e8eef2;
-}
-*/
-
-td.tiny {
-	font-size: 75%;
-}
-
-.dirtab {
-	padding: 4px;
-	border-collapse: collapse;
-	border: 1px solid #A3B4D7;
-}
-
-th.dirtab {
-	background: #EBEFF6;
-	font-weight: bold;
-}
-
-hr {
-	height: 0px;
-	border: none;
-	border-top: 1px solid #4A6AAA;
-}
-
-hr.footer {
-	height: 1px;
-}
-
-/* @group Member Descriptions */
-
-table.memberdecls {
-	border-spacing: 0px;
-	padding: 0px;
-}
-
-.memberdecls td, .fieldtable tr {
-	-webkit-transition-property: background-color, box-shadow;
-	-webkit-transition-duration: 0.5s;
-	-moz-transition-property: background-color, box-shadow;
-	-moz-transition-duration: 0.5s;
-	-ms-transition-property: background-color, box-shadow;
-	-ms-transition-duration: 0.5s;
-	-o-transition-property: background-color, box-shadow;
-	-o-transition-duration: 0.5s;
-	transition-property: background-color, box-shadow;
-	transition-duration: 0.5s;
-}
-
-.memberdecls td.glow, .fieldtable tr.glow {
-	background-color: cyan;
-	box-shadow: 0 0 15px cyan;
-}
-
-.mdescLeft, .mdescRight,
-.memItemLeft, .memItemRight,
-.memTemplItemLeft, .memTemplItemRight, .memTemplParams {
-	background-color: #F9FAFC;
-	border: none;
-	margin: 4px;
-	padding: 1px 0 0 8px;
-}
-
-.mdescLeft, .mdescRight {
-	padding: 0px 8px 4px 8px;
-	color: #555;
-}
-
-.memSeparator {
-        border-bottom: 1px solid #DEE4F0;
-        line-height: 1px;
-        margin: 0px;
-        padding: 0px;
-}
-
-.memItemLeft, .memTemplItemLeft {
-        white-space: nowrap;
-}
-
-.memItemRight {
-	width: 100%;
-}
-
-.memTemplParams {
-	color: #4665A2;
-        white-space: nowrap;
-	font-size: 80%;
-}
-
-/* @end */
-
-/* @group Member Details */
-
-/* Styles for detailed member documentation */
-
-.memtitle {
-	padding: 8px;
-	border-top: 1px solid #A8B8D9;
-	border-left: 1px solid #A8B8D9;
-	border-right: 1px solid #A8B8D9;
-	border-top-right-radius: 4px;
-	border-top-left-radius: 4px;
-	margin-bottom: -1px;
-	background-image: url('nav_f.png');
-	background-repeat: repeat-x;
-	background-color: #E2E8F2;
-	line-height: 1.25;
-	font-weight: 300;
-	float:left;
-}
-
-.permalink
-{
-        font-size: 65%;
-        display: inline-block;
-        vertical-align: middle;
-}
-
-.memtemplate {
-	font-size: 80%;
-	color: #4665A2;
-	font-weight: normal;
-	margin-left: 9px;
-}
-
-.memnav {
-	background-color: #EBEFF6;
-	border: 1px solid #A3B4D7;
-	text-align: center;
-	margin: 2px;
-	margin-right: 15px;
-	padding: 2px;
-}
-
-.mempage {
-	width: 100%;
-}
-
-.memitem {
-	padding: 0;
-	margin-bottom: 10px;
-	margin-right: 5px;
-        -webkit-transition: box-shadow 0.5s linear;
-        -moz-transition: box-shadow 0.5s linear;
-        -ms-transition: box-shadow 0.5s linear;
-        -o-transition: box-shadow 0.5s linear;
-        transition: box-shadow 0.5s linear;
-        display: table !important;
-        width: 100%;
-}
-
-.memitem.glow {
-         box-shadow: 0 0 15px cyan;
-}
-
-.memname {
-        font-weight: 400;
-        margin-left: 6px;
-}
-
-.memname td {
-	vertical-align: bottom;
-}
-
-.memproto, dl.reflist dt {
-        border-top: 1px solid #A8B8D9;
-        border-left: 1px solid #A8B8D9;
-        border-right: 1px solid #A8B8D9;
-        padding: 6px 0px 6px 0px;
-        color: #253555;
-        font-weight: bold;
-        text-shadow: 0px 1px 1px rgba(255, 255, 255, 0.9);
-        background-color: #DFE5F1;
-        /* opera specific markup */
-        box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.15);
-        border-top-right-radius: 4px;
-        /* firefox specific markup */
-        -moz-box-shadow: rgba(0, 0, 0, 0.15) 5px 5px 5px;
-        -moz-border-radius-topright: 4px;
-        /* webkit specific markup */
-        -webkit-box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.15);
-        -webkit-border-top-right-radius: 4px;
-
-}
-
-.overload {
-        font-family: "courier new",courier,monospace;
-	font-size: 65%;
-}
-
-.memdoc, dl.reflist dd {
-        border-bottom: 1px solid #A8B8D9;
-        border-left: 1px solid #A8B8D9;
-        border-right: 1px solid #A8B8D9;
-        padding: 6px 10px 2px 10px;
-        background-color: #FBFCFD;
-        border-top-width: 0;
-        background-image:url('nav_g.png');
-        background-repeat:repeat-x;
-        background-color: #FFFFFF;
-        /* opera specific markup */
-        border-bottom-left-radius: 4px;
-        border-bottom-right-radius: 4px;
-        box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.15);
-        /* firefox specific markup */
-        -moz-border-radius-bottomleft: 4px;
-        -moz-border-radius-bottomright: 4px;
-        -moz-box-shadow: rgba(0, 0, 0, 0.15) 5px 5px 5px;
-        /* webkit specific markup */
-        -webkit-border-bottom-left-radius: 4px;
-        -webkit-border-bottom-right-radius: 4px;
-        -webkit-box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.15);
-}
-
-dl.reflist dt {
-        padding: 5px;
-}
-
-dl.reflist dd {
-        margin: 0px 0px 10px 0px;
-        padding: 5px;
-}
-
-.paramkey {
-	text-align: right;
-}
-
-.paramtype {
-	white-space: nowrap;
-}
-
-.paramname {
-	color: #602020;
-	white-space: nowrap;
-}
-.paramname em {
-	font-style: normal;
-}
-.paramname code {
-        line-height: 14px;
-}
-
-.params, .retval, .exception, .tparams {
-        margin-left: 0px;
-        padding-left: 0px;
-}
-
-.params .paramname, .retval .paramname, .tparams .paramname {
-        font-weight: bold;
-        vertical-align: top;
-}
-
-.params .paramtype, .tparams .paramtype {
-        font-style: italic;
-        vertical-align: top;
-}
-
-.params .paramdir, .tparams .paramdir {
-        font-family: "courier new",courier,monospace;
-        vertical-align: top;
-}
-
-table.mlabels {
-	border-spacing: 0px;
-}
-
-td.mlabels-left {
-	width: 100%;
-	padding: 0px;
-}
-
-td.mlabels-right {
-	vertical-align: bottom;
-	padding: 0px;
-	white-space: nowrap;
-}
-
-span.mlabels {
-        margin-left: 8px;
-}
-
-span.mlabel {
-        background-color: #728DC1;
-        border-top:1px solid #5373B4;
-        border-left:1px solid #5373B4;
-        border-right:1px solid #C4CFE5;
-        border-bottom:1px solid #C4CFE5;
-	text-shadow: none;
-	color: white;
-	margin-right: 4px;
-	padding: 2px 3px;
-	border-radius: 3px;
-	font-size: 7pt;
-	white-space: nowrap;
-	vertical-align: middle;
-}
-
-
-
-/* @end */
-
-/* these are for tree view inside a (index) page */
-
-div.directory {
-        margin: 10px 0px;
-        border-top: 1px solid #9CAFD4;
-        border-bottom: 1px solid #9CAFD4;
-        width: 100%;
-}
-
-.directory table {
-        border-collapse:collapse;
-}
-
-.directory td {
-        margin: 0px;
-        padding: 0px;
-	vertical-align: top;
-}
-
-.directory td.entry {
-        white-space: nowrap;
-        padding-right: 6px;
-	padding-top: 3px;
-}
-
-.directory td.entry a {
-        outline:none;
-}
-
-.directory td.entry a img {
-        border: none;
-}
-
-.directory td.desc {
-        width: 100%;
-        padding-left: 6px;
-	padding-right: 6px;
-	padding-top: 3px;
-	border-left: 1px solid rgba(0,0,0,0.05);
-}
-
-.directory tr.even {
-	padding-left: 6px;
-	background-color: #F7F8FB;
-}
-
-.directory img {
-	vertical-align: -30%;
-}
-
-.directory .levels {
-        white-space: nowrap;
-        width: 100%;
-        text-align: right;
-        font-size: 9pt;
-}
-
-.directory .levels span {
-        cursor: pointer;
-        padding-left: 2px;
-        padding-right: 2px;
-	color: #3D578C;
-}
-
-.arrow {
-    color: #9CAFD4;
-    -webkit-user-select: none;
-    -khtml-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
-    cursor: pointer;
-    font-size: 80%;
-    display: inline-block;
-    width: 16px;
-    height: 22px;
-}
-
-.icon {
-    font-family: Arial, Helvetica;
-    font-weight: bold;
-    font-size: 12px;
-    height: 14px;
-    width: 16px;
-    display: inline-block;
-    background-color: #728DC1;
-    color: white;
-    text-align: center;
-    border-radius: 4px;
-    margin-left: 2px;
-    margin-right: 2px;
-}
-
-.icona {
-    width: 24px;
-    height: 22px;
-    display: inline-block;
-}
-
-.iconfopen {
-    width: 24px;
-    height: 18px;
-    margin-bottom: 4px;
-    background-image:url('folderopen.png');
-    background-position: 0px -4px;
-    background-repeat: repeat-y;
-    vertical-align:top;
-    display: inline-block;
-}
-
-.iconfclosed {
-    width: 24px;
-    height: 18px;
-    margin-bottom: 4px;
-    background-image:url('folderclosed.png');
-    background-position: 0px -4px;
-    background-repeat: repeat-y;
-    vertical-align:top;
-    display: inline-block;
-}
-
-.icondoc {
-    width: 24px;
-    height: 18px;
-    margin-bottom: 4px;
-    background-image:url('doc.png');
-    background-position: 0px -4px;
-    background-repeat: repeat-y;
-    vertical-align:top;
-    display: inline-block;
-}
-
-table.directory {
-    font: 400 14px Roboto,sans-serif;
-}
-
-/* @end */
-
-div.dynheader {
-        margin-top: 8px;
-	-webkit-touch-callout: none;
-	-webkit-user-select: none;
-	-khtml-user-select: none;
-	-moz-user-select: none;
-	-ms-user-select: none;
-	user-select: none;
-}
-
-address {
-	font-style: normal;
-	color: #2A3D61;
-}
-
-table.doxtable caption {
-	caption-side: top;
-}
-
-table.doxtable {
-	border-collapse:collapse;
-        margin-top: 4px;
-        margin-bottom: 4px;
-}
-
-table.doxtable td, table.doxtable th {
-	border: 1px solid #2D4068;
-	padding: 3px 7px 2px;
-}
-
-table.doxtable th {
-	background-color: #374F7F;
-	color: #FFFFFF;
-	font-size: 110%;
-	padding-bottom: 4px;
-	padding-top: 5px;
-}
-
-table.fieldtable {
-        /*width: 100%;*/
-        margin-bottom: 10px;
-        border: 1px solid #A8B8D9;
-        border-spacing: 0px;
-        -moz-border-radius: 4px;
-        -webkit-border-radius: 4px;
-        border-radius: 4px;
-        -moz-box-shadow: rgba(0, 0, 0, 0.15) 2px 2px 2px;
-        -webkit-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
-        box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
-}
-
-.fieldtable td, .fieldtable th {
-        padding: 3px 7px 2px;
-}
-
-.fieldtable td.fieldtype, .fieldtable td.fieldname {
-        white-space: nowrap;
-        border-right: 1px solid #A8B8D9;
-        border-bottom: 1px solid #A8B8D9;
-        vertical-align: top;
-}
-
-.fieldtable td.fieldname {
-        padding-top: 3px;
-}
-
-.fieldtable td.fielddoc {
-        border-bottom: 1px solid #A8B8D9;
-        /*width: 100%;*/
-}
-
-.fieldtable td.fielddoc p:first-child {
-        margin-top: 0px;
-}
-
-.fieldtable td.fielddoc p:last-child {
-        margin-bottom: 2px;
-}
-
-.fieldtable tr:last-child td {
-        border-bottom: none;
-}
-
-.fieldtable th {
-        background-image:url('nav_f.png');
-        background-repeat:repeat-x;
-        background-color: #E2E8F2;
-        font-size: 90%;
-        color: #253555;
-        padding-bottom: 4px;
-        padding-top: 5px;
-        text-align:left;
-        font-weight: 400;
-        -moz-border-radius-topleft: 4px;
-        -moz-border-radius-topright: 4px;
-        -webkit-border-top-left-radius: 4px;
-        -webkit-border-top-right-radius: 4px;
-        border-top-left-radius: 4px;
-        border-top-right-radius: 4px;
-        border-bottom: 1px solid #A8B8D9;
-}
-
-
-.tabsearch {
-	top: 0px;
-	left: 10px;
-	height: 36px;
-	background-image: url('tab_b.png');
-	z-index: 101;
-	overflow: hidden;
-	font-size: 13px;
-}
-
-.navpath ul
-{
-	font-size: 11px;
-	background-image:url('tab_b.png');
-	background-repeat:repeat-x;
-	background-position: 0 -5px;
-	height:30px;
-	line-height:30px;
-	color:#8AA0CC;
-	border:solid 1px #C2CDE4;
-	overflow:hidden;
-	margin:0px;
-	padding:0px;
-}
-
-.navpath li
-{
-	list-style-type:none;
-	float:left;
-	padding-left:10px;
-	padding-right:15px;
-	background-image:url('bc_s.png');
-	background-repeat:no-repeat;
-	background-position:right;
-	color:#364D7C;
-}
-
-.navpath li.navelem a
-{
-	height:32px;
-	display:block;
-	text-decoration: none;
-	outline: none;
-	color: #283A5D;
-	font-family: 'Lucida Grande',Geneva,Helvetica,Arial,sans-serif;
-	text-shadow: 0px 1px 1px rgba(255, 255, 255, 0.9);
-	text-decoration: none;
-}
-
-.navpath li.navelem a:hover
-{
-	color:#6884BD;
-}
-
-.navpath li.footer
-{
-        list-style-type:none;
-        float:right;
-        padding-left:10px;
-        padding-right:15px;
-        background-image:none;
-        background-repeat:no-repeat;
-        background-position:right;
-        color:#364D7C;
-        font-size: 8pt;
-}
-
-
-div.summary
-{
-	float: right;
-	font-size: 8pt;
-	padding-right: 5px;
-	width: 50%;
-	text-align: right;
-}
-
-div.summary a
-{
-	white-space: nowrap;
-}
-
-table.classindex
-{
-        margin: 10px;
-        white-space: nowrap;
-        margin-left: 3%;
-        margin-right: 3%;
-        width: 94%;
-        border: 0;
-        border-spacing: 0;
-        padding: 0;
-}
-
-div.ingroups
-{
-	font-size: 8pt;
-	width: 50%;
-	text-align: left;
-}
-
-div.ingroups a
-{
-	white-space: nowrap;
-}
-
-div.header
-{
-        background-image:url('nav_h.png');
-        background-repeat:repeat-x;
-	background-color: #F9FAFC;
-	margin:  0px;
-	border-bottom: 1px solid #C4CFE5;
-}
-
-div.headertitle
-{
-	padding: 5px 5px 5px 10px;
-}
-
-.PageDocRTL-title div.headertitle {
-  text-align: right;
-  direction: rtl;
-}
-
-dl {
-        padding: 0 0 0 0;
-}
-
-/* dl.note, dl.warning, dl.attention, dl.pre, dl.post, dl.invariant, dl.deprecated, dl.todo, dl.test, dl.bug, dl.examples */
-dl.section {
-	margin-left: 0px;
-	padding-left: 0px;
-}
-
-dl.section.DocNodeRTL {
-  margin-right: 0px;
-  padding-right: 0px;
-}
-
-dl.note {
-  margin-left: -7px;
-  padding-left: 3px;
-  border-left: 4px solid;
-  border-color: #D0C000;
-}
-
-dl.note.DocNodeRTL {
-  margin-left: 0;
-  padding-left: 0;
-  border-left: 0;
-  margin-right: -7px;
-  padding-right: 3px;
-  border-right: 4px solid;
-  border-color: #D0C000;
-}
-
-dl.warning, dl.attention {
-  margin-left: -7px;
-  padding-left: 3px;
-  border-left: 4px solid;
-  border-color: #FF0000;
-}
-
-dl.warning.DocNodeRTL, dl.attention.DocNodeRTL {
-  margin-left: 0;
-  padding-left: 0;
-  border-left: 0;
-  margin-right: -7px;
-  padding-right: 3px;
-  border-right: 4px solid;
-  border-color: #FF0000;
-}
-
-dl.pre, dl.post, dl.invariant {
-  margin-left: -7px;
-  padding-left: 3px;
-  border-left: 4px solid;
-  border-color: #00D000;
-}
-
-dl.pre.DocNodeRTL, dl.post.DocNodeRTL, dl.invariant.DocNodeRTL {
-  margin-left: 0;
-  padding-left: 0;
-  border-left: 0;
-  margin-right: -7px;
-  padding-right: 3px;
-  border-right: 4px solid;
-  border-color: #00D000;
-}
-
-dl.deprecated {
-  margin-left: -7px;
-  padding-left: 3px;
-  border-left: 4px solid;
-  border-color: #505050;
-}
-
-dl.deprecated.DocNodeRTL {
-  margin-left: 0;
-  padding-left: 0;
-  border-left: 0;
-  margin-right: -7px;
-  padding-right: 3px;
-  border-right: 4px solid;
-  border-color: #505050;
-}
-
-dl.todo {
-  margin-left: -7px;
-  padding-left: 3px;
-  border-left: 4px solid;
-  border-color: #00C0E0;
-}
-
-dl.todo.DocNodeRTL {
-  margin-left: 0;
-  padding-left: 0;
-  border-left: 0;
-  margin-right: -7px;
-  padding-right: 3px;
-  border-right: 4px solid;
-  border-color: #00C0E0;
-}
-
-dl.test {
-  margin-left: -7px;
-  padding-left: 3px;
-  border-left: 4px solid;
-  border-color: #3030E0;
-}
-
-dl.test.DocNodeRTL {
-  margin-left: 0;
-  padding-left: 0;
-  border-left: 0;
-  margin-right: -7px;
-  padding-right: 3px;
-  border-right: 4px solid;
-  border-color: #3030E0;
-}
-
-dl.bug {
-  margin-left: -7px;
-  padding-left: 3px;
-  border-left: 4px solid;
-  border-color: #C08050;
-}
-
-dl.bug.DocNodeRTL {
-  margin-left: 0;
-  padding-left: 0;
-  border-left: 0;
-  margin-right: -7px;
-  padding-right: 3px;
-  border-right: 4px solid;
-  border-color: #C08050;
-}
-
-dl.section dd {
-	margin-bottom: 6px;
-}
-
-
-#projectlogo
-{
-	text-align: center;
-	vertical-align: bottom;
-	border-collapse: separate;
-}
-
-#projectlogo img
-{
-	border: 0px none;
-}
-
-#projectalign
-{
-        vertical-align: middle;
-}
-
-#projectname
-{
-	font: 300% Tahoma, Arial,sans-serif;
-	margin: 0px;
-	padding: 2px 0px;
-}
-
-#projectbrief
-{
-	font: 120% Tahoma, Arial,sans-serif;
-	margin: 0px;
-	padding: 0px;
-}
-
-#projectnumber
-{
-	font: 50% Tahoma, Arial,sans-serif;
-	margin: 0px;
-	padding: 0px;
-}
-
-#titlearea
-{
-	padding: 0px;
-	margin: 0px;
-	width: 100%;
-	border-bottom: 1px solid #5373B4;
-}
-
-.image
-{
-        text-align: center;
-}
-
-.dotgraph
-{
-        text-align: center;
-}
-
-.mscgraph
-{
-        text-align: center;
-}
-
-.plantumlgraph
-{
-        text-align: center;
-}
-
-.diagraph
-{
-        text-align: center;
-}
-
-.caption
-{
-	font-weight: bold;
-}
-
-div.zoom
-{
-	border: 1px solid #90A5CE;
-}
-
-dl.citelist {
-        margin-bottom:50px;
-}
-
-dl.citelist dt {
-        color:#334975;
-        float:left;
-        font-weight:bold;
-        margin-right:10px;
-        padding:5px;
-}
-
-dl.citelist dd {
-        margin:2px 0;
-        padding:5px 0;
-}
-
-div.toc {
-        padding: 14px 25px;
-        background-color: #F4F6FA;
-        border: 1px solid #D8DFEE;
-        border-radius: 7px 7px 7px 7px;
-        float: right;
-        height: auto;
-        margin: 0 8px 10px 10px;
-        width: 200px;
-}
-
-.PageDocRTL-title div.toc {
-  float: left !important;
-  text-align: right;
-}
-
-div.toc li {
-        background: url("bdwn.png") no-repeat scroll 0 5px transparent;
-        font: 10px/1.2 Verdana,DejaVu Sans,Geneva,sans-serif;
-        margin-top: 5px;
-        padding-left: 10px;
-        padding-top: 2px;
-}
-
-.PageDocRTL-title div.toc li {
-  background-position-x: right !important;
-  padding-left: 0 !important;
-  padding-right: 10px;
-}
-
-div.toc h3 {
-        font: bold 12px/1.2 Arial,FreeSans,sans-serif;
-	color: #4665A2;
-        border-bottom: 0 none;
-        margin: 0;
-}
-
-div.toc ul {
-        list-style: none outside none;
-        border: medium none;
-        padding: 0px;
-}
-
-div.toc li.level1 {
-        margin-left: 0px;
-}
-
-div.toc li.level2 {
-        margin-left: 15px;
-}
-
-div.toc li.level3 {
-        margin-left: 30px;
-}
-
-div.toc li.level4 {
-        margin-left: 45px;
-}
-
-.PageDocRTL-title div.toc li.level1 {
-  margin-left: 0 !important;
-  margin-right: 0;
-}
-
-.PageDocRTL-title div.toc li.level2 {
-  margin-left: 0 !important;
-  margin-right: 15px;
-}
-
-.PageDocRTL-title div.toc li.level3 {
-  margin-left: 0 !important;
-  margin-right: 30px;
-}
-
-.PageDocRTL-title div.toc li.level4 {
-  margin-left: 0 !important;
-  margin-right: 45px;
-}
-
-.inherit_header {
-        font-weight: bold;
-        color: gray;
-        cursor: pointer;
-	-webkit-touch-callout: none;
-	-webkit-user-select: none;
-	-khtml-user-select: none;
-	-moz-user-select: none;
-	-ms-user-select: none;
-	user-select: none;
-}
-
-.inherit_header td {
-        padding: 6px 0px 2px 5px;
-}
-
-.inherit {
-        display: none;
-}
-
-tr.heading h2 {
-        margin-top: 12px;
-        margin-bottom: 4px;
-}
-
-/* tooltip related style info */
-
-.ttc {
-        position: absolute;
-        display: none;
-}
-
-#powerTip {
-	cursor: default;
-	white-space: nowrap;
-	background-color: white;
-	border: 1px solid gray;
-	border-radius: 4px 4px 4px 4px;
-	box-shadow: 1px 1px 7px gray;
-	display: none;
-	font-size: smaller;
-	max-width: 80%;
-	opacity: 0.9;
-	padding: 1ex 1em 1em;
-	position: absolute;
-	z-index: 2147483647;
-}
-
-#powerTip div.ttdoc {
-        color: grey;
-	font-style: italic;
-}
-
-#powerTip div.ttname a {
-        font-weight: bold;
-}
-
-#powerTip div.ttname {
-        font-weight: bold;
-}
-
-#powerTip div.ttdeci {
-        color: #006318;
-}
-
-#powerTip div {
-        margin: 0px;
-        padding: 0px;
-        font: 12px/16px Roboto,sans-serif;
-}
-
-#powerTip:before, #powerTip:after {
-	content: "";
-	position: absolute;
-	margin: 0px;
-}
-
-#powerTip.n:after,  #powerTip.n:before,
-#powerTip.s:after,  #powerTip.s:before,
-#powerTip.w:after,  #powerTip.w:before,
-#powerTip.e:after,  #powerTip.e:before,
-#powerTip.ne:after, #powerTip.ne:before,
-#powerTip.se:after, #powerTip.se:before,
-#powerTip.nw:after, #powerTip.nw:before,
-#powerTip.sw:after, #powerTip.sw:before {
-	border: solid transparent;
-	content: " ";
-	height: 0;
-	width: 0;
-	position: absolute;
-}
-
-#powerTip.n:after,  #powerTip.s:after,
-#powerTip.w:after,  #powerTip.e:after,
-#powerTip.nw:after, #powerTip.ne:after,
-#powerTip.sw:after, #powerTip.se:after {
-	border-color: rgba(255, 255, 255, 0);
-}
-
-#powerTip.n:before,  #powerTip.s:before,
-#powerTip.w:before,  #powerTip.e:before,
-#powerTip.nw:before, #powerTip.ne:before,
-#powerTip.sw:before, #powerTip.se:before {
-	border-color: rgba(128, 128, 128, 0);
-}
-
-#powerTip.n:after,  #powerTip.n:before,
-#powerTip.ne:after, #powerTip.ne:before,
-#powerTip.nw:after, #powerTip.nw:before {
-	top: 100%;
-}
-
-#powerTip.n:after, #powerTip.ne:after, #powerTip.nw:after {
-	border-top-color: #FFFFFF;
-	border-width: 10px;
-	margin: 0px -10px;
-}
-#powerTip.n:before {
-	border-top-color: #808080;
-	border-width: 11px;
-	margin: 0px -11px;
-}
-#powerTip.n:after, #powerTip.n:before {
-	left: 50%;
-}
-
-#powerTip.nw:after, #powerTip.nw:before {
-	right: 14px;
-}
-
-#powerTip.ne:after, #powerTip.ne:before {
-	left: 14px;
-}
-
-#powerTip.s:after,  #powerTip.s:before,
-#powerTip.se:after, #powerTip.se:before,
-#powerTip.sw:after, #powerTip.sw:before {
-	bottom: 100%;
-}
-
-#powerTip.s:after, #powerTip.se:after, #powerTip.sw:after {
-	border-bottom-color: #FFFFFF;
-	border-width: 10px;
-	margin: 0px -10px;
-}
-
-#powerTip.s:before, #powerTip.se:before, #powerTip.sw:before {
-	border-bottom-color: #808080;
-	border-width: 11px;
-	margin: 0px -11px;
-}
-
-#powerTip.s:after, #powerTip.s:before {
-	left: 50%;
-}
-
-#powerTip.sw:after, #powerTip.sw:before {
-	right: 14px;
-}
-
-#powerTip.se:after, #powerTip.se:before {
-	left: 14px;
-}
-
-#powerTip.e:after, #powerTip.e:before {
-	left: 100%;
-}
-#powerTip.e:after {
-	border-left-color: #FFFFFF;
-	border-width: 10px;
-	top: 50%;
-	margin-top: -10px;
-}
-#powerTip.e:before {
-	border-left-color: #808080;
-	border-width: 11px;
-	top: 50%;
-	margin-top: -11px;
-}
-
-#powerTip.w:after, #powerTip.w:before {
-	right: 100%;
-}
-#powerTip.w:after {
-	border-right-color: #FFFFFF;
-	border-width: 10px;
-	top: 50%;
-	margin-top: -10px;
-}
-#powerTip.w:before {
-	border-right-color: #808080;
-	border-width: 11px;
-	top: 50%;
-	margin-top: -11px;
-}
-
-@media print
-{
-  #top { display: none; }
-  #side-nav { display: none; }
-  #nav-path { display: none; }
-  body { overflow:visible; }
-  h1, h2, h3, h4, h5, h6 { page-break-after: avoid; }
-  .summary { display: none; }
-  .memitem { page-break-inside: avoid; }
-  #doc-content
-  {
-    margin-left:0 !important;
-    height:auto !important;
-    width:auto !important;
-    overflow:inherit;
-    display:inline;
-  }
-}
-
-/* @group Markdown */
-
-/*
-table.markdownTable {
-	border-collapse:collapse;
-        margin-top: 4px;
-        margin-bottom: 4px;
-}
-
-table.markdownTable td, table.markdownTable th {
-	border: 1px solid #2D4068;
-	padding: 3px 7px 2px;
-}
-
-table.markdownTableHead tr {
-}
-
-table.markdownTableBodyLeft td, table.markdownTable th {
-	border: 1px solid #2D4068;
-	padding: 3px 7px 2px;
-}
-
-th.markdownTableHeadLeft th.markdownTableHeadRight th.markdownTableHeadCenter th.markdownTableHeadNone {
-	background-color: #374F7F;
-	color: #FFFFFF;
-	font-size: 110%;
-	padding-bottom: 4px;
-	padding-top: 5px;
-}
-
-th.markdownTableHeadLeft {
-	text-align: left
-}
-
-th.markdownTableHeadRight {
-	text-align: right
-}
-
-th.markdownTableHeadCenter {
-	text-align: center
-}
-*/
-
-table.markdownTable {
-	border-collapse:collapse;
-        margin-top: 4px;
-        margin-bottom: 4px;
-}
-
-table.markdownTable td, table.markdownTable th {
-	border: 1px solid #2D4068;
-	padding: 3px 7px 2px;
-}
-
-table.markdownTable tr {
-}
-
-th.markdownTableHeadLeft, th.markdownTableHeadRight, th.markdownTableHeadCenter, th.markdownTableHeadNone {
-	background-color: #374F7F;
-	color: #FFFFFF;
-	font-size: 110%;
-	padding-bottom: 4px;
-	padding-top: 5px;
-}
-
-th.markdownTableHeadLeft, td.markdownTableBodyLeft {
-	text-align: left
-}
-
-th.markdownTableHeadRight, td.markdownTableBodyRight {
-	text-align: right
-}
-
-th.markdownTableHeadCenter, td.markdownTableBodyCenter {
-	text-align: center
-}
-
-.DocNodeRTL {
-  text-align: right;
-  direction: rtl;
-}
-
-.DocNodeLTR {
-  text-align: left;
-  direction: ltr;
-}
-
-table.DocNodeRTL {
-   width: auto;
-   margin-right: 0;
-   margin-left: auto;
-}
-
-table.DocNodeLTR {
-   width: auto;
-   margin-right: auto;
-   margin-left: 0;
-}
-
-tt, code, kbd, samp
-{
-  display: inline-block;
-  direction:ltr;
-}
-/* @end */
-
-u {
-	text-decoration: underline;
-}
+/* The standard CSS for doxygen 1.11.0*/
+
+html {
+        /* page base colors */
+        --page-background-color: white;
+        --page-foreground-color: black;
+        --page-link-color: #3D578C;
+        --page-visited-link-color: #4665A2;
+
+        /* index */
+        --index-odd-item-bg-color: #F8F9FC;
+        --index-even-item-bg-color: white;
+        --index-header-color: black;
+        --index-separator-color: #A0A0A0;
+
+        /* header */
+        --header-background-color: #F9FAFC;
+        --header-separator-color: #C4CFE5;
+        --header-gradient-image: url('nav_h.png');
+        --group-header-separator-color: #879ECB;
+        --group-header-color: #354C7B;
+        --inherit-header-color: gray;
+
+        --footer-foreground-color: #2A3D61;
+        --footer-logo-width: 104px;
+        --citation-label-color: #334975;
+        --glow-color: cyan;
+
+        --title-background-color: white;
+        --title-separator-color: #5373B4;
+        --directory-separator-color: #9CAFD4;
+        --separator-color: #4A6AAA;
+
+        --blockquote-background-color: #F7F8FB;
+        --blockquote-border-color: #9CAFD4;
+
+        --scrollbar-thumb-color: #9CAFD4;
+        --scrollbar-background-color: #F9FAFC;
+
+        --icon-background-color: #728DC1;
+        --icon-foreground-color: white;
+        --icon-doc-image: url('doc.svg');
+        --icon-folder-open-image: url('folderopen.svg');
+        --icon-folder-closed-image: url('folderclosed.svg');
+
+        /* brief member declaration list */
+        --memdecl-background-color: #F9FAFC;
+        --memdecl-separator-color: #DEE4F0;
+        --memdecl-foreground-color: #555;
+        --memdecl-template-color: #4665A2;
+
+        /* detailed member list */
+        --memdef-border-color: #A8B8D9;
+        --memdef-title-background-color: #E2E8F2;
+        --memdef-title-gradient-image: url('nav_f.png');
+        --memdef-proto-background-color: #DFE5F1;
+        --memdef-proto-text-color: #253555;
+        --memdef-proto-text-shadow: 0px 1px 1px rgba(255, 255, 255, 0.9);
+        --memdef-doc-background-color: white;
+        --memdef-param-name-color: #602020;
+        --memdef-template-color: #4665A2;
+
+        /* tables */
+        --table-cell-border-color: #2D4068;
+        --table-header-background-color: #374F7F;
+        --table-header-foreground-color: #FFFFFF;
+
+        /* labels */
+        --label-background-color: #728DC1;
+        --label-left-top-border-color: #5373B4;
+        --label-right-bottom-border-color: #C4CFE5;
+        --label-foreground-color: white;
+
+        /** navigation bar/tree/menu */
+        --nav-background-color: #F9FAFC;
+        --nav-foreground-color: #364D7C;
+        --nav-gradient-image: url('tab_b.png');
+        --nav-gradient-hover-image: url('tab_h.png');
+        --nav-gradient-active-image: url('tab_a.png');
+        --nav-gradient-active-image-parent: url("../tab_a.png");
+        --nav-separator-image: url('tab_s.png');
+        --nav-breadcrumb-image: url('bc_s.png');
+        --nav-breadcrumb-border-color: #C2CDE4;
+        --nav-splitbar-image: url('splitbar.png');
+        --nav-font-size-level1: 13px;
+        --nav-font-size-level2: 10px;
+        --nav-font-size-level3: 9px;
+        --nav-text-normal-color: #283A5D;
+        --nav-text-hover-color: white;
+        --nav-text-active-color: white;
+        --nav-text-normal-shadow: 0px 1px 1px rgba(255, 255, 255, 0.9);
+        --nav-text-hover-shadow: 0px 1px 1px rgba(0, 0, 0, 1.0);
+        --nav-text-active-shadow: 0px 1px 1px rgba(0, 0, 0, 1.0);
+        --nav-menu-button-color: #364D7C;
+        --nav-menu-background-color: white;
+        --nav-menu-foreground-color: #555555;
+        --nav-menu-toggle-color: rgba(255, 255, 255, 0.5);
+        --nav-arrow-color: #9CAFD4;
+        --nav-arrow-selected-color: #9CAFD4;
+
+        /* table of contents */
+        --toc-background-color: #F4F6FA;
+        --toc-border-color: #D8DFEE;
+        --toc-header-color: #4665A2;
+        --toc-down-arrow-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' version='1.1' height='10px' width='5px' fill='grey'><text x='0' y='5' font-size='10'>&%238595;</text></svg>");
+
+        /** search field */
+        --search-background-color: white;
+        --search-foreground-color: #909090;
+        --search-magnification-image: url('mag.svg');
+        --search-magnification-select-image: url('mag_sel.svg');
+        --search-active-color: black;
+        --search-filter-background-color: #F9FAFC;
+        --search-filter-foreground-color: black;
+        --search-filter-border-color: #90A5CE;
+        --search-filter-highlight-text-color: white;
+        --search-filter-highlight-bg-color: #3D578C;
+        --search-results-foreground-color: #425E97;
+        --search-results-background-color: #EEF1F7;
+        --search-results-border-color: black;
+        --search-box-shadow: inset 0.5px 0.5px 3px 0px #555;
+
+        /** code fragments */
+        --code-keyword-color: #008000;
+        --code-type-keyword-color: #604020;
+        --code-flow-keyword-color: #E08000;
+        --code-comment-color: #800000;
+        --code-preprocessor-color: #806020;
+        --code-string-literal-color: #002080;
+        --code-char-literal-color: #008080;
+        --code-xml-cdata-color: black;
+        --code-vhdl-digit-color: #FF00FF;
+        --code-vhdl-char-color: #000000;
+        --code-vhdl-keyword-color: #700070;
+        --code-vhdl-logic-color: #FF0000;
+        --code-link-color: #4665A2;
+        --code-external-link-color: #4665A2;
+        --fragment-foreground-color: black;
+        --fragment-background-color: #FBFCFD;
+        --fragment-border-color: #C4CFE5;
+        --fragment-lineno-border-color: #00FF00;
+        --fragment-lineno-background-color: #E8E8E8;
+        --fragment-lineno-foreground-color: black;
+        --fragment-lineno-link-fg-color: #4665A2;
+        --fragment-lineno-link-bg-color: #D8D8D8;
+        --fragment-lineno-link-hover-fg-color: #4665A2;
+        --fragment-lineno-link-hover-bg-color: #C8C8C8;
+        --fragment-copy-ok-color: #2EC82E;
+        --tooltip-foreground-color: black;
+        --tooltip-background-color: white;
+        --tooltip-border-color: gray;
+        --tooltip-doc-color: grey;
+        --tooltip-declaration-color: #006318;
+        --tooltip-link-color: #4665A2;
+        --tooltip-shadow: 1px 1px 7px gray;
+        --fold-line-color: #808080;
+        --fold-minus-image: url('minus.svg');
+        --fold-plus-image: url('plus.svg');
+        --fold-minus-image-relpath: url('../../minus.svg');
+        --fold-plus-image-relpath: url('../../plus.svg');
+
+        /** font-family */
+        --font-family-normal: Roboto,sans-serif;
+        --font-family-monospace: 'JetBrains Mono',Consolas,Monaco,'Andale Mono','Ubuntu Mono',monospace,fixed;
+        --font-family-nav: 'Lucida Grande',Geneva,Helvetica,Arial,sans-serif;
+        --font-family-title: Tahoma,Arial,sans-serif;
+        --font-family-toc: Verdana,'DejaVu Sans',Geneva,sans-serif;
+        --font-family-search: Arial,Verdana,sans-serif;
+        --font-family-icon: Arial,Helvetica;
+        --font-family-tooltip: Roboto,sans-serif;
+
+        /** special sections */
+        --warning-color-bg: #f8d1cc;
+        --warning-color-hl: #b61825;
+        --warning-color-text: #75070f;
+        --note-color-bg: #faf3d8;
+        --note-color-hl: #f3a600;
+        --note-color-text: #5f4204;
+        --todo-color-bg: #e4f3ff;
+        --todo-color-hl: #1879C4;
+        --todo-color-text: #274a5c;
+        --test-color-bg: #e8e8ff;
+        --test-color-hl: #3939C4;
+        --test-color-text: #1a1a5c;
+        --deprecated-color-bg: #ecf0f3;
+        --deprecated-color-hl: #5b6269;
+        --deprecated-color-text: #43454a;
+        --bug-color-bg: #e4dafd;
+        --bug-color-hl: #5b2bdd;
+        --bug-color-text: #2a0d72;
+        --invariant-color-bg: #d8f1e3;
+        --invariant-color-hl: #44b86f;
+        --invariant-color-text: #265532;
+        }
+
+        @media (prefers-color-scheme: dark) {
+          html:not(.dark-mode) {
+            color-scheme: dark;
+
+        /* page base colors */
+        --page-background-color: black;
+        --page-foreground-color: #C9D1D9;
+        --page-link-color: #90A5CE;
+        --page-visited-link-color: #A3B4D7;
+
+        /* index */
+        --index-odd-item-bg-color: #0B101A;
+        --index-even-item-bg-color: black;
+        --index-header-color: #C4CFE5;
+        --index-separator-color: #334975;
+
+        /* header */
+        --header-background-color: #070B11;
+        --header-separator-color: #141C2E;
+        --header-gradient-image: url('nav_hd.png');
+        --group-header-separator-color: #283A5D;
+        --group-header-color: #90A5CE;
+        --inherit-header-color: #A0A0A0;
+
+        --footer-foreground-color: #5B7AB7;
+        --footer-logo-width: 60px;
+        --citation-label-color: #90A5CE;
+        --glow-color: cyan;
+
+        --title-background-color: #090D16;
+        --title-separator-color: #354C79;
+        --directory-separator-color: #283A5D;
+        --separator-color: #283A5D;
+
+        --blockquote-background-color: #101826;
+        --blockquote-border-color: #283A5D;
+
+        --scrollbar-thumb-color: #283A5D;
+        --scrollbar-background-color: #070B11;
+
+        --icon-background-color: #334975;
+        --icon-foreground-color: #C4CFE5;
+        --icon-doc-image: url('docd.svg');
+        --icon-folder-open-image: url('folderopend.svg');
+        --icon-folder-closed-image: url('folderclosedd.svg');
+
+        /* brief member declaration list */
+        --memdecl-background-color: #0B101A;
+        --memdecl-separator-color: #2C3F65;
+        --memdecl-foreground-color: #BBB;
+        --memdecl-template-color: #7C95C6;
+
+        /* detailed member list */
+        --memdef-border-color: #233250;
+        --memdef-title-background-color: #1B2840;
+        --memdef-title-gradient-image: url('nav_fd.png');
+        --memdef-proto-background-color: #19243A;
+        --memdef-proto-text-color: #9DB0D4;
+        --memdef-proto-text-shadow: 0px 1px 1px rgba(0, 0, 0, 0.9);
+        --memdef-doc-background-color: black;
+        --memdef-param-name-color: #D28757;
+        --memdef-template-color: #7C95C6;
+
+        /* tables */
+        --table-cell-border-color: #283A5D;
+        --table-header-background-color: #283A5D;
+        --table-header-foreground-color: #C4CFE5;
+
+        /* labels */
+        --label-background-color: #354C7B;
+        --label-left-top-border-color: #4665A2;
+        --label-right-bottom-border-color: #283A5D;
+        --label-foreground-color: #CCCCCC;
+
+        /** navigation bar/tree/menu */
+        --nav-background-color: #101826;
+        --nav-foreground-color: #364D7C;
+        --nav-gradient-image: url('tab_bd.png');
+        --nav-gradient-hover-image: url('tab_hd.png');
+        --nav-gradient-active-image: url('tab_ad.png');
+        --nav-gradient-active-image-parent: url("../tab_ad.png");
+        --nav-separator-image: url('tab_sd.png');
+        --nav-breadcrumb-image: url('bc_sd.png');
+        --nav-breadcrumb-border-color: #2A3D61;
+        --nav-splitbar-image: url('splitbard.png');
+        --nav-font-size-level1: 13px;
+        --nav-font-size-level2: 10px;
+        --nav-font-size-level3: 9px;
+        --nav-text-normal-color: #B6C4DF;
+        --nav-text-hover-color: #DCE2EF;
+        --nav-text-active-color: #DCE2EF;
+        --nav-text-normal-shadow: 0px 1px 1px black;
+        --nav-text-hover-shadow: 0px 1px 1px rgba(0, 0, 0, 1.0);
+        --nav-text-active-shadow: 0px 1px 1px rgba(0, 0, 0, 1.0);
+        --nav-menu-button-color: #B6C4DF;
+        --nav-menu-background-color: #05070C;
+        --nav-menu-foreground-color: #BBBBBB;
+        --nav-menu-toggle-color: rgba(255, 255, 255, 0.2);
+        --nav-arrow-color: #334975;
+        --nav-arrow-selected-color: #90A5CE;
+
+        /* table of contents */
+        --toc-background-color: #151E30;
+        --toc-border-color: #202E4A;
+        --toc-header-color: #A3B4D7;
+        --toc-down-arrow-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' version='1.1' height='10px' width='5px'><text x='0' y='5' font-size='10' fill='grey'>&%238595;</text></svg>");
+
+        /** search field */
+        --search-background-color: black;
+        --search-foreground-color: #C5C5C5;
+        --search-magnification-image: url('mag_d.svg');
+        --search-magnification-select-image: url('mag_seld.svg');
+        --search-active-color: #C5C5C5;
+        --search-filter-background-color: #101826;
+        --search-filter-foreground-color: #90A5CE;
+        --search-filter-border-color: #7C95C6;
+        --search-filter-highlight-text-color: #BCC9E2;
+        --search-filter-highlight-bg-color: #283A5D;
+        --search-results-background-color: #101826;
+        --search-results-foreground-color: #90A5CE;
+        --search-results-border-color: #7C95C6;
+        --search-box-shadow: inset 0.5px 0.5px 3px 0px #2F436C;
+
+        /** code fragments */
+        --code-keyword-color: #CC99CD;
+        --code-type-keyword-color: #AB99CD;
+        --code-flow-keyword-color: #E08000;
+        --code-comment-color: #717790;
+        --code-preprocessor-color: #65CABE;
+        --code-string-literal-color: #7EC699;
+        --code-char-literal-color: #00E0F0;
+        --code-xml-cdata-color: #C9D1D9;
+        --code-vhdl-digit-color: #FF00FF;
+        --code-vhdl-char-color: #C0C0C0;
+        --code-vhdl-keyword-color: #CF53C9;
+        --code-vhdl-logic-color: #FF0000;
+        --code-link-color: #79C0FF;
+        --code-external-link-color: #79C0FF;
+        --fragment-foreground-color: #C9D1D9;
+        --fragment-background-color: #090D16;
+        --fragment-border-color: #30363D;
+        --fragment-lineno-border-color: #30363D;
+        --fragment-lineno-background-color: black;
+        --fragment-lineno-foreground-color: #6E7681;
+        --fragment-lineno-link-fg-color: #6E7681;
+        --fragment-lineno-link-bg-color: #303030;
+        --fragment-lineno-link-hover-fg-color: #8E96A1;
+        --fragment-lineno-link-hover-bg-color: #505050;
+        --fragment-copy-ok-color: #0EA80E;
+        --tooltip-foreground-color: #C9D1D9;
+        --tooltip-background-color: #202020;
+        --tooltip-border-color: #C9D1D9;
+        --tooltip-doc-color: #D9E1E9;
+        --tooltip-declaration-color: #20C348;
+        --tooltip-link-color: #79C0FF;
+        --tooltip-shadow: none;
+        --fold-line-color: #808080;
+        --fold-minus-image: url('minusd.svg');
+        --fold-plus-image: url('plusd.svg');
+        --fold-minus-image-relpath: url('../../minusd.svg');
+        --fold-plus-image-relpath: url('../../plusd.svg');
+
+        /** font-family */
+        --font-family-normal: Roboto,sans-serif;
+        --font-family-monospace: 'JetBrains Mono',Consolas,Monaco,'Andale Mono','Ubuntu Mono',monospace,fixed;
+        --font-family-nav: 'Lucida Grande',Geneva,Helvetica,Arial,sans-serif;
+        --font-family-title: Tahoma,Arial,sans-serif;
+        --font-family-toc: Verdana,'DejaVu Sans',Geneva,sans-serif;
+        --font-family-search: Arial,Verdana,sans-serif;
+        --font-family-icon: Arial,Helvetica;
+        --font-family-tooltip: Roboto,sans-serif;
+
+        /** special sections */
+        --warning-color-bg: #2e1917;
+        --warning-color-hl: #ad2617;
+        --warning-color-text: #f5b1aa;
+        --note-color-bg: #3b2e04;
+        --note-color-hl: #f1b602;
+        --note-color-text: #ceb670;
+        --todo-color-bg: #163750;
+        --todo-color-hl: #1982D2;
+        --todo-color-text: #dcf0fa;
+        --test-color-bg: #121258;
+        --test-color-hl: #4242cf;
+        --test-color-text: #c0c0da;
+        --deprecated-color-bg: #2e323b;
+        --deprecated-color-hl: #738396;
+        --deprecated-color-text: #abb0bd;
+        --bug-color-bg: #2a2536;
+        --bug-color-hl: #7661b3;
+        --bug-color-text: #ae9ed6;
+        --invariant-color-bg: #303a35;
+        --invariant-color-hl: #76ce96;
+        --invariant-color-text: #cceed5;
+        }}
+        body {
+            background-color: var(--page-background-color);
+            color: var(--page-foreground-color);
+        }
+
+        body, table, div, p, dl {
+                font-weight: 400;
+                font-size: 14px;
+                font-family: var(--font-family-normal);
+                line-height: 22px;
+        }
+
+        /* @group Heading Levels */
+
+        .title {
+                font-family: var(--font-family-normal);
+                line-height: 28px;
+                font-size: 150%;
+                font-weight: bold;
+                margin: 10px 2px;
+        }
+
+        h1.groupheader {
+                font-size: 150%;
+        }
+
+        h2.groupheader {
+                border-bottom: 1px solid var(--group-header-separator-color);
+                color: var(--group-header-color);
+                font-size: 150%;
+                font-weight: normal;
+                margin-top: 1.75em;
+                padding-top: 8px;
+                padding-bottom: 4px;
+                width: 100%;
+        }
+
+        h3.groupheader {
+                font-size: 100%;
+        }
+
+        h1, h2, h3, h4, h5, h6 {
+                -webkit-transition: text-shadow 0.5s linear;
+                -moz-transition: text-shadow 0.5s linear;
+                -ms-transition: text-shadow 0.5s linear;
+                -o-transition: text-shadow 0.5s linear;
+                transition: text-shadow 0.5s linear;
+                margin-right: 15px;
+        }
+
+        h1.glow, h2.glow, h3.glow, h4.glow, h5.glow, h6.glow {
+                text-shadow: 0 0 15px var(--glow-color);
+        }
+
+        dt {
+                font-weight: bold;
+        }
+
+        p.startli, p.startdd {
+                margin-top: 2px;
+        }
+
+        th p.starttd, th p.intertd, th p.endtd {
+                font-size: 100%;
+                font-weight: 700;
+        }
+
+        p.starttd {
+                margin-top: 0px;
+        }
+
+        p.endli {
+                margin-bottom: 0px;
+        }
+
+        p.enddd {
+                margin-bottom: 4px;
+        }
+
+        p.endtd {
+                margin-bottom: 2px;
+        }
+
+        p.interli {
+        }
+
+        p.interdd {
+        }
+
+        p.intertd {
+        }
+
+        /* @end */
+
+        caption {
+                font-weight: bold;
+        }
+
+        span.legend {
+                font-size: 70%;
+                text-align: center;
+        }
+
+        h3.version {
+                font-size: 90%;
+                text-align: center;
+        }
+
+        div.navtab {
+                padding-right: 15px;
+                text-align: right;
+                line-height: 110%;
+        }
+
+        div.navtab table {
+                border-spacing: 0;
+        }
+
+        td.navtab {
+                padding-right: 6px;
+                padding-left: 6px;
+        }
+
+        td.navtabHL {
+                background-image: var(--nav-gradient-active-image);
+                background-repeat:repeat-x;
+                padding-right: 6px;
+                padding-left: 6px;
+        }
+
+        td.navtabHL a, td.navtabHL a:visited {
+                color: var(--nav-text-hover-color);
+                text-shadow: var(--nav-text-hover-shadow);
+        }
+
+        a.navtab {
+                font-weight: bold;
+        }
+
+        div.qindex{
+                text-align: center;
+                width: 100%;
+                line-height: 140%;
+                font-size: 130%;
+                color: var(--index-separator-color);
+        }
+
+        #main-menu a:focus {
+                outline: auto;
+                z-index: 10;
+                position: relative;
+        }
+
+        dt.alphachar{
+                font-size: 180%;
+                font-weight: bold;
+        }
+
+        .alphachar a{
+                color: var(--index-header-color);
+        }
+
+        .alphachar a:hover, .alphachar a:visited{
+                text-decoration: none;
+        }
+
+        .classindex dl {
+                padding: 25px;
+                column-count:1
+        }
+
+        .classindex dd {
+                display:inline-block;
+                margin-left: 50px;
+                width: 90%;
+                line-height: 1.15em;
+        }
+
+        .classindex dl.even {
+                background-color: var(--index-even-item-bg-color);
+        }
+
+        .classindex dl.odd {
+                background-color: var(--index-odd-item-bg-color);
+        }
+
+        @media(min-width: 1120px) {
+                .classindex dl {
+                        column-count:2
+                }
+        }
+
+        @media(min-width: 1320px) {
+                .classindex dl {
+                        column-count:3
+                }
+        }
+
+
+        /* @group Link Styling */
+
+        a {
+                color: var(--page-link-color);
+                font-weight: normal;
+                text-decoration: none;
+        }
+
+        .contents a:visited {
+                color: var(--page-visited-link-color);
+        }
+
+        a:hover {
+                text-decoration: none;
+                background:   linear-gradient(to bottom, transparent 0,transparent calc(100% - 1px), currentColor 100%);
+        }
+
+        a:hover > span.arrow {
+                text-decoration: none;
+                background : var(--nav-background-color);
+        }
+
+        a.el {
+                font-weight: bold;
+        }
+
+        a.elRef {
+        }
+
+        a.code, a.code:visited, a.line, a.line:visited {
+                color: var(--code-link-color);
+        }
+
+        a.codeRef, a.codeRef:visited, a.lineRef, a.lineRef:visited {
+                color: var(--code-external-link-color);
+        }
+
+        a.code.hl_class { /* style for links to class names in code snippets */ }
+        a.code.hl_struct { /* style for links to struct names in code snippets */ }
+        a.code.hl_union { /* style for links to union names in code snippets */ }
+        a.code.hl_interface { /* style for links to interface names in code snippets */ }
+        a.code.hl_protocol { /* style for links to protocol names in code snippets */ }
+        a.code.hl_category { /* style for links to category names in code snippets */ }
+        a.code.hl_exception { /* style for links to exception names in code snippets */ }
+        a.code.hl_service { /* style for links to service names in code snippets */ }
+        a.code.hl_singleton { /* style for links to singleton names in code snippets */ }
+        a.code.hl_concept { /* style for links to concept names in code snippets */ }
+        a.code.hl_namespace { /* style for links to namespace names in code snippets */ }
+        a.code.hl_package { /* style for links to package names in code snippets */ }
+        a.code.hl_define { /* style for links to macro names in code snippets */ }
+        a.code.hl_function { /* style for links to function names in code snippets */ }
+        a.code.hl_variable { /* style for links to variable names in code snippets */ }
+        a.code.hl_typedef { /* style for links to typedef names in code snippets */ }
+        a.code.hl_enumvalue { /* style for links to enum value names in code snippets */ }
+        a.code.hl_enumeration { /* style for links to enumeration names in code snippets */ }
+        a.code.hl_signal { /* style for links to Qt signal names in code snippets */ }
+        a.code.hl_slot { /* style for links to Qt slot names in code snippets */ }
+        a.code.hl_friend { /* style for links to friend names in code snippets */ }
+        a.code.hl_dcop { /* style for links to KDE3 DCOP names in code snippets */ }
+        a.code.hl_property { /* style for links to property names in code snippets */ }
+        a.code.hl_event { /* style for links to event names in code snippets */ }
+        a.code.hl_sequence { /* style for links to sequence names in code snippets */ }
+        a.code.hl_dictionary { /* style for links to dictionary names in code snippets */ }
+
+        /* @end */
+
+        dl.el {
+                margin-left: -1cm;
+        }
+
+        ul.check {
+          list-style:none;
+          text-indent: -16px;
+          padding-left: 38px;
+        }
+        li.unchecked:before {
+          content: "\2610\A0";
+        }
+        li.checked:before {
+          content: "\2611\A0";
+        }
+
+        ol {
+          text-indent: 0px;
+        }
+
+        ul {
+          text-indent: 0px;
+          overflow: visible;
+        }
+
+        ul.multicol {
+                -moz-column-gap: 1em;
+                -webkit-column-gap: 1em;
+                column-gap: 1em;
+                -moz-column-count: 3;
+                -webkit-column-count: 3;
+                column-count: 3;
+                list-style-type: none;
+        }
+
+        #side-nav ul {
+          overflow: visible; /* reset ul rule for scroll bar in GENERATE_TREEVIEW window */
+        }
+
+        #main-nav ul {
+          overflow: visible; /* reset ul rule for the navigation bar drop down lists */
+        }
+
+        .fragment {
+          text-align: left;
+          direction: ltr;
+          overflow-x: auto;
+          overflow-y: hidden;
+          position: relative;
+          min-height: 12px;
+          margin: 10px 0px;
+          padding: 10px 10px;
+          border: 1px solid var(--fragment-border-color);
+          border-radius: 4px;
+          background-color: var(--fragment-background-color);
+          color: var(--fragment-foreground-color);
+        }
+
+        pre.fragment {
+          word-wrap: break-word;
+          font-size:  10pt;
+          line-height: 125%;
+          font-family: var(--font-family-monospace);
+        }
+
+        .clipboard {
+                width: 24px;
+                height: 24px;
+                right: 5px;
+                top: 5px;
+                opacity: 0;
+                position: absolute;
+                display: inline;
+                overflow: auto;
+                fill: var(--fragment-foreground-color);
+                justify-content: center;
+                align-items: center;
+                cursor: pointer;
+        }
+
+        .clipboard.success {
+                border: 1px solid var(--fragment-foreground-color);
+                border-radius: 4px;
+        }
+
+        .fragment:hover .clipboard, .clipboard.success {
+                opacity: .28;
+        }
+
+        .clipboard:hover, .clipboard.success {
+                opacity: 1 !important;
+        }
+
+        .clipboard:active:not([class~=success]) svg {
+                transform: scale(.91);
+        }
+
+        .clipboard.success svg {
+                fill: var(--fragment-copy-ok-color);
+        }
+
+        .clipboard.success {
+                border-color: var(--fragment-copy-ok-color);
+        }
+
+        div.line {
+                font-family: var(--font-family-monospace);
+                font-size: 13px;
+                min-height: 13px;
+                line-height: 1.2;
+                text-wrap: unrestricted;
+                white-space: -moz-pre-wrap; /* Moz */
+                white-space: -pre-wrap;     /* Opera 4-6 */
+                white-space: -o-pre-wrap;   /* Opera 7 */
+                white-space: pre-wrap;      /* CSS3  */
+                word-wrap: break-word;      /* IE 5.5+ */
+                text-indent: -53px;
+                padding-left: 53px;
+                padding-bottom: 0px;
+                margin: 0px;
+                -webkit-transition-property: background-color, box-shadow;
+                -webkit-transition-duration: 0.5s;
+                -moz-transition-property: background-color, box-shadow;
+                -moz-transition-duration: 0.5s;
+                -ms-transition-property: background-color, box-shadow;
+                -ms-transition-duration: 0.5s;
+                -o-transition-property: background-color, box-shadow;
+                -o-transition-duration: 0.5s;
+                transition-property: background-color, box-shadow;
+                transition-duration: 0.5s;
+        }
+
+        div.line:after {
+            content:"\000A";
+            white-space: pre;
+        }
+
+        div.line.glow {
+                background-color: var(--glow-color);
+                box-shadow: 0 0 10px var(--glow-color);
+        }
+
+        span.fold {
+                margin-left: 5px;
+                margin-right: 1px;
+                margin-top: 0px;
+                margin-bottom: 0px;
+                padding: 0px;
+                display: inline-block;
+                width: 12px;
+                height: 12px;
+                background-repeat:no-repeat;
+                background-position:center;
+        }
+
+        span.lineno {
+                padding-right: 4px;
+                margin-right: 9px;
+                text-align: right;
+                border-right: 2px solid var(--fragment-lineno-border-color);
+                color: var(--fragment-lineno-foreground-color);
+                background-color: var(--fragment-lineno-background-color);
+                white-space: pre;
+        }
+        span.lineno a, span.lineno a:visited {
+                color: var(--fragment-lineno-link-fg-color);
+                background-color: var(--fragment-lineno-link-bg-color);
+        }
+
+        span.lineno a:hover {
+                color: var(--fragment-lineno-link-hover-fg-color);
+                background-color: var(--fragment-lineno-link-hover-bg-color);
+        }
+
+        .lineno {
+                -webkit-touch-callout: none;
+                -webkit-user-select: none;
+                -khtml-user-select: none;
+                -moz-user-select: none;
+                -ms-user-select: none;
+                user-select: none;
+        }
+
+        div.classindex ul {
+                list-style: none;
+                padding-left: 0;
+        }
+
+        div.classindex span.ai {
+                display: inline-block;
+        }
+
+        div.groupHeader {
+                margin-left: 16px;
+                margin-top: 12px;
+                font-weight: bold;
+        }
+
+        div.groupText {
+                margin-left: 16px;
+                font-style: italic;
+        }
+
+        body {
+                color: var(--page-foreground-color);
+                margin: 0;
+        }
+
+        div.contents {
+                margin-top: 10px;
+                margin-left: 12px;
+                margin-right: 8px;
+        }
+
+        p.formulaDsp {
+                text-align: center;
+        }
+
+        img.dark-mode-visible {
+                display: none;
+        }
+        img.light-mode-visible {
+                display: none;
+        }
+
+        img.formulaInl, img.inline {
+                vertical-align: middle;
+        }
+
+        div.center {
+                text-align: center;
+                margin-top: 0px;
+                margin-bottom: 0px;
+                padding: 0px;
+        }
+
+        div.center img {
+                border: 0px;
+        }
+
+        address.footer {
+                text-align: right;
+                padding-right: 12px;
+        }
+
+        img.footer {
+                border: 0px;
+                vertical-align: middle;
+                width: var(--footer-logo-width);
+        }
+
+        .compoundTemplParams {
+                color: var(--memdecl-template-color);
+                font-size: 80%;
+                line-height: 120%;
+        }
+
+        /* @group Code Colorization */
+
+        span.keyword {
+                color: var(--code-keyword-color);
+        }
+
+        span.keywordtype {
+                color: var(--code-type-keyword-color);
+        }
+
+        span.keywordflow {
+                color: var(--code-flow-keyword-color);
+        }
+
+        span.comment {
+                color: var(--code-comment-color);
+        }
+
+        span.preprocessor {
+                color: var(--code-preprocessor-color);
+        }
+
+        span.stringliteral {
+                color: var(--code-string-literal-color);
+        }
+
+        span.charliteral {
+                color: var(--code-char-literal-color);
+        }
+
+        span.xmlcdata {
+                color: var(--code-xml-cdata-color);
+        }
+
+        span.vhdldigit {
+                color: var(--code-vhdl-digit-color);
+        }
+
+        span.vhdlchar {
+                color: var(--code-vhdl-char-color);
+        }
+
+        span.vhdlkeyword {
+                color: var(--code-vhdl-keyword-color);
+        }
+
+        span.vhdllogic {
+                color: var(--code-vhdl-logic-color);
+        }
+
+        blockquote {
+                background-color: var(--blockquote-background-color);
+                border-left: 2px solid var(--blockquote-border-color);
+                margin: 0 24px 0 4px;
+                padding: 0 12px 0 16px;
+        }
+
+        /* @end */
+
+        td.tiny {
+                font-size: 75%;
+        }
+
+        .dirtab {
+                padding: 4px;
+                border-collapse: collapse;
+                border: 1px solid var(--table-cell-border-color);
+        }
+
+        th.dirtab {
+                background-color: var(--table-header-background-color);
+                color: var(--table-header-foreground-color);
+                font-weight: bold;
+        }
+
+        hr {
+                height: 0px;
+                border: none;
+                border-top: 1px solid var(--separator-color);
+        }
+
+        hr.footer {
+                height: 1px;
+        }
+
+        /* @group Member Descriptions */
+
+        table.memberdecls {
+                border-spacing: 0px;
+                padding: 0px;
+        }
+
+        .memberdecls td, .fieldtable tr {
+                -webkit-transition-property: background-color, box-shadow;
+                -webkit-transition-duration: 0.5s;
+                -moz-transition-property: background-color, box-shadow;
+                -moz-transition-duration: 0.5s;
+                -ms-transition-property: background-color, box-shadow;
+                -ms-transition-duration: 0.5s;
+                -o-transition-property: background-color, box-shadow;
+                -o-transition-duration: 0.5s;
+                transition-property: background-color, box-shadow;
+                transition-duration: 0.5s;
+        }
+
+        .memberdecls td.glow, .fieldtable tr.glow {
+                background-color: var(--glow-color);
+                box-shadow: 0 0 15px var(--glow-color);
+        }
+
+        .mdescLeft, .mdescRight,
+        .memItemLeft, .memItemRight,
+        .memTemplItemLeft, .memTemplItemRight, .memTemplParams {
+                background-color: var(--memdecl-background-color);
+                border: none;
+                margin: 4px;
+                padding: 1px 0 0 8px;
+        }
+
+        .mdescLeft, .mdescRight {
+                padding: 0px 8px 4px 8px;
+                color: var(--memdecl-foreground-color);
+        }
+
+        .memSeparator {
+                border-bottom: 1px solid var(--memdecl-separator-color);
+                line-height: 1px;
+                margin: 0px;
+                padding: 0px;
+        }
+
+        .memItemLeft, .memTemplItemLeft {
+                white-space: nowrap;
+        }
+
+        .memItemRight, .memTemplItemRight {
+                width: 100%;
+        }
+
+        .memTemplParams {
+                color: var(--memdecl-template-color);
+                white-space: nowrap;
+                font-size: 80%;
+        }
+
+        /* @end */
+
+        /* @group Member Details */
+
+        /* Styles for detailed member documentation */
+
+        .memtitle {
+                padding: 8px;
+                border-top: 1px solid var(--memdef-border-color);
+                border-left: 1px solid var(--memdef-border-color);
+                border-right: 1px solid var(--memdef-border-color);
+                border-top-right-radius: 4px;
+                border-top-left-radius: 4px;
+                margin-bottom: -1px;
+                background-image: var(--memdef-title-gradient-image);
+                background-repeat: repeat-x;
+                background-color: var(--memdef-title-background-color);
+                line-height: 1.25;
+                font-weight: 300;
+                float:left;
+        }
+
+        .permalink
+        {
+                font-size: 65%;
+                display: inline-block;
+                vertical-align: middle;
+        }
+
+        .memtemplate {
+                font-size: 80%;
+                color: var(--memdef-template-color);
+                font-weight: normal;
+                margin-left: 9px;
+        }
+
+        .mempage {
+                width: 100%;
+        }
+
+        .memitem {
+                padding: 0;
+                margin-bottom: 10px;
+                margin-right: 5px;
+                -webkit-transition: box-shadow 0.5s linear;
+                -moz-transition: box-shadow 0.5s linear;
+                -ms-transition: box-shadow 0.5s linear;
+                -o-transition: box-shadow 0.5s linear;
+                transition: box-shadow 0.5s linear;
+                display: table !important;
+                width: 100%;
+        }
+
+        .memitem.glow {
+                 box-shadow: 0 0 15px var(--glow-color);
+        }
+
+        .memname {
+                font-weight: 400;
+                margin-left: 6px;
+        }
+
+        .memname td {
+                vertical-align: bottom;
+        }
+
+        .memproto, dl.reflist dt {
+                border-top: 1px solid var(--memdef-border-color);
+                border-left: 1px solid var(--memdef-border-color);
+                border-right: 1px solid var(--memdef-border-color);
+                padding: 6px 0px 6px 0px;
+                color: var(--memdef-proto-text-color);
+                font-weight: bold;
+                text-shadow: var(--memdef-proto-text-shadow);
+                background-color: var(--memdef-proto-background-color);
+                box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.15);
+                border-top-right-radius: 4px;
+        }
+
+        .overload {
+                font-family: var(--font-family-monospace);
+                font-size: 65%;
+        }
+
+        .memdoc, dl.reflist dd {
+                border-bottom: 1px solid var(--memdef-border-color);
+                border-left: 1px solid var(--memdef-border-color);
+                border-right: 1px solid var(--memdef-border-color);
+                padding: 6px 10px 2px 10px;
+                border-top-width: 0;
+                background-image:url('nav_g.png');
+                background-repeat:repeat-x;
+                background-color: var(--memdef-doc-background-color);
+                /* opera specific markup */
+                border-bottom-left-radius: 4px;
+                border-bottom-right-radius: 4px;
+                box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.15);
+                /* firefox specific markup */
+                -moz-border-radius-bottomleft: 4px;
+                -moz-border-radius-bottomright: 4px;
+                -moz-box-shadow: rgba(0, 0, 0, 0.15) 5px 5px 5px;
+                /* webkit specific markup */
+                -webkit-border-bottom-left-radius: 4px;
+                -webkit-border-bottom-right-radius: 4px;
+                -webkit-box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.15);
+        }
+
+        dl.reflist dt {
+                padding: 5px;
+        }
+
+        dl.reflist dd {
+                margin: 0px 0px 10px 0px;
+                padding: 5px;
+        }
+
+        .paramkey {
+                text-align: right;
+        }
+
+        .paramtype {
+                white-space: nowrap;
+                padding: 0px;
+                padding-bottom: 1px;
+        }
+
+        .paramname {
+                white-space: nowrap;
+                padding: 0px;
+                padding-bottom: 1px;
+                margin-left: 2px;
+        }
+
+        .paramname em {
+                color: var(--memdef-param-name-color);
+                font-style: normal;
+                margin-right: 1px;
+        }
+
+        .paramname .paramdefval {
+                font-family: var(--font-family-monospace);
+        }
+
+        .params, .retval, .exception, .tparams {
+                margin-left: 0px;
+                padding-left: 0px;
+        }
+
+        .params .paramname, .retval .paramname, .tparams .paramname, .exception .paramname {
+                font-weight: bold;
+                vertical-align: top;
+        }
+
+        .params .paramtype, .tparams .paramtype {
+                font-style: italic;
+                vertical-align: top;
+        }
+
+        .params .paramdir, .tparams .paramdir {
+                font-family: var(--font-family-monospace);
+                vertical-align: top;
+        }
+
+        table.mlabels {
+                border-spacing: 0px;
+        }
+
+        td.mlabels-left {
+                width: 100%;
+                padding: 0px;
+        }
+
+        td.mlabels-right {
+                vertical-align: bottom;
+                padding: 0px;
+                white-space: nowrap;
+        }
+
+        span.mlabels {
+                margin-left: 8px;
+        }
+
+        span.mlabel {
+                background-color: var(--label-background-color);
+                border-top:1px solid var(--label-left-top-border-color);
+                border-left:1px solid var(--label-left-top-border-color);
+                border-right:1px solid var(--label-right-bottom-border-color);
+                border-bottom:1px solid var(--label-right-bottom-border-color);
+                text-shadow: none;
+                color: var(--label-foreground-color);
+                margin-right: 4px;
+                padding: 2px 3px;
+                border-radius: 3px;
+                font-size: 7pt;
+                white-space: nowrap;
+                vertical-align: middle;
+        }
+
+
+
+        /* @end */
+
+        /* these are for tree view inside a (index) page */
+
+        div.directory {
+                margin: 10px 0px;
+                border-top: 1px solid var(--directory-separator-color);
+                border-bottom: 1px solid var(--directory-separator-color);
+                width: 100%;
+        }
+
+        .directory table {
+                border-collapse:collapse;
+        }
+
+        .directory td {
+                margin: 0px;
+                padding: 0px;
+                vertical-align: top;
+        }
+
+        .directory td.entry {
+                white-space: nowrap;
+                padding-right: 6px;
+                padding-top: 3px;
+        }
+
+        .directory td.entry a {
+                outline:none;
+        }
+
+        .directory td.entry a img {
+                border: none;
+        }
+
+        .directory td.desc {
+                width: 100%;
+                padding-left: 6px;
+                padding-right: 6px;
+                padding-top: 3px;
+                border-left: 1px solid rgba(0,0,0,0.05);
+        }
+
+        .directory tr.odd {
+                padding-left: 6px;
+                background-color: var(--index-odd-item-bg-color);
+        }
+
+        .directory tr.even {
+                padding-left: 6px;
+                background-color: var(--index-even-item-bg-color);
+        }
+
+        .directory img {
+                vertical-align: -30%;
+        }
+
+        .directory .levels {
+                white-space: nowrap;
+                width: 100%;
+                text-align: right;
+                font-size: 9pt;
+        }
+
+        .directory .levels span {
+                cursor: pointer;
+                padding-left: 2px;
+                padding-right: 2px;
+                color: var(--page-link-color);
+        }
+
+        .arrow {
+            color: var(--nav-arrow-color);
+            -webkit-user-select: none;
+            -khtml-user-select: none;
+            -moz-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
+            cursor: pointer;
+            font-size: 80%;
+            display: inline-block;
+            width: 16px;
+            height: 22px;
+        }
+
+        .icon {
+            font-family: var(--font-family-icon);
+            line-height: normal;
+            font-weight: bold;
+            font-size: 12px;
+            height: 14px;
+            width: 16px;
+            display: inline-block;
+            background-color: var(--icon-background-color);
+            color: var(--icon-foreground-color);
+            text-align: center;
+            border-radius: 4px;
+            margin-left: 2px;
+            margin-right: 2px;
+        }
+
+        .icona {
+            width: 24px;
+            height: 22px;
+            display: inline-block;
+        }
+
+        .iconfopen {
+            width: 24px;
+            height: 18px;
+            margin-bottom: 4px;
+            background-image:var(--icon-folder-open-image);
+            background-repeat: repeat-y;
+            vertical-align:top;
+            display: inline-block;
+        }
+
+        .iconfclosed {
+            width: 24px;
+            height: 18px;
+            margin-bottom: 4px;
+            background-image:var(--icon-folder-closed-image);
+            background-repeat: repeat-y;
+            vertical-align:top;
+            display: inline-block;
+        }
+
+        .icondoc {
+            width: 24px;
+            height: 18px;
+            margin-bottom: 4px;
+            background-image:var(--icon-doc-image);
+            background-position: 0px -4px;
+            background-repeat: repeat-y;
+            vertical-align:top;
+            display: inline-block;
+        }
+
+        /* @end */
+
+        div.dynheader {
+                margin-top: 8px;
+                -webkit-touch-callout: none;
+                -webkit-user-select: none;
+                -khtml-user-select: none;
+                -moz-user-select: none;
+                -ms-user-select: none;
+                user-select: none;
+        }
+
+        address {
+                font-style: normal;
+                color: var(--footer-foreground-color);
+        }
+
+        table.doxtable caption {
+                caption-side: top;
+        }
+
+        table.doxtable {
+                border-collapse:collapse;
+                margin-top: 4px;
+                margin-bottom: 4px;
+        }
+
+        table.doxtable td, table.doxtable th {
+                border: 1px solid var(--table-cell-border-color);
+                padding: 3px 7px 2px;
+        }
+
+        table.doxtable th {
+                background-color: var(--table-header-background-color);
+                color: var(--table-header-foreground-color);
+                font-size: 110%;
+                padding-bottom: 4px;
+                padding-top: 5px;
+        }
+
+        table.fieldtable {
+                margin-bottom: 10px;
+                border: 1px solid var(--memdef-border-color);
+                border-spacing: 0px;
+                border-radius: 4px;
+                box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+        }
+
+        .fieldtable td, .fieldtable th {
+                padding: 3px 7px 2px;
+        }
+
+        .fieldtable td.fieldtype, .fieldtable td.fieldname {
+                white-space: nowrap;
+                border-right: 1px solid var(--memdef-border-color);
+                border-bottom: 1px solid var(--memdef-border-color);
+                vertical-align: top;
+        }
+
+        .fieldtable td.fieldname {
+                padding-top: 3px;
+        }
+
+        .fieldtable td.fielddoc {
+                border-bottom: 1px solid var(--memdef-border-color);
+        }
+
+        .fieldtable td.fielddoc p:first-child {
+                margin-top: 0px;
+        }
+
+        .fieldtable td.fielddoc p:last-child {
+                margin-bottom: 2px;
+        }
+
+        .fieldtable tr:last-child td {
+                border-bottom: none;
+        }
+
+        .fieldtable th {
+                background-image: var(--memdef-title-gradient-image);
+                background-repeat:repeat-x;
+                background-color: var(--memdef-title-background-color);
+                font-size: 90%;
+                color: var(--memdef-proto-text-color);
+                padding-bottom: 4px;
+                padding-top: 5px;
+                text-align:left;
+                font-weight: 400;
+                border-top-left-radius: 4px;
+                border-top-right-radius: 4px;
+                border-bottom: 1px solid var(--memdef-border-color);
+        }
+
+
+        .tabsearch {
+                top: 0px;
+                left: 10px;
+                height: 36px;
+                background-image: var(--nav-gradient-image);
+                z-index: 101;
+                overflow: hidden;
+                font-size: 13px;
+        }
+
+        .navpath ul
+        {
+                font-size: 11px;
+                background-image: var(--nav-gradient-image);
+                background-repeat:repeat-x;
+                background-position: 0 -5px;
+                height:30px;
+                line-height:30px;
+                color:var(--nav-text-normal-color);
+                border:solid 1px var(--nav-breadcrumb-border-color);
+                overflow:hidden;
+                margin:0px;
+                padding:0px;
+        }
+
+        .navpath li
+        {
+                list-style-type:none;
+                float:left;
+                padding-left:10px;
+                padding-right:15px;
+                background-image:var(--nav-breadcrumb-image);
+                background-repeat:no-repeat;
+                background-position:right;
+                color: var(--nav-foreground-color);
+        }
+
+        .navpath li.navelem a
+        {
+                height:32px;
+                display:block;
+                outline: none;
+                color: var(--nav-text-normal-color);
+                font-family: var(--font-family-nav);
+                text-shadow: var(--nav-text-normal-shadow);
+                text-decoration: none;
+        }
+
+        .navpath li.navelem a:hover
+        {
+                color: var(--nav-text-hover-color);
+                text-shadow: var(--nav-text-hover-shadow);
+        }
+
+        .navpath li.footer
+        {
+                list-style-type:none;
+                float:right;
+                padding-left:10px;
+                padding-right:15px;
+                background-image:none;
+                background-repeat:no-repeat;
+                background-position:right;
+                color: var(--footer-foreground-color);
+                font-size: 8pt;
+        }
+
+
+        div.summary
+        {
+                float: right;
+                font-size: 8pt;
+                padding-right: 5px;
+                width: 50%;
+                text-align: right;
+        }
+
+        div.summary a
+        {
+                white-space: nowrap;
+        }
+
+        table.classindex
+        {
+                margin: 10px;
+                white-space: nowrap;
+                margin-left: 3%;
+                margin-right: 3%;
+                width: 94%;
+                border: 0;
+                border-spacing: 0;
+                padding: 0;
+        }
+
+        div.ingroups
+        {
+                font-size: 8pt;
+                width: 50%;
+                text-align: left;
+        }
+
+        div.ingroups a
+        {
+                white-space: nowrap;
+        }
+
+        div.header
+        {
+                background-image: var(--header-gradient-image);
+                background-repeat:repeat-x;
+                background-color: var(--header-background-color);
+                margin:  0px;
+                border-bottom: 1px solid var(--header-separator-color);
+        }
+
+        div.headertitle
+        {
+                padding: 5px 5px 5px 10px;
+        }
+
+        .PageDocRTL-title div.headertitle {
+          text-align: right;
+          direction: rtl;
+        }
+
+        dl {
+                padding: 0 0 0 0;
+        }
+
+        /*
+
+        dl.section {
+                margin-left: 0px;
+                padding-left: 0px;
+        }
+
+        dl.note {
+          margin-left: -7px;
+          padding-left: 3px;
+          border-left: 4px solid;
+          border-color: #D0C000;
+        }
+
+        dl.warning, dl.attention, dl.important {
+          margin-left: -7px;
+          padding-left: 3px;
+          border-left: 4px solid;
+          border-color: #FF0000;
+        }
+
+        dl.pre, dl.post, dl.invariant {
+          margin-left: -7px;
+          padding-left: 3px;
+          border-left: 4px solid;
+          border-color: #00D000;
+        }
+
+        dl.deprecated {
+          margin-left: -7px;
+          padding-left: 3px;
+          border-left: 4px solid;
+          border-color: #505050;
+        }
+
+        dl.todo {
+          margin-left: -7px;
+          padding-left: 3px;
+          border-left: 4px solid;
+          border-color: #00C0E0;
+        }
+
+        dl.test {
+          margin-left: -7px;
+          padding-left: 3px;
+          border-left: 4px solid;
+          border-color: #3030E0;
+        }
+
+        dl.bug {
+          margin-left: -7px;
+          padding-left: 3px;
+          border-left: 4px solid;
+          border-color: #C08050;
+        }
+
+        */
+
+        dl.bug dt a, dl.deprecated dt a, dl.todo dt a, dl.test a {
+            font-weight: bold !important;
+        }
+
+        dl.warning, dl.attention, dl.important, dl.note, dl.deprecated, dl.bug,
+        dl.invariant, dl.pre, dl.post, dl.todo, dl.test, dl.remark {
+            padding: 10px;
+            margin: 10px 0px;
+            overflow: hidden;
+            margin-left: 0;
+            border-radius: 4px;
+        }
+
+        dl.section dd {
+            margin-bottom: 2px;
+        }
+
+        dl.warning, dl.attention, dl.important {
+            background: var(--warning-color-bg);
+            border-left: 8px solid var(--warning-color-hl);
+            color: var(--warning-color-text);
+        }
+
+        dl.warning dt, dl.attention dt, dl.important dt {
+            color: var(--warning-color-hl);
+        }
+
+        dl.note, dl.remark {
+            background: var(--note-color-bg);
+            border-left: 8px solid var(--note-color-hl);
+            color: var(--note-color-text);
+        }
+
+        dl.note dt, dl.remark dt {
+            color: var(--note-color-hl);
+        }
+
+        dl.todo {
+            background: var(--todo-color-bg);
+            border-left: 8px solid var(--todo-color-hl);
+            color: var(--todo-color-text);
+        }
+
+        dl.todo dt {
+            color: var(--todo-color-hl);
+        }
+
+        dl.test {
+            background: var(--test-color-bg);
+            border-left: 8px solid var(--test-color-hl);
+            color: var(--test-color-text);
+        }
+
+        dl.test dt {
+            color: var(--test-color-hl);
+        }
+
+        dl.bug dt a {
+            color: var(--bug-color-hl) !important;
+        }
+
+        dl.bug {
+            background: var(--bug-color-bg);
+            border-left: 8px solid var(--bug-color-hl);
+            color: var(--bug-color-text);
+        }
+
+        dl.bug dt a {
+            color: var(--bug-color-hl) !important;
+        }
+
+        dl.deprecated {
+            background: var(--deprecated-color-bg);
+            border-left: 8px solid var(--deprecated-color-hl);
+            color: var(--deprecated-color-text);
+        }
+
+        dl.deprecated dt a {
+            color: var(--deprecated-color-hl) !important;
+        }
+
+        dl.note dd, dl.warning dd, dl.pre dd, dl.post dd,
+        dl.remark dd, dl.attention dd, dl.important dd, dl.invariant dd,
+        dl.bug dd, dl.deprecated dd, dl.todo dd, dl.test dd {
+            margin-inline-start: 0px;
+        }
+
+        dl.invariant, dl.pre, dl.post {
+            background: var(--invariant-color-bg);
+            border-left: 8px solid var(--invariant-color-hl);
+            color: var(--invariant-color-text);
+        }
+
+        dl.invariant dt, dl.pre dt, dl.post dt {
+            color: var(--invariant-color-hl);
+        }
+
+
+        #projectrow
+        {
+                height: 56px;
+        }
+
+        #projectlogo
+        {
+                text-align: center;
+                vertical-align: bottom;
+                border-collapse: separate;
+        }
+
+        #projectlogo img
+        {
+                border: 0px none;
+        }
+
+        #projectalign
+        {
+                vertical-align: middle;
+                padding-left: 0.5em;
+        }
+
+        #projectname
+        {
+                font-size: 200%;
+                font-family: var(--font-family-title);
+                margin: 0px;
+                padding: 2px 0px;
+        }
+
+        #projectbrief
+        {
+                font-size: 90%;
+                font-family: var(--font-family-title);
+                margin: 0px;
+                padding: 0px;
+        }
+
+        #projectnumber
+        {
+                font-size: 50%;
+                font-family: 50% var(--font-family-title);
+                margin: 0px;
+                padding: 0px;
+        }
+
+        #titlearea
+        {
+                padding: 0px;
+                margin: 0px;
+                width: 100%;
+                border-bottom: 1px solid var(--title-separator-color);
+                background-color: var(--title-background-color);
+        }
+
+        .image
+        {
+                text-align: center;
+        }
+
+        .dotgraph
+        {
+                text-align: center;
+        }
+
+        .mscgraph
+        {
+                text-align: center;
+        }
+
+        .plantumlgraph
+        {
+                text-align: center;
+        }
+
+        .diagraph
+        {
+                text-align: center;
+        }
+
+        .caption
+        {
+                font-weight: bold;
+        }
+
+        dl.citelist {
+                margin-bottom:50px;
+        }
+
+        dl.citelist dt {
+                color:var(--citation-label-color);
+                float:left;
+                font-weight:bold;
+                margin-right:10px;
+                padding:5px;
+                text-align:right;
+                width:52px;
+        }
+
+        dl.citelist dd {
+                margin:2px 0 2px 72px;
+                padding:5px 0;
+        }
+
+        div.toc {
+                padding: 14px 25px;
+                background-color: var(--toc-background-color);
+                border: 1px solid var(--toc-border-color);
+                border-radius: 7px 7px 7px 7px;
+                float: right;
+                height: auto;
+                margin: 0 8px 10px 10px;
+                width: 200px;
+        }
+
+        div.toc li {
+                background: var(--toc-down-arrow-image) no-repeat scroll 0 5px transparent;
+                font: 10px/1.2 var(--font-family-toc);
+                margin-top: 5px;
+                padding-left: 10px;
+                padding-top: 2px;
+        }
+
+        div.toc h3 {
+                font: bold 12px/1.2 var(--font-family-toc);
+                color: var(--toc-header-color);
+                border-bottom: 0 none;
+                margin: 0;
+        }
+
+        div.toc ul {
+                list-style: none outside none;
+                border: medium none;
+                padding: 0px;
+        }
+
+        div.toc li.level1 {
+                margin-left: 0px;
+        }
+
+        div.toc li.level2 {
+                margin-left: 15px;
+        }
+
+        div.toc li.level3 {
+                margin-left: 15px;
+        }
+
+        div.toc li.level4 {
+                margin-left: 15px;
+        }
+
+        span.emoji {
+                /* font family used at the site: https://unicode.org/emoji/charts/full-emoji-list.html
+                 * font-family: "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji", Times, Symbola, Aegyptus, Code2000, Code2001, Code2002, Musica, serif, LastResort;
+                 */
+        }
+
+        span.obfuscator {
+          display: none;
+        }
+
+        .inherit_header {
+                font-weight: bold;
+                color: var(--inherit-header-color);
+                cursor: pointer;
+                -webkit-touch-callout: none;
+                -webkit-user-select: none;
+                -khtml-user-select: none;
+                -moz-user-select: none;
+                -ms-user-select: none;
+                user-select: none;
+        }
+
+        .inherit_header td {
+                padding: 6px 0px 2px 5px;
+        }
+
+        .inherit {
+                display: none;
+        }
+
+        tr.heading h2 {
+                margin-top: 12px;
+                margin-bottom: 4px;
+        }
+
+        /* tooltip related style info */
+
+        .ttc {
+                position: absolute;
+                display: none;
+        }
+
+        #powerTip {
+                cursor: default;
+                /*white-space: nowrap;*/
+                color: var(--tooltip-foreground-color);
+                background-color: var(--tooltip-background-color);
+                border: 1px solid var(--tooltip-border-color);
+                border-radius: 4px 4px 4px 4px;
+                box-shadow: var(--tooltip-shadow);
+                display: none;
+                font-size: smaller;
+                max-width: 80%;
+                opacity: 0.9;
+                padding: 1ex 1em 1em;
+                position: absolute;
+                z-index: 2147483647;
+        }
+
+        #powerTip div.ttdoc {
+                color: var(--tooltip-doc-color);
+                font-style: italic;
+        }
+
+        #powerTip div.ttname a {
+                font-weight: bold;
+        }
+
+        #powerTip a {
+                color: var(--tooltip-link-color);
+        }
+
+        #powerTip div.ttname {
+                font-weight: bold;
+        }
+
+        #powerTip div.ttdeci {
+                color: var(--tooltip-declaration-color);
+        }
+
+        #powerTip div {
+                margin: 0px;
+                padding: 0px;
+                font-size: 12px;
+                       font-family: var(--font-family-tooltip);
+                line-height: 16px;
+        }
+
+        #powerTip:before, #powerTip:after {
+                content: "";
+                position: absolute;
+                margin: 0px;
+        }
+
+        #powerTip.n:after,  #powerTip.n:before,
+        #powerTip.s:after,  #powerTip.s:before,
+        #powerTip.w:after,  #powerTip.w:before,
+        #powerTip.e:after,  #powerTip.e:before,
+        #powerTip.ne:after, #powerTip.ne:before,
+        #powerTip.se:after, #powerTip.se:before,
+        #powerTip.nw:after, #powerTip.nw:before,
+        #powerTip.sw:after, #powerTip.sw:before {
+                border: solid transparent;
+                content: " ";
+                height: 0;
+                width: 0;
+                position: absolute;
+        }
+
+        #powerTip.n:after,  #powerTip.s:after,
+        #powerTip.w:after,  #powerTip.e:after,
+        #powerTip.nw:after, #powerTip.ne:after,
+        #powerTip.sw:after, #powerTip.se:after {
+                border-color: rgba(255, 255, 255, 0);
+        }
+
+        #powerTip.n:before,  #powerTip.s:before,
+        #powerTip.w:before,  #powerTip.e:before,
+        #powerTip.nw:before, #powerTip.ne:before,
+        #powerTip.sw:before, #powerTip.se:before {
+                border-color: rgba(128, 128, 128, 0);
+        }
+
+        #powerTip.n:after,  #powerTip.n:before,
+        #powerTip.ne:after, #powerTip.ne:before,
+        #powerTip.nw:after, #powerTip.nw:before {
+                top: 100%;
+        }
+
+        #powerTip.n:after, #powerTip.ne:after, #powerTip.nw:after {
+                border-top-color: var(--tooltip-background-color);
+                border-width: 10px;
+                margin: 0px -10px;
+        }
+        #powerTip.n:before, #powerTip.ne:before, #powerTip.nw:before {
+                border-top-color: var(--tooltip-border-color);
+                border-width: 11px;
+                margin: 0px -11px;
+        }
+        #powerTip.n:after, #powerTip.n:before {
+                left: 50%;
+        }
+
+        #powerTip.nw:after, #powerTip.nw:before {
+                right: 14px;
+        }
+
+        #powerTip.ne:after, #powerTip.ne:before {
+                left: 14px;
+        }
+
+        #powerTip.s:after,  #powerTip.s:before,
+        #powerTip.se:after, #powerTip.se:before,
+        #powerTip.sw:after, #powerTip.sw:before {
+                bottom: 100%;
+        }
+
+        #powerTip.s:after, #powerTip.se:after, #powerTip.sw:after {
+                border-bottom-color: var(--tooltip-background-color);
+                border-width: 10px;
+                margin: 0px -10px;
+        }
+
+        #powerTip.s:before, #powerTip.se:before, #powerTip.sw:before {
+                border-bottom-color: var(--tooltip-border-color);
+                border-width: 11px;
+                margin: 0px -11px;
+        }
+
+        #powerTip.s:after, #powerTip.s:before {
+                left: 50%;
+        }
+
+        #powerTip.sw:after, #powerTip.sw:before {
+                right: 14px;
+        }
+
+        #powerTip.se:after, #powerTip.se:before {
+                left: 14px;
+        }
+
+        #powerTip.e:after, #powerTip.e:before {
+                left: 100%;
+        }
+        #powerTip.e:after {
+                border-left-color: var(--tooltip-border-color);
+                border-width: 10px;
+                top: 50%;
+                margin-top: -10px;
+        }
+        #powerTip.e:before {
+                border-left-color: var(--tooltip-border-color);
+                border-width: 11px;
+                top: 50%;
+                margin-top: -11px;
+        }
+
+        #powerTip.w:after, #powerTip.w:before {
+                right: 100%;
+        }
+        #powerTip.w:after {
+                border-right-color: var(--tooltip-border-color);
+                border-width: 10px;
+                top: 50%;
+                margin-top: -10px;
+        }
+        #powerTip.w:before {
+                border-right-color: var(--tooltip-border-color);
+                border-width: 11px;
+                top: 50%;
+                margin-top: -11px;
+        }
+
+        @media print
+        {
+          #top { display: none; }
+          #side-nav { display: none; }
+          #nav-path { display: none; }
+          body { overflow:visible; }
+          h1, h2, h3, h4, h5, h6 { page-break-after: avoid; }
+          .summary { display: none; }
+          .memitem { page-break-inside: avoid; }
+          #doc-content
+          {
+            margin-left:0 !important;
+            height:auto !important;
+            width:auto !important;
+            overflow:inherit;
+            display:inline;
+          }
+        }
+
+        /* @group Markdown */
+
+        table.markdownTable {
+                border-collapse:collapse;
+                margin-top: 4px;
+                margin-bottom: 4px;
+        }
+
+        table.markdownTable td, table.markdownTable th {
+                border: 1px solid var(--table-cell-border-color);
+                padding: 3px 7px 2px;
+        }
+
+        table.markdownTable tr {
+        }
+
+        th.markdownTableHeadLeft, th.markdownTableHeadRight, th.markdownTableHeadCenter, th.markdownTableHeadNone {
+                background-color: var(--table-header-background-color);
+                color: var(--table-header-foreground-color);
+                font-size: 110%;
+                padding-bottom: 4px;
+                padding-top: 5px;
+        }
+
+        th.markdownTableHeadLeft, td.markdownTableBodyLeft {
+                text-align: left
+        }
+
+        th.markdownTableHeadRight, td.markdownTableBodyRight {
+                text-align: right
+        }
+
+        th.markdownTableHeadCenter, td.markdownTableBodyCenter {
+                text-align: center
+        }
+
+        tt, code, kbd, samp
+        {
+          display: inline-block;
+        }
+        /* @end */
+
+        u {
+                text-decoration: underline;
+        }
+
+        details>summary {
+          list-style-type: none;
+        }
+
+        details > summary::-webkit-details-marker {
+            display: none;
+        }
+
+        details>summary::before {
+            content: "\25ba";
+            padding-right:4px;
+            font-size: 80%;
+        }
+
+        details[open]>summary::before {
+            content: "\25bc";
+            padding-right:4px;
+            font-size: 80%;
+        }
+
+        body {
+            scrollbar-color: var(--scrollbar-thumb-color) var(--scrollbar-background-color);
+        }
+
+        ::-webkit-scrollbar {
+                background-color: var(--scrollbar-background-color);
+                height: 12px;
+                width: 12px;
+        }
+        ::-webkit-scrollbar-thumb {
+                border-radius: 6px;
+                box-shadow: inset 0 0 12px 12px var(--scrollbar-thumb-color);
+                border: solid 2px transparent;
+        }
+        ::-webkit-scrollbar-corner {
+                background-color: var(--scrollbar-background-color);
+        }
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Updated doxygen files to the version 1.11 so a dark mode renders properly

ENDRELEASENOTES

The config for oxygen was for an older version (1.8) that we had in stack (1.11). One change that I care about is the dark mode which with 1.8 is partially not readable (top level header is black on black background, code snippets from markdown are light grey on white). For light mode the changes seem to be minimal.

These are both "dark mode"
| 1.8 | 1.11 |
|-|-|
| ![image](https://github.com/user-attachments/assets/40739e84-265a-43e9-bd13-abb8e2e3a3cb) | ![image](https://github.com/user-attachments/assets/fce80168-ee04-42c4-ac84-d2f5620d6295) |
| ![image](https://github.com/user-attachments/assets/4a31f7a3-47f5-4588-921e-e93a9fee0590) | ![image](https://github.com/user-attachments/assets/3363025d-5c05-419c-ba51-ec64a4bd811e) |

Doxyfile was updated from template `doxygen -u`
html and css were regenerated for 1.11 as what we had were also the defaults but for 1.8