### PR TITLE
Install rootmap for old schema dictionaries

### DIFF
--- a/edm4hep/CMakeLists.txt
+++ b/edm4hep/CMakeLists.txt
@@ -56,6 +56,8 @@ install(TARGETS ${EDM4HEP_INSTALL_LIBS}
 install(FILES
   "${PROJECT_BINARY_DIR}/edm4hep/edm4hepDictDict.rootmap"
   "${PROJECT_BINARY_DIR}/edm4hep/libedm4hepDict_rdict.pcm"
+  "${PROJECT_BINARY_DIR}/edm4hep/edm4hepOldSchemasDictDict.rootmap"
+  "${PROJECT_BINARY_DIR}/edm4hep/libedm4hepOldSchemasDict_rdict.pcm"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT dev)
 
 install(FILES


### PR DESCRIPTION

BEGINRELEASENOTES
- Make sure to also install the `rootmap` and `rdict` files for the old schemas library

ENDRELEASENOTES

Follow up on #373 and #391, so that we now hopefully have everything installed that is necessary.