### PR TITLE
show standalone documentation pages in doxygen docs

### DIFF
--- a/doc/DoxygenLayout.xml
+++ b/doc/DoxygenLayout.xml
@@ -6,6 +6,11 @@
     <tab type="user" visible="yes" title="Key4HEP Home Page" url="https://cern.ch/key4hep"/>
     <tab type="pages" visible="no" title="" intro=""/>
     <tab type="user" visible="yes" title="Contribution Guide" url="@ref md_doc_2contributing"/>
+    <tab type="usergroup" title="Selected topics">
+      <tab type="user" visible="yes" title="Generator data" url="@ref md_doc_2_generator_info"/>
+      <tab type="user" visible="yes" title="Vertex and ReconstructedParticle" url="@ref md_doc_2_vertex_reco_particle_recos"/>
+      <tab type="user" visible="yes" title="PIDHandler" url="@ref md_doc_2_p_i_d_handler"/>
+    </tab>
     <tab type="modules" visible="yes" title="" intro=""/>
     <tab type="namespaces" visible="yes" title="">
       <tab type="namespacelist" visible="yes" title="" intro=""/>
@@ -22,6 +27,7 @@
       <tab type="globals" visible="yes" title="" intro=""/>
     </tab>
     <tab type="examples" visible="yes" title="" intro=""/>
+    <tab type="user" visible="yes" title="Release notes" url="@ref md_doc_2_release_notes"/>
   </navindex>
 
   <!-- Layout definition for a class page -->


### PR DESCRIPTION

BEGINRELEASENOTES
- Added a tab with standalone documentation pages in doxygen docs

ENDRELEASENOTES

Adding tabs:
-`Release notes`
-`Selected topics` - I'm not entirely convinced by this name.

I didn't figure out if there is a way to use more readable references to the files

![image](https://github.com/user-attachments/assets/1c4cd7bd-3584-4013-ba74-d03bfd744bee)
