### PR TITLE
[WIP] Replace the spin by a helicity property for the MCParticle

### DIFF
--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -241,7 +241,7 @@ datatypes:
       - edm4hep::Vector3d endpoint [mm]           // endpoint of the particle
       - edm4hep::Vector3d momentum [GeV]            // particle 3-momentum at the production vertex
       - edm4hep::Vector3d momentumAtEndpoint [GeV]  // particle 3-momentum at the endpoint
-      - edm4hep::Vector3f spin                 // spin (helicity) vector of the particle
+      - int32_t helicity{9}                     // particle helicity (9 if unset)
     OneToManyRelations:
       - edm4hep::MCParticle parents // The parents of this particle
       - edm4hep::MCParticle daughters // The daughters this particle
@@ -290,8 +290,8 @@ datatypes:
         bool isStopped() const { return utils::checkBit(getSimulatorStatus(), BITStopped); }
         /// True if the particle has been overlayed by the simulation (or digitization)  program.
         bool isOverlay() const { return utils::checkBit(getSimulatorStatus(), BITOverlay); }
-
-
+        /// Check if this particle has a set helicty
+        bool hasHelicity() const noexcept { return getHelicity() != 9; }
 
   edm4hep::SimTrackerHit:
     Description: "Simulated tracker hit"

--- a/edm4hep/CMakeLists.txt
+++ b/edm4hep/CMakeLists.txt
@@ -27,14 +27,22 @@ endif()
 PODIO_ADD_ROOT_IO_DICT(edm4hepDict edm4hep "${headers}" src/selection.xml)
 add_library(EDM4HEP::edm4hepDict ALIAS edm4hepDict )
 
-add_library(edm4hepOldSchemas SHARED schema_evolution/src/OldLinkEvolution.cc)
+add_library(edm4hepOldSchemas SHARED
+  schema_evolution/src/OldLinkEvolution.cc
+  schema_evolution/src/MCParticleEvolution.cc
+)
 target_include_directories(edm4hepOldSchemas PRIVATE
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/edm4hep/schema_evolution/include>
 )
 target_link_libraries(edm4hepOldSchemas PUBLIC podio::podio EDM4HEP::edm4hep)
 add_library(EDM4HEP::oldSchemas ALIAS edm4hepOldSchemas)
 
-PODIO_ADD_ROOT_IO_DICT(edm4hepOldSchemasDict edm4hepOldSchemas ${PROJECT_SOURCE_DIR}/edm4hep/schema_evolution/include/edm4hep/schema_evolution/OldLinkData.h schema_evolution/src/selection.xml)
+set(evolution_headers
+  ${PROJECT_SOURCE_DIR}/edm4hep/schema_evolution/include/edm4hep/schema_evolution/OldLinkData.h
+  ${PROJECT_SOURCE_DIR}/edm4hep/schema_evolution/include/edm4hep/schema_evolution/OldMCParticleData.h
+)
+
+PODIO_ADD_ROOT_IO_DICT(edm4hepOldSchemasDict edm4hepOldSchemas "${evolution_headers}" schema_evolution/src/selection.xml)
 add_library(EDM4HEP::oldSchemasDict ALIAS edm4hepOldSchemasDict)
 
 list(APPEND EDM4HEP_INSTALL_LIBS edm4hep edm4hepDict edm4hepOldSchemas edm4hepOldSchemasDict)

--- a/edm4hep/schema_evolution/include/edm4hep/schema_evolution/OldMCParticleData.h
+++ b/edm4hep/schema_evolution/include/edm4hep/schema_evolution/OldMCParticleData.h
@@ -1,0 +1,38 @@
+#ifndef EDM4HEP_SCHEMA_EVOLUTION_OLDMCPARTICLEDATA_H
+#define EDM4HEP_SCHEMA_EVOLUTION_OLDMCPARTICLEDATA_H
+
+#include <edm4hep/Vector3d.h>
+#include <edm4hep/Vector3f.h>
+
+#include <cstdint>
+
+namespace edm4hep::v2 {
+
+struct Vector2i {
+  int a{};
+  int b{};
+};
+
+struct MCParticleData {
+  std::int32_t PDG{};             ///< PDG code of the particle
+  std::int32_t generatorStatus{}; ///< status of the particle as defined by the generator
+  std::int32_t simulatorStatus{}; ///< status of the particle from the simulation program - use BIT constants below
+  float charge{};                 ///< particle charge
+  float time{};  ///< creation time of the particle in wrt. the event, e.g. for preassigned decays or decays in flight
+                 ///< from the simulator [ns]
+  double mass{}; ///< mass of the particle [GeV]
+  ::edm4hep::Vector3d vertex{};             ///< production vertex of the particle [mm]
+  ::edm4hep::Vector3d endpoint{};           ///< endpoint of the particle [mm]
+  ::edm4hep::Vector3d momentum{};           ///< particle 3-momentum at the production vertex [GeV]
+  ::edm4hep::Vector3d momentumAtEndpoint{}; ///< particle 3-momentum at the endpoint [GeV]
+  ::edm4hep::Vector3f spin{};               ///< particle spin
+  Vector2i colorFlow{};
+
+  unsigned int parents_begin{};
+  unsigned int parents_end{};
+  unsigned int daughters_begin{};
+  unsigned int daughters_end{};
+};
+} // namespace edm4hep::v2
+
+#endif // EDM4HEP_SCHEMA_EVOLUTION_OLDMCPARTICLEDATA_H

--- a/edm4hep/schema_evolution/src/MCParticleEvolution.cc
+++ b/edm4hep/schema_evolution/src/MCParticleEvolution.cc
@@ -1,0 +1,103 @@
+#include "edm4hep/MCParticleData.h"
+#include <edm4hep/DatamodelDefinition.h>
+#include <edm4hep/MCParticleCollection.h>
+#include <edm4hep/MCParticleCollectionData.h>
+#include <edm4hep/schema_evolution/OldMCParticleData.h>
+
+#include <podio/CollectionBufferFactory.h>
+#include <podio/CollectionBuffers.h>
+#include <podio/SchemaEvolution.h>
+
+#include <iostream>
+#include <memory>
+#include <string_view>
+
+namespace edm4hep {
+namespace {
+  auto evolveSpinHelicity(podio::CollectionReadBuffers buffers, podio::SchemaVersionT fromVersion) {
+    if (fromVersion > 2) {
+      return buffers;
+    }
+    buffers.schemaVersion = edm4hep::meta::schemaVersion;
+
+    // We only have to evolve the data, all other members are already created
+    // correctly for working after schema evolution below
+    auto* oldData = podio::CollectionWriteBuffers::asVector<edm4hep::v2::MCParticleData>(buffers.data);
+    auto* newData = new std::vector<edm4hep::MCParticleData>();
+    newData->reserve(oldData->size());
+    for (const auto& oldMC : *oldData) {
+      newData->emplace_back(oldMC.PDG, oldMC.generatorStatus, oldMC.simulatorStatus, oldMC.charge, oldMC.time,
+                            oldMC.mass, oldMC.vertex, oldMC.endpoint, oldMC.momentum, oldMC.momentumAtEndpoint,
+                            int(oldMC.spin.z), oldMC.parents_begin, oldMC.parents_end, oldMC.daughters_begin,
+                            oldMC.daughters_end);
+    }
+    delete oldData;
+    buffers.data = newData;
+
+    return buffers;
+  }
+
+  auto createOldBufferFunction(bool isSubset) {
+    auto readBuffers = podio::CollectionReadBuffers{};
+    readBuffers.type = "edm4hep::MCParticleCollection";
+    readBuffers.schemaVersion = 2;
+    readBuffers.data = isSubset ? nullptr : new std::vector<edm4hep::v2::MCParticleData>;
+    // The number of ObjectID vectors is either 1 or the sum of OneToMany and
+    // OneToOne relations
+    const auto nRefs = isSubset ? 1 : 2 + 0;
+    readBuffers.references = new podio::CollRefCollection(nRefs);
+    for (auto& ref : *readBuffers.references) {
+      // Make sure to place usable buffer pointers here
+      ref = std::make_unique<std::vector<podio::ObjectID>>();
+    }
+
+    readBuffers.vectorMembers = new podio::VectorMembersInfo();
+    if (!isSubset) {
+      readBuffers.vectorMembers->reserve(0);
+    }
+
+    readBuffers.createCollection = [](const podio::CollectionReadBuffers& buffers, bool isSubsetColl) {
+      MCParticleCollectionData data(buffers, isSubsetColl);
+      return std::make_unique<MCParticleCollection>(std::move(data), isSubsetColl);
+    };
+
+    readBuffers.recast = [](podio::CollectionReadBuffers& buffers) {
+      // We only have any of these buffers if this is not a subset collection
+      if (buffers.data) {
+        buffers.data = podio::CollectionWriteBuffers::asVector<edm4hep::v2::MCParticleData>(buffers.data);
+      }
+    };
+
+    readBuffers.deleteBuffers = [](podio::CollectionReadBuffers& buffers) {
+      if (buffers.data) {
+        // If we have data then we are not a subset collection and we have to
+        // clean up all type erased buffers by casting them back to something that
+        // we can delete. We have also not undergone schema evolution
+        delete static_cast<std::vector<edm4hep::v2::MCParticleData>*>(buffers.data);
+      }
+      delete buffers.references;
+      delete buffers.vectorMembers;
+    };
+
+    return readBuffers;
+  };
+
+  bool registerTransition() {
+    const static auto registerEvoFuncs = []() {
+      std::cout << "HERE I AM REGISTERING FUNCTIONS AND STUFF\n";
+      podio::CollectionBufferFactory::mutInstance().registerCreationFunc("edm4hep::MCParticleCollection", 2,
+                                                                         createOldBufferFunction);
+
+      podio::SchemaEvolution::mutInstance().registerEvolutionFunc("edm4hep::MCParticleCollection", 2,
+                                                                  edm4hep::meta::schemaVersion, evolveSpinHelicity,
+                                                                  podio::SchemaEvolution::Priority::UserDefined);
+      return true;
+    }();
+
+    return registerEvoFuncs;
+  }
+
+  const static auto reg_MCParticleSpinHelicityEvo = registerTransition();
+
+} // namespace
+} // namespace edm4hep

--- a/edm4hep/schema_evolution/src/selection.xml
+++ b/edm4hep/schema_evolution/src/selection.xml
@@ -7,5 +7,8 @@
       <class name="edm4hep::CaloHitSimCaloHitLinkData" ClassVersion="2"/>
       <class name="edm4hep::TrackerHitSimTrackerHitLinkData" ClassVersion="2"/>
       <class name="edm4hep::VertexRecoParticleLinkData" ClassVersion="2"/>
+
+      <class name="edm4hep::v2::Vector2i"/>
+      <class name="edm4hep::v2::MCParticleData" ClassVersion="2"/>
     </selection>
 </lcgdict>

--- a/scripts/createEDM4hepFile.py
+++ b/scripts/createEDM4hepFile.py
@@ -51,7 +51,7 @@ def create_MCParticleCollection():
         particle.setMomentumAtEndpoint(
             edm4hep.Vector3d(next(counter), next(counter), next(counter))
         )
-        particle.setSpin(edm4hep.Vector3f(next(counter), next(counter), next(counter)))
+        particle.setHelicity(next(counter))
 
     p_list[0].addToDaughters(p_list[1])
     p_list[0].addToParents(p_list[2])

--- a/test/test_EDM4hepFile.py
+++ b/test/test_EDM4hepFile.py
@@ -155,7 +155,14 @@ def test_MCParticleCollection(event, edm4hep_version):
         assert particle.getMomentumAtEndpoint() == edm4hep.Vector3d(
             next(counter), next(counter), next(counter)
         )
-        assert particle.getSpin() == edm4hep.Vector3f(next(counter), next(counter), next(counter))
+
+        if edm4hep_version < podio.version.parse("0.99.2"):
+            # The spin 3D vector has been replaced by helicity and schema
+            # evolution puts the contents of the z-component into the helicity
+            # as that was the main use case in any case
+            next(counter)
+            next(counter)
+        assert particle.getHelicity() == next(counter)
 
         if edm4hep_version < podio.version.parse("0.99.2"):
             # The colorFlow was here so we have increase the counter here to

--- a/test/utils/test_kinematics.py
+++ b/test/utils/test_kinematics.py
@@ -33,7 +33,7 @@ class TestKinematics(unittest.TestCase):
             edm4hep.Vector3d(0, 0, 0),  # endpoint
             edm4hep.Vector3d(1.0, 2.0, 3.0),  # momentum
             edm4hep.Vector3d(0, 0, 0),  # momentumAtEndpoint
-            edm4hep.Vector3f(0, 0, 0),  # spin
+            1,  # helicity
         )
 
         self.assertEqual(p4(p), LVM(1.0, 2.0, 3.0, 125.0))


### PR DESCRIPTION

BEGINRELEASENOTES
- Replace the `spin` by `helicity` in `MCParticle` as the former is not usable without the full spin-density matrix whereas the latter is always well defined (or unset).
  - Defaults to `9` which is used to signify an unset value. Use `hasHelicity` to check whether the `helicity` is set

ENDRELEASENOTES

- [ ] Schema evolution to make this a backwards compatible change, such that `spin.z` will end up in `helicity` as that seems to be the main way that `spin` has been populated in the past in LCIO.