### PR TITLE
Use std::swap and add a default case for the switch statement

### DIFF
--- a/utils/include/edm4hep/utils/cov_matrix_utils.h
+++ b/utils/include/edm4hep/utils/cov_matrix_utils.h
@@ -5,6 +5,7 @@
 #include <stdexcept>
 #include <string>
 #include <type_traits>
+#include <utility>
 
 namespace edm4hep {
 
@@ -26,13 +27,6 @@ namespace utils {
     template <typename DimEnum>
     constexpr DimEnum to_enum(DimEnum index) {
       return static_cast<DimEnum>(index);
-    }
-
-    /// Need a constexpr swap for integers before c++20
-    constexpr void swap(int& i, int& j) {
-      int tmp = j;
-      j = i;
-      i = tmp;
     }
 
     /**
@@ -63,12 +57,12 @@ namespace utils {
         return 2;
       case 1:
         return 1;
+      default:
+        // We simply use throwing an exception to make compilation fail in constexpr
+        // cases.
+        throw std::invalid_argument(
+            "Not a valid size for a covariance matrix stored in lower triangular form (N = " + std::to_string(N) + ")");
       }
-
-      // We simply use throwing an exception to make compilation fail in constexpr
-      // cases.
-      throw std::invalid_argument(
-          "Not a valid size for a covariance matrix stored in lower triangular form (N = " + std::to_string(N) + ")");
     }
 
     /**
@@ -81,7 +75,7 @@ namespace utils {
      */
     constexpr int to_lower_tri(int i, int j) {
       if (i < j) {
-        detail::swap(i, j);
+        std::swap(i, j);
       }
       return i * (i + 1) / 2 + j;
     }


### PR DESCRIPTION
BEGINRELEASENOTES
- Use `std::swap` (available now that we compile with C++20) and add a default
  case for the switch statement in the covariance matrix utils

ENDRELEASENOTES