### PR TITLE
Limit the RNTuple backwards compatibility to podio 1.2

### DIFF
--- a/test/backwards_compat/CMakeLists.txt
+++ b/test/backwards_compat/CMakeLists.txt
@@ -10,7 +10,7 @@ set_tests_properties(
 )
 
 
-if (${ROOT_VERSION} VERSION_GREATER_EQUAL 6.34)
+if (${ROOT_VERSION} VERSION_GREATER_EQUAL 6.34 AND ${podio_VERSION} VERSION_LESS_EQUAL 1.2)
   # This input file has been written with ROOT 6.34.
   # Trying to read this with an older version of ROOT doesn't work
   ExternalData_Add_Test(backward_compat_tests


### PR DESCRIPTION

BEGINRELEASENOTES
- Limit the RNTuple backwards compatibility checks to only run with ROOT 6.34.04 and podio 1.2

ENDRELEASENOTES

The file we download has been written with podio 1.2, and https://github.com/AIDASoft/podio/pull/711 changes the storage details of the metadata for the podio RNTuple backend. Once that PR is merged we can update this file and change the conditions for this check again.