### PR TITLE
use link collection `typeName`

### DIFF
--- a/edm4hep/schema_evolution/src/OldLinkEvolution.cc
+++ b/edm4hep/schema_evolution/src/OldLinkEvolution.cc
@@ -31,7 +31,7 @@ namespace {
   /// createCollection to actually create a templated LinkCollection
   template <typename FromT, typename ToT>
   auto evolveLinks(podio::CollectionReadBuffers buffers, podio::SchemaVersionT) {
-    buffers.type = podio::detail::linkCollTypeName<FromT, ToT>();
+    buffers.type = podio::LinkCollection<FromT, ToT>::typeName;
     buffers.schemaVersion = podio::LinkCollection<FromT, ToT>::schemaVersion;
 
     buffers.createCollection = [](const podio::CollectionReadBuffers& buffs, bool isSubsetColl) {


### PR DESCRIPTION

BEGINRELEASENOTES
- Replace `podio::detail::linkCollTypeName` with  link collection `typeName` introduced in AIDASoft/podio#748

ENDRELEASENOTES


Replace `podio::detail::linkCollTypeName` with  link collection `typeName` introduced in AIDASoft/podio#748