### PR TITLE
add missing units in datamodel yaml file

### DIFF
--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -510,7 +510,7 @@ datatypes:
     Description: "Vertex"
     Author: "EDM4hep authors"
     Members:
-      - uint32_t            type          // Flagword that defines the type of the vertex, see reserved bits for more information
+      - uint32_t            type          // flagword that defines the type of the vertex, see reserved bits for more information
       - float               chi2          // chi-squared of the vertex fit
       - int32_t             ndf           // number of degrees of freedom of the vertex fit
       - edm4hep::Vector3f   position [mm]     //  position of the vertex

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -494,7 +494,7 @@ datatypes:
     Author: "EDM4hep authors"
     Members:
       - int32_t type                         // flagword that defines the type of track
-      - float chi2                       // Chi^2 of the track fit
+      - float chi2                       // chi-squared of the track fit
       - int32_t ndf                          // number of degrees of freedom of the track fit
       - int32_t Nholes                   // number of holes on track
     VectorMembers:

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -398,10 +398,10 @@ datatypes:
       - float                energy [GeV]        // energy of the cluster
       - float                energyError [GeV]   // error on the energy
       - edm4hep::Vector3f    position [mm]       // position of the cluster
-      - edm4hep::CovMatrix3f positionError [mm**2]  // covariance matrix of the position
+      - edm4hep::CovMatrix3f positionError [mm^2]  // covariance matrix of the position
       - float                iTheta [rad]    // Polar angle of the cluster's intrinsic direction (used e.g. for vertexing). Not to be confused with the cluster position seen from IP
       - float                phi [rad]       // Azimuthal angle of the cluster's intrinsic direction (used e.g. for vertexing). Not to be confused with the cluster position seen from IP
-      - edm4hep::Vector3f    directionError [mm**2]  // covariance matrix of the direction
+      - edm4hep::Vector3f    directionError [mm^2]  // covariance matrix of the direction
     VectorMembers:
       - float   shapeParameters      // shape parameters. This should be accompanied by a descriptive list of names in the shapeParameterNames collection level metadata, as a vector of strings with the same ordering
       - float   subdetectorEnergies  // energy observed in a particular subdetector
@@ -433,7 +433,7 @@ datatypes:
       - float eDep [GeV]                   // energy deposited on the hit
       - float eDepError [GeV]              // error measured on eDep
       - edm4hep::Vector3d position [mm]    // hit position
-      - edm4hep::CovMatrix3f covMatrix [mm**2] // covariance matrix of the position (x,y,z)
+      - edm4hep::CovMatrix3f covMatrix [mm^2] // covariance matrix of the position (x,y,z)
     ExtraCode:
       includes: "#include <edm4hep/Constants.h>"
       declaration: |
@@ -462,7 +462,7 @@ datatypes:
       - float du                       // measurement error along the direction
       - float dv                       // measurement error along the direction
       - edm4hep::Vector3d position [mm]   // hit position
-      - edm4hep::CovMatrix3f covMatrix [mm**2] // covariance of the position (x,y,z)
+      - edm4hep::CovMatrix3f covMatrix [mm^2] // covariance of the position (x,y,z)
     ExtraCode:
       includes: "#include <edm4hep/Constants.h>"
       declaration: |
@@ -514,7 +514,7 @@ datatypes:
       - float               chi2          // chi-squared of the vertex fit
       - int32_t             ndf           // number of degrees of freedom of the vertex fit
       - edm4hep::Vector3f   position [mm]     //  position of the vertex
-      - edm4hep::CovMatrix3f covMatrix [mm**2]  // covariance matrix of the position
+      - edm4hep::CovMatrix3f covMatrix [mm^2]  // covariance matrix of the position
       - int32_t                 algorithmType // type code for the algorithm that has been used to create the vertex
     VectorMembers:
       - float               parameters    // additional parameters related to this vertex
@@ -563,7 +563,7 @@ datatypes:
       - float                  charge [e]        // charge of the reconstructed particle
       - float                  mass  [GeV]    //  mass of the reconstructed particle, set independently from four vector. Four momentum state is not kept consistent internally
       - float                  goodnessOfPID  // overall goodness of the PID on a scale of [0;1]
-      - edm4hep::CovMatrix4f   covMatrix  [GeV**2]    // covariance matrix of the reconstructed particle 4vector
+      - edm4hep::CovMatrix4f   covMatrix  [GeV^2]    // covariance matrix of the reconstructed particle 4vector
     OneToOneRelations:
       - edm4hep::Vertex          decayVertex    // decay vertex for the particle (if it is a composite particle)
     OneToManyRelations:

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -234,7 +234,7 @@ datatypes:
       - int32_t PDG                         // PDG code of the particle
       - int32_t generatorStatus             // status of the particle as defined by the generator
       - int32_t simulatorStatus             // status of the particle from the simulation program - use BIT constants below
-      - float charge                    // particle charge
+      - float charge [e]                   // particle charge
       - float time [ns]                     // creation time of the particle in wrt. the event, e.g. for preassigned decays or decays in flight from the simulator
       - double mass [GeV]                    // mass of the particle
       - edm4hep::Vector3d vertex [mm]             // production vertex of the particle
@@ -338,7 +338,7 @@ datatypes:
     Author: "EDM4hep authors"
     Members:
       - int32_t   PDG                        // PDG code of the shower particle that caused this contribution
-      - float energy [G]                    // energy of the this contribution
+      - float energy [GeV]                    // energy of this contribution
       - float time [ns]                     // time of this contribution
       - edm4hep::Vector3f stepPosition [mm] // position of this energy deposition (step)
     OneToOneRelations:
@@ -398,7 +398,7 @@ datatypes:
       - float                energy [GeV]        // energy of the cluster
       - float                energyError [GeV]   // error on the energy
       - edm4hep::Vector3f    position [mm]       // position of the cluster
-      - edm4hep::CovMatrix3f positionError   // covariance matrix of the position
+      - edm4hep::CovMatrix3f positionError [mm**2]  // covariance matrix of the position
       - float                iTheta [rad]    // Polar angle of the cluster's intrinsic direction (used e.g. for vertexing). Not to be confused with the cluster position seen from IP
       - float                phi [rad]       // Azimuthal angle of the cluster's intrinsic direction (used e.g. for vertexing). Not to be confused with the cluster position seen from IP
       - edm4hep::Vector3f    directionError [mm**2]  // covariance matrix of the direction
@@ -433,7 +433,7 @@ datatypes:
       - float eDep [GeV]                   // energy deposited on the hit
       - float eDepError [GeV]              // error measured on eDep
       - edm4hep::Vector3d position [mm]    // hit position
-      - edm4hep::CovMatrix3f covMatrix // covariance matrix of the position (x,y,z)
+      - edm4hep::CovMatrix3f covMatrix [mm**2] // covariance matrix of the position (x,y,z)
     ExtraCode:
       includes: "#include <edm4hep/Constants.h>"
       declaration: |
@@ -462,7 +462,7 @@ datatypes:
       - float du                       // measurement error along the direction
       - float dv                       // measurement error along the direction
       - edm4hep::Vector3d position [mm]   // hit position
-      - edm4hep::CovMatrix3f covMatrix // covariance of the position (x,y,z)
+      - edm4hep::CovMatrix3f covMatrix [mm**2] // covariance of the position (x,y,z)
     ExtraCode:
       includes: "#include <edm4hep/Constants.h>"
       declaration: |
@@ -513,8 +513,8 @@ datatypes:
       - uint32_t            type          // Flagword that defines the type of the vertex, see reserved bits for more information
       - float               chi2          // chi-squared of the vertex fit
       - int32_t             ndf           // number of degrees of freedom of the vertex fit
-      - edm4hep::Vector3f   position      // [mm] position of the vertex
-      - edm4hep::CovMatrix3f covMatrix // covariance matrix of the position
+      - edm4hep::Vector3f   position [mm]     //  position of the vertex
+      - edm4hep::CovMatrix3f covMatrix [mm**2]  // covariance matrix of the position
       - int32_t                 algorithmType // type code for the algorithm that has been used to create the vertex
     VectorMembers:
       - float               parameters    // additional parameters related to this vertex
@@ -560,10 +560,10 @@ datatypes:
       - float                  energy [GeV]    // energy of the reconstructed particle. Four momentum state is not kept consistent internally
       - edm4hep::Vector3f      momentum [GeV]  //  particle momentum. Four momentum state is not kept consistent internally
       - edm4hep::Vector3f      referencePoint [mm] // reference, i.e. where the particle has been measured
-      - float                  charge         // charge of the reconstructed particle
+      - float                  charge [e]        // charge of the reconstructed particle
       - float                  mass  [GeV]    //  mass of the reconstructed particle, set independently from four vector. Four momentum state is not kept consistent internally
       - float                  goodnessOfPID  // overall goodness of the PID on a scale of [0;1]
-      - edm4hep::CovMatrix4f   covMatrix      // covariance matrix of the reconstructed particle 4vector
+      - edm4hep::CovMatrix4f   covMatrix  [GeV**2]    // covariance matrix of the reconstructed particle 4vector
     OneToOneRelations:
       - edm4hep::Vertex          decayVertex    // decay vertex for the particle (if it is a composite particle)
     OneToManyRelations:


### PR DESCRIPTION

BEGINRELEASENOTES
- Add missing units for covariances, particle charge and other members

ENDRELEASENOTES

There are some cases where a unit was missing, mostly for covariances. I also suggest to add that particle charge is measured in the units the elementary charge