### PR TITLE
Run pre-commit on Key4hep to have a recent enough clang-format

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -22,6 +22,10 @@ jobs:
           STARTDIR=$(pwd)
           echo "::group::Build podio"
           cd ${STARTDIR}/podio
+          # Newer versions of git are more cautious around the github runner
+          # environment and without this git rev-parse --show-cdup in pre-commit
+          # fails
+          git config --global --add safe.directory $(pwd)
           echo "Building podio @"$(git log -1 --format=%H)
           cmake -DCMAKE_CXX_STANDARD=20 \
             -DENABLE_SIO=ON \
@@ -33,6 +37,7 @@ jobs:
           echo "::endgroup::"
           echo "::group::Run pre-commit"
           cd ${STARTDIR}/edm4hep
+          git config --global --add safe.directory $(pwd)
           python3 -m venv /root/pre-commit-venv
           source /root/pre-commit-venv/bin/activate
           pre-commit run --show-diff-on-failure \

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,7 +14,8 @@ jobs:
     - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: aidasoft/run-lcg-view@v4
       with:
-        release-platform: LCG_104/x86_64-el9-clang16-opt
+        container: el9
+        view-path: /cvmfs/sw-nightlies.hsf.org/key4hep
         run: |
           STARTDIR=$(pwd)
           echo "::group::Build podio"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -34,12 +34,6 @@ jobs:
           python3 -m venv /root/pre-commit-venv
           source /root/pre-commit-venv/bin/activate
           pip install pre-commit ruff
-          cmake -DENABLE_SIO=ON \
-            -DCMAKE_CXX_STANDARD=20 \
-            -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror "\
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-            -DUSE_EXTERNAL_CATCH2=OFF -B build
-          ln -s $(pwd)/build/compile_commands.json ./compile_commands.json
           pre-commit run --show-diff-on-failure \
             --color=always \
             --all-files

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        path: edm4hep
     - uses: actions/checkout@v4
       with:
         repository: AIDASoft/podio
@@ -17,9 +19,8 @@ jobs:
         container: el9
         view-path: /cvmfs/sw-nightlies.hsf.org/key4hep
         run: |
-          STARTDIR=$(pwd)
           echo "::group::Build podio"
-          cd podio
+          cd ${GITHUB_WORKSPACE}/podio
           echo "Building podio @"$(git log -1 --format=%H)
           cmake -DCMAKE_CXX_STANDARD=20 \
             -DENABLE_SIO=ON \
@@ -30,7 +31,7 @@ jobs:
           source init.sh && source env.sh
           echo "::endgroup::"
           echo "::group::Run pre-commit"
-          cd $STARTDIR
+          cd ${GITHUB_WORKSPACE}/edm4hep
           python3 -m venv /root/pre-commit-venv
           source /root/pre-commit-venv/bin/activate
           pip install pre-commit ruff

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,8 +19,9 @@ jobs:
         container: el9
         view-path: /cvmfs/sw-nightlies.hsf.org/key4hep
         run: |
+          STARTDIR=$(pwd)
           echo "::group::Build podio"
-          cd ${GITHUB_WORKSPACE}/podio
+          cd ${STARTDIR}/podio
           echo "Building podio @"$(git log -1 --format=%H)
           cmake -DCMAKE_CXX_STANDARD=20 \
             -DENABLE_SIO=ON \
@@ -31,10 +32,9 @@ jobs:
           source init.sh && source env.sh
           echo "::endgroup::"
           echo "::group::Run pre-commit"
-          cd ${GITHUB_WORKSPACE}/edm4hep
+          cd ${STARTDIR}/edm4hep
           python3 -m venv /root/pre-commit-venv
           source /root/pre-commit-venv/bin/activate
-          pip install pre-commit ruff
           pre-commit run --show-diff-on-failure \
             --color=always \
             --all-files

--- a/include/edm4hep/GeneratorToolInfo.h
+++ b/include/edm4hep/GeneratorToolInfo.h
@@ -29,7 +29,7 @@ struct GeneratorToolInfo {
   /// @param versionTool     The version of the tool
   /// @param descrTool       The brief description of the tool
   GeneratorToolInfo(const std::string& nameTool, const std::string& versionTool, const std::string& descrTool)
-      : name(nameTool), version(versionTool), description(descrTool) {};
+      : name(nameTool), version(versionTool), description(descrTool) {}
 };
 
 namespace utils {


### PR DESCRIPTION

BEGINRELEASENOTES
- Switch pre-commit workflow to run on Key4hep nightlies to have a recent enough version of `clang-format`.

ENDRELEASENOTES