### PR TITLE
Remove intermediate variables and make loading consistent in `__init__.py`

### DIFF
--- a/python/edm4hep/__init__.py
+++ b/python/edm4hep/__init__.py
@@ -5,28 +5,22 @@ import sys
 from .__version__ import __version__
 import ROOT
 
-res = ROOT.gSystem.Load("libedm4hepDict")
-if res < 0:
+if ROOT.gSystem.Load("libedm4hepDict") != 0:
     raise RuntimeError("Failed to load libedm4hepDict")
 
-res = ROOT.gSystem.Load("libedm4hepRDF")
-if res < 0:
+if ROOT.gSystem.Load("libedm4hepRDF") != 0:
     raise RuntimeError("Failed to load libedm4hepRDF")
 
-res = ROOT.gInterpreter.LoadFile("edm4hep/utils/kinematics.h")
-if res != 0:
+if ROOT.gInterpreter.LoadFile("edm4hep/utils/kinematics.h") != 0:
     raise RuntimeError("Failed to load kinematics.h")
 
-res = ROOT.gInterpreter.LoadFile("edm4hep/utils/dataframe.h")
-if res != 0:
+if ROOT.gInterpreter.LoadFile("edm4hep/utils/dataframe.h") != 0:
     raise RuntimeError("Failed to load dataframe.h")
 
-res = ROOT.gInterpreter.LoadFile("edm4hep/Constants.h")
-if res != 0:
+if ROOT.gInterpreter.LoadFile("edm4hep/Constants.h") != 0:
     raise RuntimeError("Failed to load Constants.h")
 
-res = ROOT.gSystem.Load("libedm4hepOldSchemas")
-if res != 0:
+if ROOT.gSystem.Load("libedm4hepOldSchemas") != 0:
     raise RuntimeError("Failed to load edm4hep legacy schemas library")
 
 from ROOT import edm4hep  # noqa: E402


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove intermediate variables and make loading libraries and files consistent in `__init__.py`

ENDRELEASENOTES

< 0 is bad (see https://root.cern.ch/doc/master/classTSystem.html#a6ff4c4c6cd8a75a199a30dd94359f205)  but 1 is returned when the library has already been loaded, which is not that bad but maybe we should know if that ever happens.