### PR TITLE
Fix building with C++23

### DIFF
--- a/utils/include/edm4hep/utils/cov_matrix_utils.h
+++ b/utils/include/edm4hep/utils/cov_matrix_utils.h
@@ -13,15 +13,14 @@ namespace utils {
 
   namespace detail {
     // From c++23 this is functionality offered by the STL
-#if __cpp_lib_to_underlying
-    using to_index = std::to_underlying;
-#else
-    // Otherwise it is simple enough to roll our own
     template <typename E>
     constexpr auto to_index(E e) {
+#if __cpp_lib_to_underlying
+      return std::to_underlying(e);
+#else
       return static_cast<std::underlying_type_t<E>>(e);
-    }
 #endif
+    }
 
     /// Cast an index to an enum value
     template <typename DimEnum>


### PR DESCRIPTION
std::to_underlying can not be assigned using `using` because it is
not a type, it is a templated function

BEGINRELEASENOTES
- Fix building with C++23 by not aliasing std::to_underlying to a type.

ENDRELEASENOTES