### PR TITLE
Bump the required version of podio to 1.3.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ SET( ${PROJECT_NAME}_VERSION_PATCH 99 )
 
 SET( ${PROJECT_NAME}_VERSION  "${${PROJECT_NAME}_VERSION_MAJOR}.${${PROJECT_NAME}_VERSION_MINOR}.${${PROJECT_NAME}_VERSION_PATCH}" )
 
-find_package(podio 1.2 REQUIRED HINTS $ENV{PODIO})
+find_package(podio 1.3 REQUIRED HINTS $ENV{PODIO})
 find_package(ROOT REQUIRED COMPONENTS RIO Tree Physics)
 
 option(EDM4HEP_WITH_JSON "Whether or not to build EDM4HEP with JSON support (and edm4hep2json)" ON)


### PR DESCRIPTION
BEGINRELEASENOTES
- Bump the required version of podio to 1.3. This is needed since ::typeName in link collections are only present in 1.3 and onwards. See https://github.com/key4hep/EDM4hep/issues/415

ENDRELEASENOTES

Closes #415

For versioning, EDM4hep 0.99.1 doesn't build with podio 1.3.