### PR TITLE
fix path to docs main page

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1142,7 +1142,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE = README.md
+USE_MDFILE_AS_MAINPAGE = @PROJECT_SOURCE_DIR@/README.md
 
 # The Fortran standard specifies that for fixed formatted Fortran code all
 # characters from position 72 are to be considered as comment. A common


### PR DESCRIPTION

BEGINRELEASENOTES
- Fixed blank documentation page with new doxygen version

ENDRELEASENOTES

It seems that with the current doxygen version the front page is blank. Setting full path to the file  fixes this.
The other pages weren't affected