### PR TITLE
Add timeouts and fixtures to the tests that create and read files

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,27 +15,33 @@ endfunction()
 
 add_test(NAME create_complete_file COMMAND python ${PROJECT_SOURCE_DIR}/scripts/createEDM4hepFile.py --output-file edm4hep_example.root)
 set_test_env(create_complete_file)
+set_tests_properties(create_complete_file PROPERTIES
+  FIXTURES_SETUP complete_file
+  TIMEOUT 600
+)
 
 add_test(NAME create_complete_file_rntuple COMMAND python ${PROJECT_SOURCE_DIR}/scripts/createEDM4hepFile.py --rntuple --output-file edm4hep_example_rntuple.root)
 set_test_env(create_complete_file_rntuple)
 set_tests_properties(create_complete_file_rntuple PROPERTIES
   SKIP_REGULAR_EXPRESSION "The RNTuple writer from podio is not available but was requested"
+  FIXTURES_SETUP complete_file_rntuple
+  TIMEOUT 600
 )
 
 add_test(NAME check_complete_file COMMAND pytest --inputfile=${PROJECT_BINARY_DIR}/test/edm4hep_example.root -v)
 set_test_env(check_complete_file)
 set_tests_properties(
-  check_complete_file
-  PROPERTIES
-   DEPENDS create_complete_file
+  check_complete_file PROPERTIES
+  FIXTURES_REQUIRED complete_file
+  TIMEOUT 600
 )
 add_test(NAME check_complete_file_rntuple COMMAND pytest --inputfile=${PROJECT_BINARY_DIR}/test/edm4hep_example_rntuple.root -v)
 set_test_env(check_complete_file_rntuple)
 set_tests_properties(
-  check_complete_file_rntuple
-  PROPERTIES
-   DEPENDS create_complete_file_rntuple
-   SKIP_REGULAR_EXPRESSION "collected 0 items / 1 skipped"
+  check_complete_file_rntuple PROPERTIES
+  FIXTURES_REQUIRED complete_file_rntuple
+  SKIP_REGULAR_EXPRESSION "collected 0 items / 1 skipped"
+  TIMEOUT 600
 )
 
 set_tests_properties(


### PR DESCRIPTION
to make the CI jobs (like https://github.com/key4hep/EDM4hep/actions/runs/16770157743/job/47483241179?pr=437) that fail due to timeouts fail faster instead of taking more than an hour.

BEGINRELEASENOTES
- Add timeouts and fixtures to the tests that create and read files to make jobs that fail due to timeouts fail faster

ENDRELEASENOTES