### PR TITLE
Update the schema version after adding the step length

### DIFF
--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -1,5 +1,5 @@
 ---
-schema_version: 3
+schema_version: 4
 options:
   getSyntax: True
   exposePODMembers: False


### PR DESCRIPTION
BEGINRELEASENOTES
- Update the schema version after the changes in 32af1cb8 to avoid a warning every time that a file with CaloHitCollections is read

ENDRELEASENOTES

The warning:

``` 
Warning in <TStreamerInfo::BuildCheck>:
   The StreamerInfo of class edm4hep::CaloHitContributionData read from file edm4hep.root
   has the same version (=3) as the active class but a different checksum.
   You should update the version to ClassDef(edm4hep::CaloHitContributionData,4).
   Do not try to write objects with the current class definition,
   the files will not be readable.

Warning in <TStreamerInfo::CompareContent>: The following data member of
the in-memory layout version 3 of class 'edm4hep::CaloHitContributionData' is missing from
the on-file layout version 3:
   float stepLength; //mm
```

I think there is no reason not to bump it? Tagging