### PR TITLE
fix `edm4hep2json` not recognizing generator metadata types

### DIFF
--- a/tools/include/edm4hep2json.hxx
+++ b/tools/include/edm4hep2json.hxx
@@ -125,6 +125,12 @@ nlohmann::json processEvent(const podio::Frame& frame, std::vector<std::string>&
     } else if (coll->getTypeName() == "podio::LinkCollection<edm4hep::Vertex,edm4hep::ReconstructedParticle>") {
       insertIntoJson<edm4hep::VertexRecoParticleLinkCollection>(jsonDict, coll, collList[i]);
     }
+    // Generator (meta-)data
+    else if (coll->getTypeName() == "edm4hep::GeneratorEventParametersCollection") {
+      insertIntoJson<edm4hep::GeneratorEventParametersCollection>(jsonDict, coll, collList[i]);
+    } else if (coll->getTypeName() == "edm4hep::GeneratorPdfInfoCollection") {
+      insertIntoJson<edm4hep::GeneratorPdfInfoCollection>(jsonDict, coll, collList[i]);
+    }
     // Podio user data
     else if (coll->getTypeName() == "podio::UserDataCollection<float>") {
       insertIntoJson<podio::UserDataCollection<float>>(jsonDict, coll, collList[i]);
@@ -147,12 +153,8 @@ nlohmann::json processEvent(const podio::Frame& frame, std::vector<std::string>&
     } else if (coll->getTypeName() == "podio::UserDataCollection<uint64_t>") {
       insertIntoJson<podio::UserDataCollection<uint64_t>>(jsonDict, coll, collList[i]);
     }
-    // Generator (meta-)data
-    else if (coll->getTypeName() == "edm4hep::GeneratorEventParametersCollection") {
-      insertIntoJson<edm4hep::GeneratorEventParametersCollection>(jsonDict, coll, collList[i]);
-    } else if (coll->getTypeName() == "edm4hep::GeneratorPdfInfoCollection") {
-      insertIntoJson<edm4hep::GeneratorPdfInfoCollection>(jsonDict, coll, collList[i]);
-    } else {
+    // Unknown
+    else {
       std::cout << "WARNING: Collection type not recognized!\n"
                 << "         " << coll->getTypeName() << "\n";
     }

--- a/tools/include/edm4hep2json.hxx
+++ b/tools/include/edm4hep2json.hxx
@@ -148,9 +148,9 @@ nlohmann::json processEvent(const podio::Frame& frame, std::vector<std::string>&
       insertIntoJson<podio::UserDataCollection<uint64_t>>(jsonDict, coll, collList[i]);
     }
     // Generator (meta-)data
-    else if (coll->getTypeName() == "podio::GeneratorParametersCollection") {
+    else if (coll->getTypeName() == "edm4hep::GeneratorEventParametersCollection") {
       insertIntoJson<edm4hep::GeneratorEventParametersCollection>(jsonDict, coll, collList[i]);
-    } else if (coll->getTypeName() == "podio::GeneratorPdfInfoCollection") {
+    } else if (coll->getTypeName() == "edm4hep::GeneratorPdfInfoCollection") {
       insertIntoJson<edm4hep::GeneratorPdfInfoCollection>(jsonDict, coll, collList[i]);
     } else {
       std::cout << "WARNING: Collection type not recognized!\n"


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix `edm4hep2json` not recognizing generator metadata types

ENDRELEASENOTES

The strings for edm4hep generator metada types hardcoded in edm4hep2json were wrong so those types couldn't be recognized.

For example reading file created with `createEDM4hepFile.py` gives:

```
$ edm4hep2json edm4hep.root 
WARNING: Collection type not recognized!
         edm4hep::GeneratorEventParametersCollection
WARNING: Collection type not recognized!
         edm4hep::GeneratorPdfInfoCollection
WARNING: Collection type not recognized!
         edm4hep::GeneratorEventParametersCollection
WARNING: Collection type not recognized!
         edm4hep::GeneratorPdfInfoCollection
WARNING: Collection type not recognized!
         edm4hep::GeneratorEventParametersCollection
WARNING: Collection type not recognized!
         edm4hep::GeneratorPdfInfoCollection
```