### PR TITLE
write UserDataCollection in example edm4hep file

### DIFF
--- a/scripts/createEDM4hepFile.py
+++ b/scripts/createEDM4hepFile.py
@@ -374,6 +374,14 @@ def create_GeneratorPdfInfoCollection():
     return gpi_coll
 
 
+def create_UserDataCollection(element_type):
+    counter = count(COUNT_START)
+    collection = podio.podio.UserDataCollection[element_type]()
+    for _ in range(3):
+        collection.push_back(next(counter))
+    return collection
+
+
 def put_link_collection(frame, link_name, from_el, to_el):
     """Helper function to put a link collection into the frame"""
     coll_name = f"{link_name}Collection"
@@ -452,6 +460,9 @@ def create_frame():
         "GeneratorEventParametersCollection",
     )
     frame.put(create_GeneratorPdfInfoCollection(), "GeneratorPdfInfoCollection")
+
+    frame.put(create_UserDataCollection(int), "UserDataCollectionInt")
+    frame.put(create_UserDataCollection(float), "UserDataCollectionFloat")
 
     return frame
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Include `podio::UserDataCollection` in file created by `creatEDM4hepFile.py`

ENDRELEASENOTES

Having `UserDataCollection` in example edm4hep file could be useful for development (aidasoft/podio#824), otherwise one has to look for a file that has both edm4hep and `UserDataCollection` for verification