### PR TITLE
remove mentions of removed un-namespaced labels

### DIFF
--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -401,7 +401,7 @@ datatypes:
       - float                phi [rad]       // Azimuthal angle of the cluster's intrinsic direction (used e.g. for vertexing). Not to be confused with the cluster position seen from IP
       - edm4hep::Vector3f    directionError [mm^2]  // covariance matrix of the direction
     VectorMembers:
-      - float   shapeParameters      // shape parameters. The corresponding names of the shape parameters should be stored in the collection-level metadata collection identified by edm4hep::labels::ShapeParameterNames, as a vector of strings in the same order as the parameters.
+      - float   shapeParameters      // shape parameters. The corresponding names of the shape parameters should be stored in the collection named by edm4hep::labels::ShapeParameterNames in the file-level metadata, as a vector of strings in the same order as the parameters.
       - float   subdetectorEnergies  // energy observed in a particular subdetector
     OneToManyRelations:
       - edm4hep::Cluster        clusters     // clusters that have been combined to this cluster


### PR DESCRIPTION

BEGINRELEASENOTES
- Update comments referring to removed un-namespaced labels

ENDRELEASENOTES

Follow up to #440. The comments in yaml file were still referring to old labels (or even wrong names). Also reworded a bit to, hopefully, make it more clear what is a names and what is a variable.