### PR TITLE
Fix missing arcticle data in citation file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -46,6 +46,12 @@ license: Apache-2.0
 preferred-citation:
   title: EDM4hep - a common event data model for HEP experiments
   type: article
+  doi: 10.22323/1.414.1237
+  journal: PoS
+  volume: ICHEP2022
+  start: 1237
+  month: 11
+  year: 2022
   authors:
     - given-names: Frank
       family-names: Gaede
@@ -89,6 +95,3 @@ preferred-citation:
       email: valentin.volkl@cern.ch
       affiliation: CERN
       orcid: 'https://orcid.org/0000-0002-9172-6629'
-  identifiers:
-    - type: doi
-      value: 10.22323/1.414.1237


### PR DESCRIPTION

BEGINRELEASENOTES
- Add missing article data in the citation file so the BibTeX entry generated from it references the article correctly

ENDRELEASENOTES

"cite this repository" button generates citation with missing information, in particular it doesn't contain the data from citation in the README

- old (doi, etc missing)
  ```
  @article{Gaede_EDM4hep_-_a,
  author = {Gaede, Frank and Madlener, Thomas and Declara Fernandez, Placido and Ganis, Gerardo and Hegner, Benedikt and Helsens, Clement and Sailer, André Philippe and Stewart, Graeme Andrew and Völkl, Valentin},
  title = {{EDM4hep - a common event data model for HEP experiments}}
  }
  ```
- new
  ```
  @article{Gaede_EDM4hep_-_a_2022,
  author = {Gaede, Frank and Madlener, Thomas and Declara Fernandez, Placido and Ganis, Gerardo and Hegner, Benedikt and Helsens, Clement and Sailer, André Philippe and Stewart, Graeme Andrew and Völkl, Valentin},
  doi = {10.22323/1.414.1237},
  journal = {PoS},
  month = nov,
  pages = {1237},
  title = {{EDM4hep - a common event data model for HEP experiments}},
  volume = {ICHEP2022},
  year = {2022}
  }
  ```

