### PR TITLE
Use std::hypot when possible, prefer std::sqrt or std::hypot to sqrt

### DIFF
--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -272,7 +272,7 @@ datatypes:
         static const int BITStopped = 24 ;
         static const int BITOverlay = 23 ;
         /// return energy computed from momentum and mass
-        double getEnergy() const { return sqrt( getMomentum()[0]*getMomentum()[0]+getMomentum()[1]*getMomentum()[1]+
+        double getEnergy() const { return std::sqrt( getMomentum()[0]*getMomentum()[0]+getMomentum()[1]*getMomentum()[1]+
                                           getMomentum()[2]*getMomentum()[2] + getMass()*getMass()  )  ;}
 
         /// True if the particle has been created by the simulation program (rather than the generator).
@@ -327,7 +327,7 @@ datatypes:
         double x() const {return getPosition()[0];}
         double y() const {return getPosition()[1];}
         double z() const {return getPosition()[2];}
-        double rho() const {return sqrt(x()*x() + y()*y());}
+        double rho() const {return std::hypot(x(), y());}
 
 
   edm4hep::CaloHitContribution:

--- a/utils/include/edm4hep/utils/kinematics.h
+++ b/utils/include/edm4hep/utils/kinematics.h
@@ -23,7 +23,7 @@ namespace utils {
    */
   template <typename ParticleT>
   inline float pT(ParticleT const& p) {
-    return std::sqrt(p.getMomentum()[0] * p.getMomentum()[0] + p.getMomentum()[1] * p.getMomentum()[1]);
+    return std::hypot(p.getMomentum()[0], p.getMomentum()[1]);
   }
 
   /**
@@ -40,7 +40,7 @@ namespace utils {
   template <typename ParticleT>
   inline float p(ParticleT const& part) {
     const auto mom = part.getMomentum();
-    return std::sqrt(mom[0] * mom[0] + mom[1] * mom[1] + mom[2] * mom[2]);
+    return std::hypot(mom[0], mom[1], mom[2]);
   }
 
   namespace detail {


### PR DESCRIPTION
BEGINRELEASENOTES
- Use `std::hypot` when possible, prefer `std::sqrt` or `std::hypot` to sqrt

ENDRELEASENOTES

`std::hypot` prevents under and overflows happening when squaring the inputs so it's safer although slower.