### PR TITLE
Fix missing std namespace for math functions, more hypot usage

### DIFF
--- a/utils/include/edm4hep/utils/vector_utils.h
+++ b/utils/include/edm4hep/utils/vector_utils.h
@@ -113,7 +113,7 @@ namespace utils {
 
   // inline edm4hep::Vector2f VectorFromPolar(const double r, const double theta)
   // {
-  //  return {r * sin(theta), r * cos(theta)};
+  //  return {r * std::sin(theta), r * std::cos(theta)};
   //}
 
 } // namespace utils
@@ -130,10 +130,10 @@ namespace utils {
   template <Vector3D V = edm4hep::Vector3f>
   V sphericalToVector(const double r, const double theta, const double phi) {
     using FloatType = ValueType<V>;
-    const double sth = sin(theta);
-    const double cth = cos(theta);
-    const double sph = sin(phi);
-    const double cph = cos(phi);
+    const double sth = std::sin(theta);
+    const double cth = std::cos(theta);
+    const double sph = std::sin(phi);
+    const double cph = std::cos(phi);
     const FloatType x = r * sth * cph;
     const FloatType y = r * sth * sph;
     const FloatType z = r * cth;
@@ -201,7 +201,7 @@ namespace utils {
     if (dot == 0) {
       return 0.;
     }
-    return acos(dot / (magnitude(v1) * magnitude(v2)));
+    return std::acos(dot / (magnitude(v1) * magnitude(v2)));
   }
 
   // Project v onto v1

--- a/utils/src/dataframe.cc
+++ b/utils/src/dataframe.cc
@@ -19,7 +19,7 @@ ROOT::VecOps::RVec<float> pt(ROOT::VecOps::RVec<T> const& in) {
   ROOT::VecOps::RVec<float> result;
   result.reserve(in.size());
   for (size_t i = 0; i < in.size(); ++i) {
-    result.push_back(std::sqrt(in[i].momentum.x * in[i].momentum.x + in[i].momentum.y * in[i].momentum.y));
+    result.push_back(std::hypot(in[i].momentum.x, in[i].momentum.y));
   }
   return result;
 }
@@ -41,7 +41,7 @@ ROOT::VecOps::RVec<float> cos_theta(ROOT::VecOps::RVec<T> const& in) {
   result.reserve(in.size());
   for (size_t i = 0; i < in.size(); ++i) {
     ROOT::Math::XYZVector lv{in[i].momentum.x, in[i].momentum.y, in[i].momentum.z};
-    result.push_back(cos(lv.Theta()));
+    result.push_back(std::cos(lv.Theta()));
   }
   return result;
 }
@@ -51,7 +51,7 @@ ROOT::VecOps::RVec<float> r(ROOT::VecOps::RVec<T> const& in) {
   ROOT::VecOps::RVec<double> result;
   result.reserve(in.size());
   for (size_t i = 0; i < in.size(); ++i) {
-    result.push_back(std::sqrt(in[i].position.x * in[i].position.x + in[i].position.y * in[i].position.y));
+    result.push_back(std::hypot(in[i].position.x, in[i].position.y));
   }
   return result;
 }


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix missing `std::` for math functions, replace more `sqrt` with `hypot`

ENDRELEASENOTES

Missed in #454