### PR TITLE
Hide CollectionBuffers::recast depending on podio version

### DIFF
--- a/edm4hep/schema_evolution/src/OldLinkEvolution.cc
+++ b/edm4hep/schema_evolution/src/OldLinkEvolution.cc
@@ -86,11 +86,13 @@ namespace {
         return std::make_unique<podio::LinkCollection<FromT, ToT>>(std::move(data), isSubsetColl);
       };
 
+#if PODIO_BUILD_VERSION <= PODIO_VERSION(1, 6, 0)
       readBuffers.recast = [](podio::CollectionReadBuffers& buffers) {
         if (buffers.data) {
           buffers.data = podio::CollectionWriteBuffers::asVector<float>(buffers.data);
         }
       };
+#endif
 
       readBuffers.deleteBuffers = [](podio::CollectionReadBuffers& buffers) {
         if (buffers.data) {


### PR DESCRIPTION
BEGINRELEASENOTES
- Conditionally remove recast in buffers following https://github.com/AIDASoft/podio/pull/882

ENDRELEASENOTES

Needs a new version in podio after https://github.com/AIDASoft/podio/pull/882 is merged, otherwise EDM4hep won't compile.