### PR TITLE
Change type to use 32 bit integer in Quantity instead of 16 bit

### DIFF
--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -206,7 +206,7 @@ components:
 
     edm4hep::Quantity:
       Members:
-        - int16_t type // flag identifying how to interpret the quantity
+        - int32_t type // flag identifying how to interpret the quantity
         - float value  // value of the quantity
         - float error  // error on the value of the quantity
 


### PR DESCRIPTION
Otherwise we will just waste the padding between type and value, since value will be aligned on a 32 bit boundary again.



BEGINRELEASENOTES
- Make `Quantity::type` a 32 bit integer to not waste padding

ENDRELEASENOTES

As discussed / discovered at the [EDM4hep meeting on Nov 25](https://indico.cern.ch/event/1615736/)