### PR TITLE
Fix a few issues in the vector utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,43 +13,43 @@ A generic event data model for future HEP collider experiments.
 
 | | | |
 |-|-|-|
-| [Vector4f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L9)      | [Vector3f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L39)      | [Vector3d](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L67)     |
-| [Vector2f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L95)     | [TrackState](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L198)   | [Quantity](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L227)    |
-| [CovMatrix2f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L119) | [CovMatrix3f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L139)  | [CovMatrix4f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L158) |
-| [CovMatrix6f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L178) |   |   |
+| [Vector4f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L9)      | [Vector3f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L34)      | [Vector3d](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L57)     |
+| [Vector2f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L80)     | [TrackState](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L178)   | [Quantity](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L207)    |
+| [CovMatrix2f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L99) | [CovMatrix3f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L119)  | [CovMatrix4f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L138) |
+| [CovMatrix6f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L158) |   |   |
 
 
 **Datatypes**
 
 | | | |
 |-|-|-|
-| [EventHeader](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L236)           | [MCParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L248)        | [SimTrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L317)         |
-| [CaloHitContribution](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L353)   | [SimCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L366) | [RawCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L377)     |
-| [CalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L386)        | [ParticleID](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L397)        | [Cluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L411)               |
-| [TrackerHit3D](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L448)          | [TrackerHitPlane](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L473)   | [SenseWireHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L514)          |
-| [RawTimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L501)         | [Track](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L538)             | [Vertex](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L555)                |
-| [ReconstructedParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L601) | [TimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L635)        | [RecDqdx](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L647)               |
+| [EventHeader](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L216)           | [MCParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L228)        | [SimTrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L297)         |
+| [CaloHitContribution](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L333)   | [SimCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L346) | [RawCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L357)     |
+| [CalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L366)        | [ParticleID](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L377)        | [Cluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L391)               |
+| [TrackerHit3D](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L428)          | [TrackerHitPlane](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L453)   | [SenseWireHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L494)          |
+| [RawTimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L481)         | [Track](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L518)             | [Vertex](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L535)                |
+| [ReconstructedParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L581) | [TimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L615)        | [RecDqdx](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L627)               |
 
 **Links**
 
 | | | |
 |-|-|-|
-| [RecoMCParticleLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L689)        | [CaloHitSimCaloHitLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L713)         | [TrackerHitSimTrackerHitLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L719)         |
-| [CaloHitMCParticleLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L695) | [ClusterMCParticleLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L701) | [TrackMCParticleLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L707)   |
-| [VertexRecoParticleLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L725) | | |
+| [RecoMCParticleLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L669)        | [CaloHitSimCaloHitLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L693)         | [TrackerHitSimTrackerHitLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L699)         |
+| [CaloHitMCParticleLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L675) | [ClusterMCParticleLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L681) | [TrackMCParticleLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L687)   |
+| [VertexRecoParticleLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L705) | | |
 
 **Generator related (meta-)data**
 
 | | | |
 |-|-|-|
-| [GeneratorEventParameters](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L656) | | |
+| [GeneratorEventParameters](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L636) | | |
 | | | |
 
 **Interfaces**
 
 | | | |
 |-|-|-|
-| [TrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L672) | | |
+| [TrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L652) | | |
 
 The tests and examples in the `tests` directory show how to read, write, and use these types in your code.
 

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -21,11 +21,6 @@ components:
           constexpr Vector4f(const float* v) : x(v[0]),y(v[1]),z(v[2]),t(v[3]) {}
           constexpr bool operator==(const Vector4f& v) const { return (x==v.x&&y==v.y&&z==v.z&&t==v.t) ; }
           constexpr bool operator!=(const Vector4f& v) const { return !(*this == v) ; }
-          template <typename T>
-          requires requires { T{x, y, z, t}; }
-          constexpr T to() const {
-            return T{x, y, z, t};
-          }
           constexpr float operator[](unsigned i) const {
             static_assert(
               (offsetof(Vector4f,x)+sizeof(Vector4f::x) == offsetof(Vector4f,y)) &&
@@ -49,11 +44,6 @@ components:
           constexpr Vector3f(const float* v) : x(v[0]),y(v[1]),z(v[2]) {}
           constexpr bool operator==(const Vector3f& v) const { return (x==v.x&&y==v.y&&z==v.z) ; }
           constexpr bool operator!=(const Vector3f& v) const { return !(*this == v) ; }
-          template <typename T>
-          requires requires { T{x, y, z}; }
-          constexpr T to() const {
-            return T{x, y, z};
-          }
           constexpr float operator[](unsigned i) const {
             static_assert(
               (offsetof(Vector3f,x)+sizeof(Vector3f::x) == offsetof(Vector3f,y)) &&
@@ -80,11 +70,6 @@ components:
           constexpr Vector3d(const float* v) : x(v[0]),y(v[1]),z(v[2]) {}
           constexpr bool operator==(const Vector3d& v) const { return (x==v.x&&y==v.y&&z==v.z) ; }
           constexpr bool operator!=(const Vector3d& v) const { return !(*this == v) ; }
-          template <typename T>
-          requires requires { T{x, y, z}; }
-          constexpr T to() const {
-            return T{x, y, z};
-          }
           constexpr double operator[](unsigned i) const {
             static_assert(
               (offsetof(Vector3d,x)+sizeof(Vector3d::x) == offsetof(Vector3d,y)) &&
@@ -104,11 +89,6 @@ components:
           constexpr Vector2f(const float* v) : a(v[0]), b(v[1]) {}
           constexpr bool operator==(const Vector2f& v) const { return (a==v.a&&b==v.b) ; }
           constexpr bool operator!=(const Vector2f& v) const { return !(*this == v) ; }
-          template <typename T>
-          requires requires { T{a, b}; }
-          constexpr T to() const {
-            return T{a, b};
-          }
           constexpr float operator[](unsigned i) const {
             static_assert(
               offsetof(Vector2f,a)+sizeof(Vector2f::a) == offsetof(Vector2f,b),

--- a/test/utils/test_vector_utils.cpp
+++ b/test/utils/test_vector_utils.cpp
@@ -9,10 +9,6 @@
 #include "edm4hep/Vector3f.h"
 #include "edm4hep/Vector4f.h"
 
-#include "Math/Vector2D.h"
-#include "Math/Vector3D.h"
-#include "Math/Vector4D.h"
-
 #include <tuple>
 #include <type_traits>
 using Vector2And3Types = std::tuple<edm4hep::Vector3f, edm4hep::Vector3d, edm4hep::Vector2f>;
@@ -143,28 +139,4 @@ TEST_CASE("Vector utility functionality for 4D vectors", "[vector_utils]") {
   REQUIRE(utils::magnitude(temporal) == Catch::Approx(std::sqrt(100 - 14)));
   const auto light = Vector4f(2, 3, 6, 7);
   REQUIRE(utils::magnitude(light) == Catch::Approx(0));
-}
-
-TEST_CASE("Vector conversion to ROOT vectors", "[vector_utils]") {
-  using namespace edm4hep;
-
-  const auto v2 = Vector2f{3.0f, 4.0f};
-  const auto rv2 = v2.to<ROOT::Math::XYVectorF>();
-  REQUIRE(rv2.R() == Catch::Approx(5.0f));
-  REQUIRE(rv2.R() == Catch::Approx(utils::magnitude(v2)));
-
-  const auto v3 = Vector3f{1.0f, 2.0f, 3.0f};
-  const auto rv3 = v3.to<ROOT::Math::XYZVectorF>();
-  REQUIRE(rv3.R() == Catch::Approx(std::sqrt(14.0f)));
-  REQUIRE(rv3.R() == Catch::Approx(utils::magnitude(v3)));
-
-  const auto v3d = Vector3d{1.0, 2.0, 3.0};
-  const auto rv3d = v3d.to<ROOT::Math::XYZVector>();
-  REQUIRE(rv3d.R() == Catch::Approx(std::sqrt(14.0)));
-  REQUIRE(rv3d.R() == Catch::Approx(utils::magnitude(v3d)));
-
-  const auto v4 = Vector4f{1.0f, 2.0f, 3.0f, 10.0f};
-  const auto rv4 = v4.to<ROOT::Math::PxPyPzEVector>();
-  REQUIRE(rv4.P() == Catch::Approx(std::sqrt(14.0)));
-  REQUIRE(rv4.M() == Catch::Approx(std::sqrt(100.0 - 14.0)));
 }


### PR DESCRIPTION
BEGINRELEASENOTES
- `magnitude` isn't correct for 4D vectors. I've chosen to return a non-negative value which may be unexpected.
- `angleBetween` wasn't correctly implemented and was returning a value different than PI / 2 for orthogonal vectors. Avoid also dividing by zero.
- Add tests for the failures above

ENDRELEASENOTES

ROOT does throw an exception if you want to find the magnitude of a spacelike vector:
https://root.cern.ch/doc/master/classROOT_1_1Math_1_1LorentzVector.html#a26ec12d649ae172a505d2ef9a8a7f9b9