### PR TITLE
Use Clang 19 instead of 16 in CI

### DIFF
--- a/.github/workflows/lcg_linux_with_podio.yml
+++ b/.github/workflows/lcg_linux_with_podio.yml
@@ -8,8 +8,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        LCG: ["dev3/x86_64-el9-clang16-opt",
-              "dev4/x86_64-el9-clang16-opt",
+        LCG: ["dev3/x86_64-el9-clang19-opt",
+              "dev4/x86_64-el9-clang19-opt",
               "dev4/x86_64-el9-gcc13-opt",
               "LCG_106/x86_64-el9-gcc13-opt"]
         CXX_STANDARD: [20]


### PR DESCRIPTION
BEGINRELEASENOTES
- Use Clang 19 instead of 16 in CI, since these builds are going to be removed

ENDRELEASENOTES

Clang 16 builds seem not to work and are going to be removed, see
https://its.cern.ch/jira/projects/SPI/issues/SPI-2955