### PR TITLE
Clarify expected usage of SimCalorimeterHit and CaloHitContribution

### DIFF
--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -334,7 +334,7 @@ datatypes:
 
 
   edm4hep::CaloHitContribution:
-    Description: "Monte Carlo contribution to SimCalorimeterHit"
+    Description: "Monte Carlo contribution to SimCalorimeterHit (infinite granularity)"
     Author: "EDM4hep authors"
     Members:
       - int32_t   PDG                        // PDG code of the shower particle that caused this contribution
@@ -347,7 +347,7 @@ datatypes:
 
 
   edm4hep::SimCalorimeterHit:
-    Description: "Simulated calorimeter hit"
+    Description: "Simulated calorimeter hit (cell level granularity)"
     Author: "EDM4hep authors"
     Members:
       - uint64_t cellID       // ID of the sensor that created this hit


### PR DESCRIPTION
The fact that `SimCalorimeterHits` are already 'ganged' into cells and that individual hits have to be accessed through `CaloHitContributions` is creating a lot of confusion for newcomers. Given that e.g. `SimCalorimeterHits`has no time member, we can see this an EDM4hep level convention (as opposed to just how `ddsim` chooses to use EDM4hep). I therefore propose to clearly state that here.

BEGINRELEASENOTES
- Clarify expected usage of SimCalorimeterHit and CaloHitContribution

ENDRELEASENOTES