### PR TITLE
Add detector local-context datatypes and links to EDM4hep

### DIFF
--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -664,6 +664,25 @@ datatypes:
     OneToManyRelations:
       - edm4hep::MCParticle signalVertexParticles  // List of initial state MCParticles that are the source of the hard interaction
 
+  edm4hep::DetectorElement:
+    Description: "Stable detector-element identity and rigid global transform for detector-local context binding"
+    Author: "Physics Foundry upstream proposal"
+    Members:
+      - uint64_t detectorElementKey // stable numeric detector-element identity
+      - uint64_t sourceVolumeKey // stable numeric source-volume identity
+      - uint64_t sensitiveDetectorKey // stable numeric sensitive-detector identity
+      - edm4hep::Vector3d translation [mm] // global detector-element translation
+      - edm4hep::Vector3f rotation [rad] // global detector-element rotation in ZYX convention
+
+  edm4hep::HitLocalContext:
+    Description: "Local detector context bound to a resolved detector element"
+    Author: "Physics Foundry upstream proposal"
+    Members:
+      - edm4hep::Vector3d localPosition [mm] // local hit position in detector-element coordinates
+      - float pathLength [mm] // path length through the sensitive detector element
+    OneToOneRelations:
+      - edm4hep::DetectorElement detectorElement // resolved detector element for this local hit context
+
 interfaces:
   edm4hep::TrackerHit:
     Description: "Tracker hit interface class"
@@ -723,3 +742,27 @@ links:
     Author: "EDM4hep authors"
     From: edm4hep::Vertex
     To: edm4hep::ReconstructedParticle
+
+  edm4hep::CaloHitLocalContextLink:
+    Description: "Link between a CalorimeterHit and its local detector context"
+    Author: "Physics Foundry upstream proposal"
+    From: edm4hep::CalorimeterHit
+    To: edm4hep::HitLocalContext
+
+  edm4hep::TrackerHitLocalContextLink:
+    Description: "Link between a TrackerHit interface object and its local detector context"
+    Author: "Physics Foundry upstream proposal"
+    From: edm4hep::TrackerHit
+    To: edm4hep::HitLocalContext
+
+  edm4hep::SimCaloHitLocalContextLink:
+    Description: "Link between a SimCalorimeterHit and its local detector context"
+    Author: "Physics Foundry upstream proposal"
+    From: edm4hep::SimCalorimeterHit
+    To: edm4hep::HitLocalContext
+
+  edm4hep::SimTrackerHitLocalContextLink:
+    Description: "Link between a SimTrackerHit and its local detector context"
+    Author: "Physics Foundry upstream proposal"
+    From: edm4hep::SimTrackerHit
+    To: edm4hep::HitLocalContext


### PR DESCRIPTION
Closes #494

# Add detector local-context datatypes and links to EDM4hep

## Summary

This proposal adds the minimum detector-side native schema surface needed to carry stable numeric detector-element identity, rigid transforms, local hit coordinates, path length, and hit-to-context relations.

## Proposed datatypes

- `edm4hep::DetectorElement`
- `edm4hep::HitLocalContext`

## Proposed links

- `edm4hep::CaloHitLocalContextLink`
- `edm4hep::TrackerHitLocalContextLink`
- `edm4hep::SimCaloHitLocalContextLink`
- `edm4hep::SimTrackerHitLocalContextLink`

## Evidence

- Physics Foundry schema-contract digest: `37ccd756e0cab06ceb0d578222c24b43f669b67996015ae735439e5fe7a143f2`
- Proposed native semantic count: `8`
- Retained sidecar semantic count: `4`
- Covered detector slices: `minimal_barrel_calo, minimal_barrel_tracker, minimal_barrel_tracker_plane`

## Explicit non-goals

- `foundry_transport_track_id`
- `resolved_instance_id`
- `source_sensitive_detector_id`
- `source_volume_id`

These remain outside the native datamodel on purpose.

## Proposed artifact in this repo

- candidate YAML: `benchmarks/detector/foundrydetector_upstream_adoption/upstream_candidate_edm4hep.yaml`
- issue body: `benchmarks/detector/foundrydetector_upstream_adoption/upstream_issue.md`
- PR body: `benchmarks/detector/foundrydetector_upstream_adoption/upstream_pr.md`

BEGINRELEASENOTES
- add detector-side local-context datatypes and links
  - add `edm4hep::DetectorElement`
  - add `edm4hep::HitLocalContext`
  - add local-context links for calorimeter hits, tracker hits, sim calorimeter hits, and sim tracker hits
ENDRELEASENOTES
