### PR TITLE
Add operator== to ParticleIDMeta

### DIFF
--- a/utils/include/edm4hep/utils/ParticleIDUtils.h
+++ b/utils/include/edm4hep/utils/ParticleIDUtils.h
@@ -64,6 +64,7 @@ struct ParticleIDMeta {
   ParticleIDMeta& operator=(const ParticleIDMeta&) = default;
   ParticleIDMeta(ParticleIDMeta&&) = default;
   ParticleIDMeta& operator=(ParticleIDMeta&&) = default;
+  bool operator==(const ParticleIDMeta&) const = default;
 
   std::string algoName{};                ///< The name of the algorithm
   std::vector<std::string> paramNames{}; ///< The names of the parameters


### PR DESCRIPTION
BEGINRELEASENOTES
- Add operator== to ParticleIDMeta

ENDRELEASENOTES

Needed for https://github.com/key4hep/k4FWCore/pull/399, to compare if the existing metadata parameter is the same as the one we're trying to set.