### PR TITLE
Skip the convert_events test if building with `EDM4HEP_WITH_JSON=OFF`

### DIFF
--- a/test/tools/CMakeLists.txt
+++ b/test/tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-if (nlohmann_json_FOUND)
+if (TARGET edm4hep2json)
   add_edm4hep_test(convert_events
     COMMAND edm4hep2json ${CMAKE_CURRENT_BINARY_DIR}/../edm4hep_events.root)
   set_property(TEST convert_events PROPERTY FIXTURES_REQUIRED write_events_fixture)

--- a/test/tools/CMakeLists.txt
+++ b/test/tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-if (TARGET edm4hep2json)
+if (EDM4HEP_WITH_JSON)
   add_edm4hep_test(convert_events
     COMMAND edm4hep2json ${CMAKE_CURRENT_BINARY_DIR}/../edm4hep_events.root)
   set_property(TEST convert_events PROPERTY FIXTURES_REQUIRED write_events_fixture)


### PR DESCRIPTION
BEGINRELEASENOTES
- Skip the convert_events test if building with `EDM4HEP_WITH_JSON=OFF` since nlohmann_json can still be found through podio or other dependencies, but then the test will fail

ENDRELEASENOTES