### PR TITLE
Remove an unecessary include in OldLinkEvolution.cc

### DIFF
--- a/edm4hep/schema_evolution/include/edm4hep/schema_evolution/OldLinkData.h
+++ b/edm4hep/schema_evolution/include/edm4hep/schema_evolution/OldLinkData.h
@@ -1,5 +1,5 @@
-#ifndef EDM4HEP_SCHEMA_EVOLUTION_OLDLINKDATA_H
-#define EDM4HEP_SCHEMA_EVOLUTION_OLDLINKDATA_H
+#ifndef EDM4HEP_SCHEMA_EVOLUTION_OLD_LINK_DATA_H
+#define EDM4HEP_SCHEMA_EVOLUTION_OLD_LINK_DATA_H
 
 #define MAKE_DATA_STRUCT(name)                                                                                         \
   struct name {                                                                                                        \
@@ -20,4 +20,4 @@ MAKE_DATA_STRUCT(VertexRecoParticleLinkData)
 
 #undef MAKE_DATA_STRUCT
 
-#endif // EDM4HEP_SCHEMA_EVOLUTION_OLDLINKDATA_H
+#endif // EDM4HEP_SCHEMA_EVOLUTION_OLD_LINK_DATA_H

--- a/edm4hep/schema_evolution/src/OldLinkEvolution.cc
+++ b/edm4hep/schema_evolution/src/OldLinkEvolution.cc
@@ -9,7 +9,6 @@
 #include "edm4hep/TrackCollection.h"
 #include "edm4hep/TrackerHit.h"
 #include "edm4hep/VertexCollection.h"
-#include "edm4hep/schema_evolution/OldLinkData.h"
 
 #include <podio/CollectionBufferFactory.h>
 #include <podio/CollectionBuffers.h>


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove an unecessary include in OldLinkEvolution.cc, fix include guards

ENDRELEASENOTES