### PR TITLE
Make edm4hep::Track::getTrackState const

### DIFF
--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -542,7 +542,7 @@ datatypes:
         ///
         /// @note This will return the first TrackState for which the location matches
         /// even if there are multiple in the track
-        std::optional<edm4hep::TrackState> getTrackState(int location) {
+        std::optional<edm4hep::TrackState> getTrackState(int location) const {
           const auto trackStates = getTrackStates();
           const auto it = std::ranges::find(trackStates, location, &edm4hep::TrackState::location);
           return it != trackStates.end() ? std::optional{*it} : std::nullopt;

--- a/test/utils/test_extra_code.cpp
+++ b/test/utils/test_extra_code.cpp
@@ -7,8 +7,7 @@ TEST_CASE("Track::getTrackState") {
   // Populate a track with track states
   auto mutableTrack = edm4hep::MutableTrack{};
   mutableTrack.addToTrackStates(edm4hep::TrackState{.location = edm4hep::TrackState::AtIP});
-  auto inputState =
-      edm4hep::TrackState{.location = edm4hep::TrackState::AtCalorimeter, .D0 = 3.13f, .phi = 42.0f};
+  auto inputState = edm4hep::TrackState{.location = edm4hep::TrackState::AtCalorimeter, .D0 = 3.13f, .phi = 42.0f};
   mutableTrack.addToTrackStates(inputState);
   mutableTrack.addToTrackStates(edm4hep::TrackState{.location = edm4hep::TrackState::AtCalorimeter});
 

--- a/test/utils/test_extra_code.cpp
+++ b/test/utils/test_extra_code.cpp
@@ -9,7 +9,7 @@ TEST_CASE("Track::getTrackState") {
   mutableTrack.addToTrackStates(edm4hep::TrackState{.location = edm4hep::TrackState::AtIP});
   auto inputState = edm4hep::TrackState{.location = edm4hep::TrackState::AtCalorimeter, .D0 = 3.13f, .phi = 42.0f};
   mutableTrack.addToTrackStates(inputState);
-  mutableTrack.addToTrackStates(edm4hep::TrackState{.location = edm4hep::TrackState::AtCalorimeter});
+  mutableTrack.addToTrackStates(edm4hep::TrackState{.location = edm4hep::TrackState::AtCalorimeter, .D0 = 99.f});
 
   SECTION("returns desired track state via MutableTrack") {
     auto state = mutableTrack.getTrackState(edm4hep::TrackState::AtCalorimeter);

--- a/test/utils/test_extra_code.cpp
+++ b/test/utils/test_extra_code.cpp
@@ -30,8 +30,7 @@ TEST_CASE("Track::getTrackState returns first found track state") {
 
 TEST_CASE("Track::getTrackState works with const Track") {
   auto mutableTrack = edm4hep::MutableTrack{};
-  auto inputState =
-      edm4hep::TrackState{.location = edm4hep::TrackState::AtCalorimeter, .D0 = 3.13f, .phi = 42.0f};
+  auto inputState = edm4hep::TrackState{.location = edm4hep::TrackState::AtCalorimeter, .D0 = 3.13f, .phi = 42.0f};
   mutableTrack.addToTrackStates(inputState);
 
   const edm4hep::Track track = mutableTrack;

--- a/test/utils/test_extra_code.cpp
+++ b/test/utils/test_extra_code.cpp
@@ -3,47 +3,37 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-TEST_CASE("Track::getTrackState returns desired track state") {
-  auto track = edm4hep::MutableTrack{};
-  track.addToTrackStates(edm4hep::TrackState{.location = edm4hep::TrackState::AtIP});
-  auto inputState = edm4hep::TrackState{.location = edm4hep::TrackState::AtCalorimeter, .D0 = 3.13f, .phi = 42.0f};
-  track.addToTrackStates(inputState);
-
-  auto stateAtCalo = track.getTrackState(edm4hep::TrackState::AtCalorimeter);
-  REQUIRE(stateAtCalo.has_value());
-  REQUIRE(stateAtCalo.value().D0 == inputState.D0);
-  REQUIRE(stateAtCalo.value().phi == inputState.phi);
-}
-
-TEST_CASE("Track::getTrackState returns first found track state") {
-  auto track = edm4hep::MutableTrack{};
-  track.addToTrackStates(edm4hep::TrackState{.location = edm4hep::TrackState::AtIP});
-  auto inputState = edm4hep::TrackState{.location = edm4hep::TrackState::AtCalorimeter, .D0 = 3.13f, .phi = 42.0f};
-  track.addToTrackStates(inputState);
-  track.addToTrackStates(edm4hep::TrackState{.location = edm4hep::TrackState::AtCalorimeter});
-
-  auto firstStateAtCalo = track.getTrackState(edm4hep::TrackState::AtCalorimeter);
-  REQUIRE(firstStateAtCalo.has_value());
-  REQUIRE(firstStateAtCalo.value().D0 == inputState.D0);
-  REQUIRE(firstStateAtCalo.value().phi == inputState.phi);
-}
-
-TEST_CASE("Track::getTrackState works with const Track") {
+TEST_CASE("Track::getTrackState") {
+  // Populate a track with track states
   auto mutableTrack = edm4hep::MutableTrack{};
-  auto inputState = edm4hep::TrackState{.location = edm4hep::TrackState::AtCalorimeter, .D0 = 3.13f, .phi = 42.0f};
+  mutableTrack.addToTrackStates(edm4hep::TrackState{.location = edm4hep::TrackState::AtIP});
+  auto inputState =
+      edm4hep::TrackState{.location = edm4hep::TrackState::AtCalorimeter, .D0 = 3.13f, .phi = 42.0f};
   mutableTrack.addToTrackStates(inputState);
+  mutableTrack.addToTrackStates(edm4hep::TrackState{.location = edm4hep::TrackState::AtCalorimeter});
 
-  const edm4hep::Track track = mutableTrack;
-  auto stateAtCalo = track.getTrackState(edm4hep::TrackState::AtCalorimeter);
-  REQUIRE(stateAtCalo.has_value());
-  REQUIRE(stateAtCalo.value().D0 == inputState.D0);
-  REQUIRE(stateAtCalo.value().phi == inputState.phi);
-}
+  SECTION("returns desired track state via MutableTrack") {
+    auto state = mutableTrack.getTrackState(edm4hep::TrackState::AtCalorimeter);
+    REQUIRE(state.has_value());
+    REQUIRE(state.value().D0 == inputState.D0);
+    REQUIRE(state.value().phi == inputState.phi);
+  }
 
-TEST_CASE("Track::getTrackState returns empty optional if no track state found") {
-  auto track = edm4hep::MutableTrack{};
-  track.addToTrackStates(edm4hep::TrackState{.location = edm4hep::TrackState::AtIP});
-  track.addToTrackStates(edm4hep::TrackState{.location = edm4hep::TrackState::AtCalorimeter});
+  SECTION("returns desired track state via const Track") {
+    const edm4hep::Track track = mutableTrack;
+    auto state = track.getTrackState(edm4hep::TrackState::AtCalorimeter);
+    REQUIRE(state.has_value());
+    REQUIRE(state.value().D0 == inputState.D0);
+    REQUIRE(state.value().phi == inputState.phi);
+  }
 
-  REQUIRE_FALSE(track.getTrackState(edm4hep::TrackState::AtFirstHit).has_value());
+  SECTION("returns first matching track state when multiple match") {
+    auto state = mutableTrack.getTrackState(edm4hep::TrackState::AtCalorimeter);
+    REQUIRE(state.has_value());
+    REQUIRE(state.value().D0 == inputState.D0); // first added, not the duplicate
+  }
+
+  SECTION("returns empty optional when no track state matches") {
+    REQUIRE_FALSE(mutableTrack.getTrackState(edm4hep::TrackState::AtFirstHit).has_value());
+  }
 }

--- a/test/utils/test_extra_code.cpp
+++ b/test/utils/test_extra_code.cpp
@@ -28,6 +28,19 @@ TEST_CASE("Track::getTrackState returns first found track state") {
   REQUIRE(firstStateAtCalo.value().phi == inputState.phi);
 }
 
+TEST_CASE("Track::getTrackState works with const Track") {
+  auto mutableTrack = edm4hep::MutableTrack{};
+  auto inputState =
+      edm4hep::TrackState{.location = edm4hep::TrackState::AtCalorimeter, .D0 = 3.13f, .phi = 42.0f};
+  mutableTrack.addToTrackStates(inputState);
+
+  const edm4hep::Track track = mutableTrack;
+  auto stateAtCalo = track.getTrackState(edm4hep::TrackState::AtCalorimeter);
+  REQUIRE(stateAtCalo.has_value());
+  REQUIRE(stateAtCalo.value().D0 == inputState.D0);
+  REQUIRE(stateAtCalo.value().phi == inputState.phi);
+}
+
 TEST_CASE("Track::getTrackState returns empty optional if no track state found") {
   auto track = edm4hep::MutableTrack{};
   track.addToTrackStates(edm4hep::TrackState{.location = edm4hep::TrackState::AtIP});


### PR DESCRIPTION
BEGINRELEASENOTES
- Make `edm4hep::Track::getTrackState` `const`, allowing `const` `Track`s to call it.
- Add a test to make sure that we can call `getTrackState` from `const` and non `const`

ENDRELEASENOTES

As suggested in https://github.com/key4hep/k4ActsTracking/pull/79#issuecomment-4970958056, this is an oversight. This allows `const` `Track`s to call `getTrackState` and since non-const `Track`s can call `const` methods, then it doesn't break existing code.