### PR TITLE
Update CMake configuration to use new PodioArrow library suffix

### DIFF
--- a/edm4hep/CMakeLists.txt
+++ b/edm4hep/CMakeLists.txt
@@ -67,8 +67,8 @@ ENDIF()
 if(PODIO_ENABLE_ARROW)
   PODIO_ADD_ARROW(edm4hep "${headers}" "${sources}")
   message(STATUS "Building and installing the Arrow component since podio supports it")
-  add_library(EDM4HEP::edm4hepArrow ALIAS edm4hepArrow)
-  list(APPEND EDM4HEP_INSTALL_LIBS edm4hepArrow)
+  add_library(EDM4HEP::edm4hepPodioArrow ALIAS edm4hepPodioArrow)
+  list(APPEND EDM4HEP_INSTALL_LIBS edm4hepPodioArrow)
 endif()
 
 install(TARGETS ${EDM4HEP_INSTALL_LIBS}


### PR DESCRIPTION
Updates EDM4hep aliases and install rules to expect the edm4hepPodioArrow target. This reflects the macro changes in podio which renamed the generated suffix from Arrow to PodioArrow to avoid dynamic loading collisions.

Depends upon https://github.com/AIDASoft/podio/pull/999

BEGINRELEASENOTES
- **Fix:** Updated CMake targets to match the new `PodioArrow` suffix generated by podio's `PODIO_ADD_ARROW` macro.

ENDRELEASENOTES