### PR TITLE
Switch to nightlies stacks that exist for CI and update actions

### DIFF
--- a/.github/workflows/lcg_linux_with_podio.yml
+++ b/.github/workflows/lcg_linux_with_podio.yml
@@ -15,14 +15,14 @@ jobs:
           - {LCG: "dev3/x86_64-el9-clang22-opt", CXX_STANDARD: 23}
           - {LCG: "dev4/x86_64-el9-clang22-opt", CXX_STANDARD: 23}
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         repository: AIDASoft/podio
         path: podio
     - uses: key4hep/key4hep-actions/cache-external-data@main
-    - uses: cvmfs-contrib/github-action-cvmfs@v4
-    - uses: aidasoft/run-lcg-view@v5
+    - uses: cvmfs-contrib/github-action-cvmfs@10197e000cc0add8e54ac4fb73d3ed44e2de72b4 # v5.5
+    - uses: aidasoft/run-lcg-view@b4da52e1c5ccb70a60ad4e7216de0a90664d5849 # v6.0.2
       with:
         release-platform: ${{ matrix.LCG }}
         ccache-key: ccache-${{ matrix.LCG }}

--- a/.github/workflows/lcg_linux_with_podio.yml
+++ b/.github/workflows/lcg_linux_with_podio.yml
@@ -8,11 +8,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        LCG: ["dev3/x86_64-el9-clang22-opt",
-              "dev4/x86_64-el9-clang22-opt",
-              "dev4/x86_64-el9-gcc13-opt",
+        LCG: ["dev4/x86_64-el9-gcc13-opt",
               "LCG_106/x86_64-el9-gcc13-opt"]
         CXX_STANDARD: [20]
+        include:
+          - {LCG: "dev3/x86_64-el9-clang22-opt", CXX_STANDARD: 23}
+          - {LCG: "dev4/x86_64-el9-clang22-opt", CXX_STANDARD: 23}
     steps:
     - uses: actions/checkout@v4
     - uses: actions/checkout@v4

--- a/.github/workflows/lcg_linux_with_podio.yml
+++ b/.github/workflows/lcg_linux_with_podio.yml
@@ -8,8 +8,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        LCG: ["dev3/x86_64-el9-clang19-opt",
-              "dev4/x86_64-el9-clang19-opt",
+        LCG: ["dev3/x86_64-el9-clang22-opt",
+              "dev4/x86_64-el9-clang22-opt",
               "dev4/x86_64-el9-gcc13-opt",
               "LCG_106/x86_64-el9-gcc13-opt"]
         CXX_STANDARD: [20]

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,15 +6,15 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         path: edm4hep
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         repository: AIDASoft/podio
         path: podio
-    - uses: cvmfs-contrib/github-action-cvmfs@v4
-    - uses: aidasoft/run-lcg-view@v4
+    - uses: cvmfs-contrib/github-action-cvmfs@10197e000cc0add8e54ac4fb73d3ed44e2de72b4 # v5.5
+    - uses: aidasoft/run-lcg-view@b4da52e1c5ccb70a60ad4e7216de0a90664d5849 # v6.0.2
       with:
         container: el9
         view-path: /cvmfs/sw-nightlies.hsf.org/key4hep


### PR DESCRIPTION
clang19 based stacks have been removed



BEGINRELEASENOTES
- Switch to `clang22` base stacks for LCG nightlies based CI workflows
- Switch to latest action versions and pin them via commit sha instead of just tags

ENDRELEASENOTES