### PR TITLE
Fix error prone retrieval of track states via location from Track

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A generic event data model for future HEP collider experiments.
 | | | |
 |-|-|-|
 | [Vector4f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L9)      | [Vector3f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L34)      | [Vector3d](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L57)     |
-| [Vector2f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L80)     | [TrackState](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L178)   | [Quantity](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L207)    |
+| [Vector2f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L80)     | [TrackState](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L178)   | [Quantity](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L220)    |
 | [CovMatrix2f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L99) | [CovMatrix3f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L119)  | [CovMatrix4f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L138) |
 | [CovMatrix6f](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L158) |   |   |
 
@@ -23,33 +23,33 @@ A generic event data model for future HEP collider experiments.
 
 | | | |
 |-|-|-|
-| [EventHeader](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L216)           | [MCParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L228)        | [SimTrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L300)         |
-| [CaloHitContribution](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L336)   | [SimCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L349) | [RawCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L360)     |
-| [CalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L369)        | [ParticleID](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L380)        | [Cluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L394)               |
-| [TrackerHit3D](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L431)          | [TrackerHitPlane](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L456)   | [SenseWireHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L497)          |
-| [RawTimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L484)         | [Track](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L521)             | [Vertex](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L551)                |
-| [ReconstructedParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L597) | [TimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L631)        | [RecDqdx](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L643)               |
+| [EventHeader](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L229)           | [MCParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L241)        | [SimTrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L313)         |
+| [CaloHitContribution](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L349)   | [SimCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L362) | [RawCalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L373)     |
+| [CalorimeterHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L382)        | [ParticleID](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L393)        | [Cluster](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L407)               |
+| [TrackerHit3D](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L444)          | [TrackerHitPlane](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L469)   | [SenseWireHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L510)          |
+| [RawTimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L497)         | [Track](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L534)             | [Vertex](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L577)                |
+| [ReconstructedParticle](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L623) | [TimeSeries](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L657)        | [RecDqdx](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L669)               |
 
 **Links**
 
 | | | |
 |-|-|-|
-| [RecoMCParticleLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L685)        | [CaloHitSimCaloHitLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L709)         | [TrackerHitSimTrackerHitLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L715)         |
-| [CaloHitMCParticleLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L691) | [ClusterMCParticleLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L697) | [TrackMCParticleLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L703)   |
-| [VertexRecoParticleLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L721) | | |
+| [RecoMCParticleLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L711)        | [CaloHitSimCaloHitLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L735)         | [TrackerHitSimTrackerHitLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L741)         |
+| [CaloHitMCParticleLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L717) | [ClusterMCParticleLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L723) | [TrackMCParticleLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L729)   |
+| [VertexRecoParticleLink](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L747) | | |
 
 **Generator related (meta-)data**
 
 | | | |
 |-|-|-|
-| [GeneratorEventParameters](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L652) | | |
+| [GeneratorEventParameters](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L678) | | |
 | | | |
 
 **Interfaces**
 
 | | | |
 |-|-|-|
-| [TrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L668) | | |
+| [TrackerHit](https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L694) | | |
 
 The tests and examples in the `tests` directory show how to read, write, and use these types in your code.
 

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -178,7 +178,7 @@ components:
     edm4hep::TrackState:
       Description: "Parametrized description of a particle track"
       Members:
-        - int32_t location // for use with At{Other|IP|FirstHit|LastHit|Calorimeter|Vertex}|LastLocation
+        - int32_t location // location of this track state, see edm4hep::TrackState::Location for the predefined values
         - float D0 // transverse impact parameter
         - float phi [rad] // azimuthal angle of the track at this location (i.e. not phi0)
         - float omega [1/mm] // is the signed curvature of the track
@@ -190,13 +190,26 @@ components:
       ExtraCode:
         includes: "#include <edm4hep/Constants.h>"
         declaration: |
-          static constexpr int AtOther = 0 ; // any location other than the ones defined below
-          static constexpr int AtIP = 1 ;
-          static constexpr int AtFirstHit = 2 ;
-          static constexpr int AtLastHit = 3 ;
-          static constexpr int AtCalorimeter = 4 ;
-          static constexpr int AtVertex = 5 ;
-          static constexpr int LastLocation = AtVertex  ;
+          /// The predefined locations at which a TrackState can be defined
+          ///
+          /// NOTE: This is deliberately an *unscoped* enum with a fixed underlying type:
+          /// - The implicit conversion to std::int32_t keeps all existing uses of
+          ///   edm4hep::TrackState::AtIP (and friends) valid, e.g. assigning to the
+          ///   location member or aggregate initialization of a TrackState.
+          /// - cppyy picks up the enumerators of an unscoped enum directly, so
+          ///   edm4hep.TrackState.AtIP keeps working from python.
+          ///
+          /// It is nevertheless a distinct type, which is useful in certain cases to avoid
+          /// confusion with plain ints.
+          enum Location : std::int32_t {
+            AtOther = 0,             ///< any location other than the ones defined below
+            AtIP = 1,                ///< at the interaction point
+            AtFirstHit = 2,          ///< at the first hit of the track
+            AtLastHit = 3,           ///< at the last hit of the track
+            AtCalorimeter = 4,       ///< at the entry point into the calorimeter
+            AtVertex = 5,            ///< at the vertex
+            LastLocation = AtVertex, ///< the last of the predefined locations
+          };
 
           /// Get the covariance matrix value for the two passed parameters
           constexpr float getCovMatrix(edm4hep::TrackParams parI, edm4hep::TrackParams parJ) const { return covMatrix.getValue(parI, parJ); }
@@ -537,16 +550,29 @@ datatypes:
       includes: |
         #include <optional>
         #include <algorithm>
+        #include <ranges>
+        #include <cstdint>
       declaration: |
         /// Get the TrackState at a dedicated location
         ///
         /// @note This will return the first TrackState for which the location matches
         /// even if there are multiple in the track
-        std::optional<edm4hep::TrackState> getTrackState(int location) const {
+        std::optional<edm4hep::TrackState> getTrackState(edm4hep::TrackState::Location location) const {
           const auto trackStates = getTrackStates();
           const auto it = std::ranges::find(trackStates, location, &edm4hep::TrackState::location);
           return it != trackStates.end() ? std::optional{*it} : std::nullopt;
         }
+
+        /// Get the TrackState at a dedicated location
+        [[deprecated("Use getTrackState(edm4hep::TrackState::Location) instead")]]
+        std::optional<edm4hep::TrackState> getTrackState(std::int32_t location) const {
+          return getTrackState(static_cast<edm4hep::TrackState::Location>(location));
+        }
+
+        /// Deliberately deleted: getTrackStates(index) takes an *index* into the vector
+        /// of track states, not a location. Use getTrackState(location) to look up a
+        /// TrackState by its location.
+        edm4hep::TrackState getTrackStates(edm4hep::TrackState::Location) const = delete;
 
   edm4hep::Vertex:
     Description: "Vertex"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -118,6 +118,8 @@ endif()
 
 add_edm4hep_test(py_test_module COMMAND python ${CMAKE_CURRENT_LIST_DIR}/test_module.py)
 
+add_edm4hep_test(py_test_extra_code COMMAND pytest ${CMAKE_CURRENT_LIST_DIR}/test_ExtraCode.py -v)
+
 add_subdirectory(utils)
 add_subdirectory(tools)
 

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --ignore=test_rdf.py --ignore=tools --ignore=utils -p no:gaudi_fixtures
+addopts = --ignore=test_rdf.py --ignore=test_ExtraCode.py --ignore=tools --ignore=utils -p no:gaudi_fixtures

--- a/test/test_ExtraCode.py
+++ b/test/test_ExtraCode.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+import edm4hep
+
+# TrackState locations. Make sure that the enumerator names are available in
+# python, both via the enum and directly from the TrackState
+assert edm4hep.TrackState.Location.AtIP == 1
+assert edm4hep.TrackState.AtIP == 1
+assert edm4hep.TrackState.Location.AtVertex == edm4hep.TrackState.AtVertex
+
+# The Location enum is unscoped, so the constants can be assigned to and compared
+# with the location member directly
+trackState = edm4hep.TrackState()
+assert trackState.location == edm4hep.TrackState.AtOther
+trackState.location = edm4hep.TrackState.AtVertex
+assert trackState.location == 5
+assert trackState.location == edm4hep.TrackState.AtVertex
+
+# Track::getTrackState returns a std::optional.track = edm4hep.MutableTrack()
+# NOTE: when using this in python it is important to bind the optional to a
+# variable as trying to use value() on a temporary will result in a dangling
+# reference otherwise
+track = edm4hep.MutableTrack()
+track.addToTrackStates(trackState)
+trackStateAtVertex = track.getTrackState(edm4hep.TrackState.AtVertex)
+assert trackStateAtVertex.has_value()
+assert trackStateAtVertex.value().location == edm4hep.TrackState.AtVertex
+assert not track.getTrackState(edm4hep.TrackState.AtIP).has_value()

--- a/test/test_ExtraCode.py
+++ b/test/test_ExtraCode.py
@@ -1,28 +1,39 @@
 #!/usr/bin/env python3
+"""Tests for the extra code that is injected via the ExtraCode YAML directives"""
 
 import edm4hep
 
-# TrackState locations. Make sure that the enumerator names are available in
-# python, both via the enum and directly from the TrackState
-assert edm4hep.TrackState.Location.AtIP == 1
-assert edm4hep.TrackState.AtIP == 1
-assert edm4hep.TrackState.Location.AtVertex == edm4hep.TrackState.AtVertex
 
-# The Location enum is unscoped, so the constants can be assigned to and compared
-# with the location member directly
-trackState = edm4hep.TrackState()
-assert trackState.location == edm4hep.TrackState.AtOther
-trackState.location = edm4hep.TrackState.AtVertex
-assert trackState.location == 5
-assert trackState.location == edm4hep.TrackState.AtVertex
+def test_track_state_location_enum_values():
+    """Make sure that the enumerator names are available in python, both via
+    the enum and directly from the TrackState"""
+    assert edm4hep.TrackState.Location.AtIP == 1
+    assert edm4hep.TrackState.AtIP == 1
+    assert edm4hep.TrackState.Location.AtVertex == edm4hep.TrackState.AtVertex
 
-# Track::getTrackState returns a std::optional.track = edm4hep.MutableTrack()
-# NOTE: when using this in python it is important to bind the optional to a
-# variable as trying to use value() on a temporary will result in a dangling
-# reference otherwise
-track = edm4hep.MutableTrack()
-track.addToTrackStates(trackState)
-trackStateAtVertex = track.getTrackState(edm4hep.TrackState.AtVertex)
-assert trackStateAtVertex.has_value()
-assert trackStateAtVertex.value().location == edm4hep.TrackState.AtVertex
-assert not track.getTrackState(edm4hep.TrackState.AtIP).has_value()
+
+def test_track_state_location_assignment():
+    """The Location enum is unscoped, so the constants can be assigned to and
+    compared with the location member directly"""
+    trackState = edm4hep.TrackState()
+    assert trackState.location == edm4hep.TrackState.AtOther
+    trackState.location = edm4hep.TrackState.AtVertex
+    assert trackState.location == 5
+    assert trackState.location == edm4hep.TrackState.AtVertex
+
+
+def test_track_get_track_state():
+    """Track::getTrackState returns a std::optional.
+    NOTE: when using this in python it is important to bind the optional to a
+    variable, as trying to use value() on a temporary will result in a
+    dangling reference otherwise"""
+    trackState = edm4hep.TrackState()
+    trackState.location = edm4hep.TrackState.AtVertex
+
+    track = edm4hep.MutableTrack()
+    track.addToTrackStates(trackState)
+
+    trackStateAtVertex = track.getTrackState(edm4hep.TrackState.AtVertex)
+    assert trackStateAtVertex.has_value()
+    assert trackStateAtVertex.value().location == edm4hep.TrackState.AtVertex
+    assert not track.getTrackState(edm4hep.TrackState.AtIP).has_value()

--- a/test/utils/test_extra_code.cpp
+++ b/test/utils/test_extra_code.cpp
@@ -3,6 +3,18 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+namespace {
+// Two helper concepts that we can use to statically check whether indexing into
+// getTrackStates (plural!) compiles or not. We want this to work with integer
+// types but we want this to fail with the TrackState constants. We assert this
+// in the tests below
+template <typename T>
+concept IndexableWithLocation = requires(const T& t) { t.getTrackStates(edm4hep::TrackState::AtIP); };
+
+template <typename T>
+concept IndexableWithInteger = requires(const T& t) { t.getTrackStates(0); };
+} // namespace
+
 TEST_CASE("Track::getTrackState") {
   // Populate a track with track states
   auto mutableTrack = edm4hep::MutableTrack{};
@@ -34,5 +46,14 @@ TEST_CASE("Track::getTrackState") {
 
   SECTION("returns empty optional when no track state matches") {
     REQUIRE_FALSE(mutableTrack.getTrackState(edm4hep::TrackState::AtFirstHit).has_value());
+  }
+
+  SECTION("No confusing overloads") {
+    // indexing with ints should work
+    STATIC_REQUIRE(IndexableWithInteger<edm4hep::Track>);
+    STATIC_REQUIRE(IndexableWithInteger<edm4hep::MutableTrack>);
+    // but using the track states should not
+    STATIC_REQUIRE(!IndexableWithLocation<edm4hep::Track>);
+    STATIC_REQUIRE(!IndexableWithLocation<edm4hep::MutableTrack>);
   }
 }


### PR DESCRIPTION

BEGINRELEASENOTES
- Make it harder to use `Track::getTrackStates` with a location defined in `TrackState` by shifting the locations into an unscoped enum.
- The `Track::getTrackState(int)` overload has been deprecated and will be removed once all occurrences have been fixed

ENDRELEASENOTES

Fixes #511 

Turning the location into an unscoped enum keeps pretty much all of the existing behavior, but allows us to use a dedicated type for the `getTrackState` overload, while removing the overload for `getTrackStates(TrackState::Location)` entirely.

Having an unscoped enum has the advantages that it implicitly converts to int so existing code should keep working and also cppyy deals much better with this than a scoped enum as that doesn't implicitly convert and would require 

- [x] Check if / where this breaks downstream