### PR TITLE
Remove deprecated Cluster phi aliases

### DIFF
--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -427,18 +427,12 @@ datatypes:
       declaration: |
         /// Get the position error value for the two passed dimensions
         float getPositionError(edm4hep::Cartesian dimI, edm4hep::Cartesian dimJ) const { return getPositionError().getValue(dimI, dimJ); }
-        /// Get the Azimuthal angle of the cluster's intrinsic direction (used e.g. for vertexing). Not to be confused with the cluster position seen from IP
-        [[deprecated("Use getIPhi instead")]]
-        float getPhi() const { return getIPhi(); }
 
     MutableExtraCode:
       includes: "#include <edm4hep/Constants.h>"
       declaration: |
         /// Set the position error value for the two passed dimensions
         void setPositionError(float value, edm4hep::Cartesian dimI, edm4hep::Cartesian dimJ) { return getPositionError().setValue(value, dimI, dimJ); }
-        /// Set the Azimuthal angle of the cluster's intrinsic direction (used e.g. for vertexing). Not to be confused with the cluster position seen from IP
-        [[deprecated("Use setIPhi instead")]]
-        void setPhi(float value) { setIPhi(value); }
 
 
   edm4hep::TrackerHit3D:


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove the deprecated Cluster phi aliases. Under some circumstances ROOT reads the header files and emits deprecation warnings even when the aliases are not used.

ENDRELEASENOTES